### PR TITLE
APK signature verification

### DIFF
--- a/modules/google.nix
+++ b/modules/google.nix
@@ -66,7 +66,10 @@ in
         config_priorityOnlyDndExemptPackages = [ "com.google.android.dialer" ]; # Found under PixelConfigOverlayCommon.apk
       };
       apps.prebuilt.GoogleDialer = {
-        apk = "${productPath}/priv-app/GoogleDialer/GoogleDialer.apk";
+        apk = pkgs.verifyApk {
+          apk = "${productPath}/priv-app/GoogleDialer/GoogleDialer.apk";
+          sha256 = "e2d049f3a01192f620b1240615fa8c13badc553c22bc6fddfca45c84d8fc545d";
+        };
         privileged = true;
         certificate = "PRESIGNED";
       };
@@ -77,40 +80,58 @@ in
       google.base.enable = true;
       google.dialer.enable = true;
       apps.prebuilt = {
-        Tycho = {
-          apk = "${productPath}/app/Tycho/Tycho.apk"; # Google Fi app
+        Tycho = { # Google Fi app
+          apk = pkgs.verifyApk {
+            apk = "${productPath}/app/Tycho/Tycho.apk";
+            sha256 = "4c36af4a5bdad97c1f3d8b283416d244496c2ac5eafe8226079ef6f676fd1859";
+          };
           certificate = "PRESIGNED";
         };
-        GCS = {
-          apk = "${productPath}/priv-app/GCS/GCS.apk"; # Google Connectivity Services (does wifi VPN at least)
+        GCS = { # Google Connectivity Services (does wifi VPN at least)
+          apk = pkgs.verifyApk {
+            apk = "${productPath}/priv-app/GCS/GCS.apk";
+            sha256 = "8efed9b84a6320eafde625cea7bb6bae0e320473d0e3c04fb0cd43b779078e1d";
+          };
           certificate = "PRESIGNED";
           privileged = true;
         };
 #### Disabling for now, since calls aren't working ####
 #        CarrierServices = {
-#          apk = "${productPath}/priv-app/CarrierServices/CarrierServices.apk"; # Google Carrier Services. com.google.android.ims (needed for wifi calls)
+#          apk = pkgs.verifyApk {
+#            apk = "${productPath}/priv-app/CarrierServices/CarrierServices.apk"; # Google Carrier Services. com.google.android.ims (needed for wifi calls)
+#            sha256 = "c25d5afacb6783109d6136d79353fad4f6541c3545d25228a18703d043ca783f";
+#          };
 #          certificate = "PRESIGNED";
 #          privileged = true;
 #        };
-        CarrierSettings = {
-          apk = "${productPath}/priv-app/CarrierSettings/CarrierSettings.apk"; # com.google.android.carrier
+        CarrierSettings = { # com.google.android.carrier
+          apk = pkgs.verifyApk {
+            apk = "${productPath}/priv-app/CarrierSettings/CarrierSettings.apk";
+            sha256 = "383d1e1b525ec6fb8204c5bf9b8390d37fd157e78b8b7212d61487b178066d20";
+          };
           certificate = "PRESIGNED";
           privileged = true;
         };
-        CarrierSetup = {
-          apk = "${systemExtPath}/priv-app/CarrierSetup/CarrierSetup.apk"; # com.google.android.carriersetup
+        CarrierSetup = { # com.google.android.carriersetup
+          apk = "${systemExtPath}/priv-app/CarrierSetup/CarrierSetup.apk"; # Uses device-specific keys
           certificate = "PRESIGNED";
           privileged = true;
         };
       } // (optionalAttrs (config.deviceFamily == "crosshatch") { # TODO: Generalize to other devices with esim
         EuiccGoogle = {
-          apk = "${productPath}/priv-app/EuiccGoogle/EuiccGoogle.apk";
+          apk = pkgs.verifyApk {
+            apk = "${productPath}/priv-app/EuiccGoogle/EuiccGoogle.apk";
+            sha256 = "7e26b6d5802a16799448ad635868f0345d6730310634684c0ae44e7e9f7ea764";
+          };
           certificate = "PRESIGNED";
           privileged = true;
         };
       }) // (optionalAttrs ((config.deviceFamily == "crosshatch") && (config.androidVersion >= 10)) {
         EuiccSupportPixel = {
-          apk = "${productPath}/priv-app/EuiccSupportPixel/EuiccSupportPixel.apk";
+          apk = pkgs.verifyApk {
+            apk = "${productPath}/priv-app/EuiccSupportPixel/EuiccSupportPixel.apk";
+            sha256 = "e0afeca77af15aee48a25ead314c576f8f274682a8fba3365610878f7c1ddb6b";
+          };
           certificate = "PRESIGNED";
           privileged = true;
         };

--- a/modules/microg.nix
+++ b/modules/microg.nix
@@ -4,6 +4,10 @@ with lib;
 
 let
   version = "0.2.13.203915";
+  verifyApk = apk: pkgs.verifyApk {
+    inherit apk;
+    sha256 = "9bd06727e62796c0130eb6dab39b73157451582cbd138e86c468acc395d14165"; # O=NOGAPPS Project, C=DE
+  };
 in
 {
   options = {
@@ -27,10 +31,10 @@ in
     # Used https://github.com/lineageos4microg/android_prebuilts_prebuiltapks as source for Android.mk options
     apps.prebuilt = {
       GmsCore = { 
-        apk = pkgs.fetchurl {
+        apk = verifyApk (pkgs.fetchurl {
           url = "https://github.com/microg/android_packages_apps_GmsCore/releases/download/v${version}/GmsCore-v${version}.apk";
           sha256 = "0266zbmf20z7sa4xbgkq6f3qglrf8kcl24p6d87bzygm72340wxa";
-        };
+        });
         packageName = "com.google.android.gms";
         privileged = true;
         privappPermissions = [ "FAKE_PACKAGE_SIGNATURE" "INSTALL_LOCATION_PROVIDER" "CHANGE_DEVICE_IDLE_TEMP_WHITELIST" "UPDATE_APP_OPS_STATS" ];
@@ -38,16 +42,16 @@ in
         allowInPowerSave = true;
       };
 
-      GsfProxy.apk = pkgs.fetchurl {
+      GsfProxy.apk = verifyApk (pkgs.fetchurl {
         url = "https://github.com/microg/android_packages_apps_GsfProxy/releases/download/v0.1.0/GsfProxy.apk";
         sha256 = "14ln6i1qg435x223x3vndd608mra19d58yqqhhf6mw018cbip2c6";
-      };
+      });
 
       FakeStore = {
-        apk = pkgs.fetchurl {
+        apk = verifyApk (pkgs.fetchurl {
           url = "https://github.com/microg/android_packages_apps_FakeStore/releases/download/v0.1.0/FakeStore-v0.1.0.apk";
           sha256 = "1kp5v4qajp4cdx8pxw6j4776bcwc9f8jgfpiyllpk1kbhq92w1ci";
-        };
+        });
         packageName = "com.android.vending";
         privileged = true;
         privappPermissions = [ "FAKE_PACKAGE_SIGNATURE" ];

--- a/pkgs/build-tools/default.nix
+++ b/pkgs/build-tools/default.nix
@@ -1,0 +1,29 @@
+{ lib, runCommand, androidPkgs, makeWrapper, jre8_headless }:
+
+let
+  # getName snippet originally from nixpkgs/pkgs/build-support/trivial-builders.nix
+  getName = fname: apk:
+    if lib.elem (builtins.typeOf apk) [ "path" "string" ]
+      then lib.removeSuffix ".apk" (builtins.baseNameOf apk)
+      else
+        if builtins.isAttrs apk && builtins.hasAttr "name" apk
+        then lib.removeSuffix ".apk" apk.name
+        else throw "${fname}: please supply a `name` argument because a default name can only be computed when the `apk` is a path or is an attribute set with a `name` attribute.";
+
+  build-tools =
+    (androidPkgs.sdk (p: with p.stable; [ tools build-tools-30-0-2 ]))
+    + "/share/android-sdk/build-tools/30.0.2";
+
+  apksigner = runCommand "apksigner" { nativeBuildInputs = [ makeWrapper ]; } ''
+      mkdir -p $out/bin
+      makeWrapper "${jre8_headless}/bin/java" "$out/bin/apksigner" \
+        --add-flags "-jar ${build-tools}/lib/apksigner.jar"
+    '';
+
+  signApk = { apk, keyPath, name ? (getName "signApk" apk) + "-signed.apk" }: runCommand name {} ''
+      cp ${apk} $out
+      ${apksigner}/bin/apksigner sign --key ${keyPath}.pk8 --cert ${keyPath}.x509.pem $out
+    '';
+in {
+  inherit build-tools apksigner signApk;
+}

--- a/pkgs/build-tools/default.nix
+++ b/pkgs/build-tools/default.nix
@@ -24,6 +24,19 @@ let
       cp ${apk} $out
       ${apksigner}/bin/apksigner sign --key ${keyPath}.pk8 --cert ${keyPath}.x509.pem $out
     '';
+
+  # Currently only supports 1 signer.
+  verifyApk = { apk, sha256, name ? (getName "verifyApk" apk) + ".apk" }: runCommand name {} ''
+    sha256=$(${apksigner}/bin/apksigner verify --print-certs ${apk} | grep "^Signer #1 certificate SHA-256 digest: " | cut -d" " -f6 || exit 1)
+
+    if [[ "$sha256" = "${sha256}" ]]; then
+      echo "${name} APK certificate digest matches ${sha256}"
+      ln -s ${apk} $out
+    else
+      echo "${name} APK certificate digest $sha256 is not ${sha256}"
+      exit 1
+    fi
+  '';
 in {
-  inherit build-tools apksigner signApk;
+  inherit build-tools apksigner signApk verifyApk;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -43,6 +43,13 @@ let
     fetchgerritpatchset = super.callPackage ./fetchgerritpatchset {};
 
     nix-prefetch-git = super.callPackage ./nix-prefetch-git {};
+
+    ###
+
+    inherit (super.callPackage ./build-tools {})
+      build-tools
+      apksigner
+      signApk;
   };
 in
   import nixpkgs (args // {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -49,7 +49,8 @@ let
     inherit (super.callPackage ./build-tools {})
       build-tools
       apksigner
-      signApk;
+      signApk
+      verifyApk;
   };
 in
   import nixpkgs (args // {


### PR DESCRIPTION
This adds an APK signature verification derivation called `verifyApk`.  `verifyApk` takes an input APK file and certificate sha256, and outputs a symlink to that file if and only if the APK signature is valid and the certificate SHA256 digest matches the one provided.  The goal is to ensure _authenticity_ of build inputs in addition to _integrity_, which is already ensured via use of Nix.  

This is currently just being used for the prebuilt MicroG and Google APKs derived from a Google image. (We build everything else from source.)  These are example uses of `verifyApk`, and don't provide a ton of additional assurance, in contrast to if we fetched APKs from other (less trustworthy) sources. The Google APKs are currently directly from a Google image, whose SHA256 comes from the `developers.google.com` webpage using HTTPS, so they are unlikely to be compromised.  Another alternative for the MicroG package would be to check the detached GPG signature provided on the Github releases page.  (See also: https://github.com/NixOS/nixpkgs/pull/43233)