### PR TITLE
Enable support for coral/flame (Pixel 4 (XL))

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # robotnix - Building Android (AOSP) with Nix
 
-This project enables using [Nix](https://nixos.org/nix/) to build Android ROMs, currently targeting Pixel 1-3a (XL) devices.
+This project enables using [Nix](https://nixos.org/nix/) to build Android ROMs, currently targeting Pixel 1-4(a) (XL) devices.
 Robotnix uses a NixOS-style module system for customizing various aspects of the build.
  
 Some optional modules include:
@@ -84,7 +84,7 @@ To use `extra-sandbox-paths`, the user must be a `trusted-user` in `nix.conf`.
 
 ### Testing / CI / Reproducibility
 
-All devices (Pixel 1-3(a) (XL)) have very basic checks to ensure that the android build process will at least start properly.
+All devices (Pixel 1-4(a) (XL)) have very basic checks to ensure that the android build process will at least start properly.
 See `release.nix` for the set of configurations with this minimal build testing.
 This check is run using `nix-build ./release.nix -A check`.
 As each build takes approximately 4 hours--I only build marlin and crosshatch builds for myself.

--- a/pkgs/android-prepare-vendor/default.nix
+++ b/pkgs/android-prepare-vendor/default.nix
@@ -44,8 +44,8 @@ in
   (fetchFromGitHub { # api == "29"
     owner = "danielfullmer";
     repo = "android-prepare-vendor";
-    rev = "c9b9505ab1f503d72711004ded42779fd9e2aed1";
-    sha256 = "19250xxm6b2zlr8v3jnz5agwky4wbkkccrf4za56mbvfw7p55fbl";
+    rev = "059c4b69765c296e3efc8938bb49e4f129204c54";
+    sha256 = "1hcq6d9fxw5dj5473r8xs6wppd7py9lffrvqpzk661inw6ndp696";
   });
 
   nativeBuildInputs = [ makeWrapper ];

--- a/release.nix
+++ b/release.nix
@@ -14,7 +14,8 @@ let
     { device="blueline";   flavor="vanilla"; }
     { device="bonito";     flavor="vanilla"; }
     { device="sargo";      flavor="vanilla"; }
-    #"coral" "flame" # No android-prepare-vendor yet
+    { device="coral";     flavor="vanilla"; }
+    { device="flame";      flavor="vanilla"; }
 
     { device="x86";        flavor="grapheneos"; }
     { device="arm64";      flavor="grapheneos"; }


### PR DESCRIPTION
Built a vanilla image successfully, but untested since I don't have one.