### PR TITLE
README: add line to set ccache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ As root:
 ```console
 # mkdir -p -m0770 /var/cache/ccache
 # chown root:nixbld /var/cache/ccache
+# echo max_size = 100G > /var/cache/ccache/ccache.conf
 ```
 Set `ccache.enable = true` in configuration, and be sure to pass `/var/cache/ccache` as a sandbox exception when building.
 


### PR DESCRIPTION
The default maximum ccache size is 5GB, which is not very useful when building Android. This adds a line to the ccache instructions to change the maximum size to 100GB.