### PR TITLE
Build vanilla kernels from source

### DIFF
--- a/flavors/vanilla/default.nix
+++ b/flavors/vanilla/default.nix
@@ -116,10 +116,8 @@ in mkIf (config.flavor == "vanilla") (mkMerge [
       arch/arm64/boot/Makefile
   '';
 
-  # TODO: Only build kernel for marlin since it needs verity key in build.
-  # Kernel sources for crosshatch and bonito require multiple repos--which
-  # could normally be fetched with repo at https://android.googlesource.com/kernel/manifest
-  # but google didn't push a branch like android-msm-crosshatch-4.9-pie-qpr3 to that repo.
+  # TODO: Currently, only build kernel for marlin since it needs verity key in build.
+  # Could also build for other devices, like is done for Android 11
   kernel.useCustom = mkDefault config.signing.enable;
 })
 

--- a/flavors/vanilla/kernel-hashes.json
+++ b/flavors/vanilla/kernel-hashes.json
@@ -1,0 +1,242 @@
+{
+  "android-11.0.0_r0.10": {
+    "https://android.googlesource.com/kernel/msm": {
+      "date": "2020-07-30T10:33:15+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/83adbm9chc7f6ghqfqd1jd9dfpr5q8v8-msm",
+      "rev": "51b9e1042e59d260cfc09c51c1c5b44d33928232",
+      "sha256": "00dyqazgb1bs86hvnvmxyl9vgrkrdgfkn87klrhw0xnv2pf05fhq",
+      "url": "https://android.googlesource.com/kernel/msm"
+    },
+    "https://android.googlesource.com/kernel/msm-extra": {
+      "date": "2020-06-08T18:03:19+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/xc8nmsxhhbmd3q6rvnvix8qc6dqa6q64-msm-extra",
+      "rev": "f49c717db2d431ea5878f72f5f696f4b803ea3c2",
+      "sha256": "016kvrq0mkm9wlla0dlj8sdfn062ps755n74ya79dbxyhnni8zgw",
+      "url": "https://android.googlesource.com/kernel/msm-extra"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn": {
+      "date": "2020-03-16T16:08:13+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/36x5a7c1dqlw2b35wk5k5vnhvrkr6xsk-qca-wfi-host-cmn",
+      "rev": "51363f51d4b485b6e70987a426dc6eb791bb99dd",
+      "sha256": "0f3mwsikdj3nsvyyw4nv5qhpyd7yfxffzvirrxb37j8vg9n8d9xy",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qcacld": {
+      "date": "2020-06-24T01:05:19+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/4hf13dymr5dqvq53ss1c9v2gymyzp84a-qcacld",
+      "rev": "e6b769be80938e5a974a2ac96d2cb70ae5ed3ef9",
+      "sha256": "02fm6zqzbzgxxjjjmr9bfnpy857fkkn60aqvly85jm8w6348vrhq",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qcacld"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api": {
+      "date": "2020-03-20T17:29:43+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/ahgnxwznrp258p32d5n0d1ipq40qyxpc-wlan-fw-api",
+      "rev": "f0fd7e2fcfa46be30b793032c7d421f6adcebb05",
+      "sha256": "08693q8r6xdhn9j1hr94v3vd6qz4ds8vhacjfgw3kgc3pw8gchzn",
+      "url": "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api"
+    }
+  },
+  "android-11.0.0_r0.12": {
+    "https://android.googlesource.com/kernel/msm": {
+      "date": "2020-07-30T16:18:51+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/fy0znphz2syibss3pacwb7p34zcq7v7d-msm",
+      "rev": "a1605987a054eabce43c0409b7fd1cce6b0c0076",
+      "sha256": "1xfw63j2xyf9v80khmczr52kk8dbbjfh4br60hw74qm2s9qzkijb",
+      "url": "https://android.googlesource.com/kernel/msm"
+    },
+    "https://android.googlesource.com/kernel/msm-extra": {
+      "date": "2020-05-19T20:11:20+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/gqv4vlp8j4356r6pf4h5vs7whnndjlbk-msm-extra",
+      "rev": "ab11b12d131f189bbf0c737988149d8699eeb0bd",
+      "sha256": "0fpvmva22y739fkvnm3b48bii3fx5yzjgbrvw16cgz2rn8cicdyj",
+      "url": "https://android.googlesource.com/kernel/msm-extra"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/fts_touch": {
+      "date": "2020-03-17T13:29:38-07:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/i879mx32qlaskbhvybyy2ilja6ywxiy1-fts_touch",
+      "rev": "3a9e5718c20f4259ad2d43ab7138a980adafc9e9",
+      "sha256": "05qhzpmvqwfrzpaiy3v63k0d5qsqxwd4qzx8031i75j7yxjfjlv2",
+      "url": "https://android.googlesource.com/kernel/msm-modules/fts_touch"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn": {
+      "date": "2020-05-19T05:28:44+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/r1hnjdjjafmyccfz7aqz8hwyzlxa8j80-qca-wfi-host-cmn",
+      "rev": "4c496e937225a44f8e5eaadd37b6fa1f9d2a7773",
+      "sha256": "1zy7frc4cab77m0ba4dw7dmqy7hhr6i75j2k39ivbr40zgjyr617",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qcacld": {
+      "date": "2020-06-30T05:45:31+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/dwg3kpb5whfin51b1bjzxbk8jwm3bm6x-qcacld",
+      "rev": "42eb4006e53a2cda1dac462c16bdcaa763e701a7",
+      "sha256": "0lxilxzi00vd6qihyzndx73qsj9zf5k2gjz24zl937ldn381qmli",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qcacld"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api": {
+      "date": "2020-03-02T17:39:45+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/a6ha4nqchqznxdfa324kgy4qq5prkfxr-wlan-fw-api",
+      "rev": "ce07fe6eb24d36dc76a7edf116e7c0229f992210",
+      "sha256": "18kmgabyxa4cps4d2744c1jizmbkk388z53qc50m4sfg01q98gh5",
+      "url": "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api"
+    }
+  },
+  "android-11.0.0_r0.14": {
+    "https://android.googlesource.com/kernel/msm": {
+      "date": "2020-07-30T16:15:35+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/b8jvccbjkx0j93fcnavbhziklsv58qvc-msm",
+      "rev": "538dda190bfb5d845bd1d71a439940367eca2a0a",
+      "sha256": "1fgqp6nc144zpsrsjkwkbzyy00hr50v2gjf1frijakzlg3srwr7z",
+      "url": "https://android.googlesource.com/kernel/msm"
+    },
+    "https://android.googlesource.com/kernel/msm-extra": {
+      "date": "2020-06-11T16:47:37+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/3zbqq909dvxr54jf3m9280aisnhcm8kx-msm-extra",
+      "rev": "d12d6405e9b75217bdcb1aa72c9c2013bbd65593",
+      "sha256": "0aakvarjag8wfxg31dx1msac4cxnm40si9ryl47w1kzd1zkph21v",
+      "url": "https://android.googlesource.com/kernel/msm-extra"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/fts_touch": {
+      "date": "2020-04-23T17:09:22+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/dv6ajmharz459wcgyknqlqcnak7r6r8q-fts_touch",
+      "rev": "0e5e23adf847c5e54442e471db5e4ff1b3192be4",
+      "sha256": "18mgqf2dn3xchn6fzr2gc0nfbch9gaa1ciaf6rnp00pl235l2wz2",
+      "url": "https://android.googlesource.com/kernel/msm-modules/fts_touch"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn": {
+      "date": "2020-05-19T05:29:50+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/cp8axw687j7rbnm63ilnmhmcximkrr54-qca-wfi-host-cmn",
+      "rev": "4f14fd9d8b90a548f432e9869a80c1df20326841",
+      "sha256": "1mclzmprhaxdbi187cs6pwvjvr5919cim5zpnav5dmn8qy5ylm2j",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qcacld": {
+      "date": "2020-06-30T05:50:58+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/445vzyayq7bbjragrxq7r9zxhvhwggac-qcacld",
+      "rev": "6e0025c17f580c528d9165413d89807232a31b2f",
+      "sha256": "0ckhwcqhy5b37cyd163mcxs02px5izqmkbvnwbb3q2sn2ll6j2pw",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qcacld"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api": {
+      "date": "2020-03-27T05:00:35+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/a6ha4nqchqznxdfa324kgy4qq5prkfxr-wlan-fw-api",
+      "rev": "0e771a38174f11bdf3c9313a5cb7a2f5e5a10a4a",
+      "sha256": "18kmgabyxa4cps4d2744c1jizmbkk388z53qc50m4sfg01q98gh5",
+      "url": "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api"
+    }
+  },
+  "android-11.0.0_r0.6": {
+    "https://android.googlesource.com/kernel/msm": {
+      "date": "2020-07-28T04:23:58+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/54f29mhid7n687w9mi4hrgpp8kr9jbgl-msm",
+      "rev": "a176abe6ae2a29023a356b009263f7b35ca230e7",
+      "sha256": "18w7dr6jgx25h0n8f4mphfn36ypwyy5nz44h60a5zw7b19dkmww3",
+      "url": "https://android.googlesource.com/kernel/msm"
+    }
+  },
+  "android-11.0.0_r0.8": {
+    "https://android.googlesource.com/kernel/msm": {
+      "date": "2020-07-30T10:33:15+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/83adbm9chc7f6ghqfqd1jd9dfpr5q8v8-msm",
+      "rev": "51b9e1042e59d260cfc09c51c1c5b44d33928232",
+      "sha256": "00dyqazgb1bs86hvnvmxyl9vgrkrdgfkn87klrhw0xnv2pf05fhq",
+      "url": "https://android.googlesource.com/kernel/msm"
+    },
+    "https://android.googlesource.com/kernel/msm-extra": {
+      "date": "2020-06-08T18:03:19+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/xc8nmsxhhbmd3q6rvnvix8qc6dqa6q64-msm-extra",
+      "rev": "f49c717db2d431ea5878f72f5f696f4b803ea3c2",
+      "sha256": "016kvrq0mkm9wlla0dlj8sdfn062ps755n74ya79dbxyhnni8zgw",
+      "url": "https://android.googlesource.com/kernel/msm-extra"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn": {
+      "date": "2020-03-16T16:08:13+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/36x5a7c1dqlw2b35wk5k5vnhvrkr6xsk-qca-wfi-host-cmn",
+      "rev": "51363f51d4b485b6e70987a426dc6eb791bb99dd",
+      "sha256": "0f3mwsikdj3nsvyyw4nv5qhpyd7yfxffzvirrxb37j8vg9n8d9xy",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qca-wfi-host-cmn"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/qcacld": {
+      "date": "2020-06-24T01:05:19+00:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/4hf13dymr5dqvq53ss1c9v2gymyzp84a-qcacld",
+      "rev": "e6b769be80938e5a974a2ac96d2cb70ae5ed3ef9",
+      "sha256": "02fm6zqzbzgxxjjjmr9bfnpy857fkkn60aqvly85jm8w6348vrhq",
+      "url": "https://android.googlesource.com/kernel/msm-modules/qcacld"
+    },
+    "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api": {
+      "date": "2020-03-20T17:29:43+08:00",
+      "deepClone": false,
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/ahgnxwznrp258p32d5n0d1ipq40qyxpc-wlan-fw-api",
+      "rev": "f0fd7e2fcfa46be30b793032c7d421f6adcebb05",
+      "sha256": "08693q8r6xdhn9j1hr94v3vd6qz4ds8vhacjfgw3kgc3pw8gchzn",
+      "url": "https://android.googlesource.com/kernel/msm-modules/wlan-fw-api"
+    }
+  }
+}

--- a/flavors/vanilla/kernel-metadata.json
+++ b/flavors/vanilla/kernel-metadata.json
@@ -1,0 +1,35 @@
+{
+  "android-11.0.0_r0.6": {
+    "kernel/msm": ""
+  },
+  "android-11.0.0_r0.8": {
+    "kernel/msm": "",
+    "kernel/msm-extra": "techpack/audio",
+    "kernel/msm-modules/qca-wfi-host-cmn": "drivers/staging/qca-wifi-host-cmn",
+    "kernel/msm-modules/qcacld": "drivers/staging/qcacld-3.0",
+    "kernel/msm-modules/wlan-fw-api": "drivers/staging/fw-api"
+  },
+  "android-11.0.0_r0.10": {
+    "kernel/msm": "",
+    "kernel/msm-extra": "techpack/audio",
+    "kernel/msm-modules/qca-wfi-host-cmn": "drivers/staging/qca-wifi-host-cmn",
+    "kernel/msm-modules/qcacld": "drivers/staging/qcacld-3.0",
+    "kernel/msm-modules/wlan-fw-api": "drivers/staging/fw-api"
+  },
+  "android-11.0.0_r0.12": {
+    "kernel/msm": "",
+    "kernel/msm-extra": "techpack/audio",
+    "kernel/msm-modules/qca-wfi-host-cmn": "drivers/staging/qca-wifi-host-cmn",
+    "kernel/msm-modules/qcacld": "drivers/staging/qcacld-3.0",
+    "kernel/msm-modules/wlan-fw-api": "drivers/staging/fw-api",
+    "kernel/msm-modules/fts_touch": "drivers/input/touchscreen/fts_touch"
+  },
+  "android-11.0.0_r0.14": {
+    "kernel/msm": "",
+    "kernel/msm-extra": "techpack/audio",
+    "kernel/msm-modules/qca-wfi-host-cmn": "drivers/staging/qca-wifi-host-cmn",
+    "kernel/msm-modules/qcacld": "drivers/staging/qcacld-3.0",
+    "kernel/msm-modules/wlan-fw-api": "drivers/staging/fw-api",
+    "kernel/msm-modules/fts_touch": "drivers/input/touchscreen/fts_touch"
+  }
+}

--- a/flavors/vanilla/update-kernels.py
+++ b/flavors/vanilla/update-kernels.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p python3 nix-prefetch-git -I nixpkgs=../../pkgs
+
+import argparse
+import json
+import subprocess
+
+# TODO: Combine with mk-repo-file.py
+def checkout_git(url, rev):
+    print("Checking out %s %s" % (url, rev))
+    json_text = subprocess.check_output([ "nix-prefetch-git", "--url", url, "--rev", rev]).decode()
+    return json.loads(json_text)
+
+def save(filename, data):
+    open(filename, 'w').write(json.dumps(data, sort_keys=True, indent=2, separators=(',', ': ')))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mirror', action="append", help="a repo mirror to use for a given url, specified by <url>=<path>")
+    args = parser.parse_args()
+
+    if args.mirror:
+        mirrors = dict(mirror.split("=") for mirror in args.mirror)
+    else:
+        mirrors = {}
+
+    data = json.load(open('kernel-metadata.json'))
+    outhashes = {}
+    for tag, repos in data.items():
+        for repo_name, repo_relpath in repos.items():
+            orig_url = f"https://android.googlesource.com/{repo_name}"
+
+            url = orig_url
+            for mirror_url, mirror_path in mirrors.items():
+                if url.startswith(mirror_url):
+                    url = url.replace(mirror_url, mirror_path)
+
+            git_data = checkout_git(url, tag)
+            git_data['url'] = orig_url
+
+            if tag not in outhashes:
+                outhashes[tag] = {}
+            outhashes[tag][orig_url] = git_data
+
+            save('kernel-hashes.json', outhashes)
+
+    save('kernel-hashes.json', outhashes)
+
+if __name__ == "__main__":
+    main()

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -130,7 +130,7 @@ in
       ] ++ lib.optionals (cfg.compiler == "clang") [
         "CC=clang"
         "CLANG_TRIPLE=aarch64-unknown-linux-gnu-" # This should match the prefix being produced by pkgsCross.aarch64-multiplatform.buildPackages.binutils. TODO: Generalize to other arches
-      ] ++ lib.optionals (config.deviceFamily == "coral") [
+      ] ++ lib.optionals (elem config.deviceFamily [ "coral" "sunfish" ]) [
         # HACK: Otherwise fails with  aarch64-linux-android-ld.gold: error: arch/arm64/lib/lib.a: member at 4210 is not an ELF object
         "LD=ld.lld"
       ];
@@ -153,7 +153,7 @@ in
 
       dontFixup = true;
       dontStrip = true;
-    } // optionalAttrs (config.deviceFamily == "coral") {
+    } // optionalAttrs (elem config.deviceFamily [ "coral" "sunfish" ]) {
       # HACK: Needed for coral (pixel 4) (Don't turn this on for other devices)
       DTC_EXT = "${prebuiltMisc}/bin/dtc";
       DTC_OVERLAY_TEST_EXT = "${prebuiltMisc}/bin/ufdt_apply_overlay";

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -160,7 +160,9 @@ in
     });
 
     source = mkIf cfg.useCustom {
-      dirs.${cfg.relpath}.src = lib.mkForce config.build.kernel;
+      dirs.${cfg.relpath}.postPatch = ''
+        cp -fv ${config.build.kernel}/* .
+      '';
     };
   };
 }

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -113,6 +113,10 @@ in
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
         sed -i scripts/ld-version.sh -e "s|/usr/bin/awk|${pkgs.gawk}/bin/awk|"
+
+        if [[ -f scripts/generate_initcall_order.pl ]]; then
+          patchShebangs scripts/generate_initcall_order.pl
+        fi
       '';
 
       nativeBuildInputs = with pkgs; [

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -159,6 +159,10 @@ in
       DTC_OVERLAY_TEST_EXT = "${prebuiltMisc}/bin/ufdt_apply_overlay";
     });
 
+    # We have to replace files here, instead of just using the
+    # config.build.kernel drv output in place of source.dirs.${cfg.relpath}.
+    # This is because there are some additional things in the prebuilt kernel
+    # output directory like kernel headers for sunfish under device/google/sunfish-kernel/sm7150
     source = mkIf cfg.useCustom {
       dirs.${cfg.relpath}.postPatch = ''
         cp -fv ${config.build.kernel}/* .

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -148,6 +148,7 @@ in
 
       installPhase = ''
         mkdir -p $out
+        shopt -s globstar nullglob
       '' + (concatMapStringsSep "\n" (filename: "cp out/${filename} $out/") cfg.buildProductFilenames);
 
       dontFixup = true;

--- a/modules/kernel.nix
+++ b/modules/kernel.nix
@@ -159,9 +159,7 @@ in
     });
 
     source = mkIf cfg.useCustom {
-      dirs.${cfg.relpath}.postPatch = ''
-        cp -fv ${config.build.kernel}/* .
-      '';
+      dirs.${cfg.relpath}.src = lib.mkForce config.build.kernel;
     };
   };
 }

--- a/modules/pixel/default.nix
+++ b/modules/pixel/default.nix
@@ -55,8 +55,6 @@ mkMerge [
     source.includeGroups = mkDefault [ config.device config.deviceFamily config.kernel.name config.kernel.configName ];
 
     signing.avb.enable = mkDefault true;
-
-    kernel.buildProductFilenames = [ "**/*.ko" ]; # Copy kernel modules if they exist
   })
 
   # Device-specific overrides

