### PR TITLE
fix taimen build

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -239,7 +239,9 @@ in
           BUILD_DATETIME=config.buildDateTime;
           DISPLAY_BUILD_NUMBER="true"; # Enabling this shows the BUILD_ID concatenated with the BUILD_NUMBER in the settings menu
 
-          buildPhase = ''
+          buildPhase = lib.optionalString (config.device == "taimen") ''
+            ln -s wahoo-kernel device/google/taimen-kernel
+          '' + ''
             export OUT_DIR=$rootDir/out
 
             # Become the original user--not fake root.


### PR DESCRIPTION
Somewhere in the dark guts of the AOSP build, it tries to copy
`arch/arm64/boot/Image.lz4-dtb` from `devices/google/taimen-kernel`
instead of `devices/google/wahoo-kernel`.

I spent a while trying to hunt down how that string was being built,
because it looks like ${config.device} is being used instead of
${config.kernelName}, but I couldn't find it.

So, I did this lame hack.