--- a/modules/pixel/default.nix
+++ b/modules/pixel/default.nix
@@ -131,5 +131,10 @@ mkMerge [
   })
   (mkIf (config.deviceFamily == "sunfish") {
     signing.avb.mode = "vbmeta_chained_v2";
+    kernel.buildProductFilenames = [
+      "arch/arm64/boot/Image.lz4"
+      "arch/arm64/boot/dtbo.img"
+      "arch/arm64/boot/dts/google/qcom-base/sdmmagpie.dtb"
+    ];
   })
 ]

--- a/modules/pixel/default.nix
+++ b/modules/pixel/default.nix
@@ -55,6 +55,8 @@ mkMerge [
     source.includeGroups = mkDefault [ config.device config.deviceFamily config.kernel.name config.kernel.configName ];
 
     signing.avb.enable = mkDefault true;
+
+    kernel.buildProductFilenames = [ "**/*.ko" ]; # Copy kernel modules if they exist
   })
 
   # Device-specific overrides


### PR DESCRIPTION
I'm currently only doing this for Android 11, and not Android 10, which isn't receiving security updates anyway.

This could likely be improved significantly--especially around the updater / metadata.  (e.g. we have to specify the tags in two places right now). 

I unfortunately can't directly test this on a real device since I use the kernels from GrapheneOS on my `crosshatch`, and those are already building fine.  I really ought to get another backup device to test things on...  I'd be interested if anyone trying out Robotnix currently on pixel phones could try this branch, to have some assurance I'm not breaking anything.  If not, I'll YOLO merge this anyway, since I'd rather have broken device images than vulnerable kernels.  If it breaks, you can always temporarily work around it by setting `kernel.useCustom = false`.

Fixes #46