### PR TITLE
Add sunfish to attestation

### DIFF
--- a/apks/auditor/customized-auditor.patch
+++ b/apks/auditor/customized-auditor.patch
@@ -1,4 +1,4 @@
-From 4f2cbfe3362c903a2770aab145a25ff6be3d8c34 Mon Sep 17 00:00:00 2001
+From aa43a3a1aa34e59419db74a8606c104a394e71f6 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sun, 14 Jul 2019 15:53:34 -0400
 Subject: [PATCH 1/4] Custom domain
@@ -23,19 +23,18 @@ index 78eb7c5..8d14f81 100644
 -- 
 2.28.0
 
-
-From 6a3b8364e191f9c7c530ec1222e2af4e47da81cf Mon Sep 17 00:00:00 2001
+From d05a45e15a7d80da71269d9eac359119c633237d Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sun, 14 Jul 2019 16:17:57 -0400
 Subject: [PATCH 2/4] Custom fingerprints
 
 ---
- .../app/attestation/auditor/AttestationProtocol.java   | 10 +++++++++-
- app/src/main/res/values/strings.xml                    |  1 +
- 2 files changed, 10 insertions(+), 1 deletion(-)
+ .../attestation/auditor/AttestationProtocol.java   | 14 +++++++++++++-
+ app/src/main/res/values/strings.xml                |  1 +
+ 2 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
-index fd3defe..2270aed 100644
+index fd3defe..2bf731f 100644
 --- a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
 +++ b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
 @@ -225,7 +225,7 @@ class AttestationProtocol {
@@ -47,7 +46,7 @@ index fd3defe..2270aed 100644
      private static final int OS_VERSION_MINIMUM = 80000;
      private static final int OS_PATCH_LEVEL_MINIMUM = 201801;
      private static final int VENDOR_PATCH_LEVEL_MINIMUM = 201808;
-@@ -316,6 +316,11 @@ class AttestationProtocol {
+@@ -316,6 +316,13 @@ class AttestationProtocol {
                      new DeviceInfo(R.string.device_pixel_2_generic, 2, 3, true, true, R.string.os_calyx))
              .put("B4DE537A5F4B8FDAB6789EB2C06EC6E065E48A79EDD493A91F635004DD89F3E2",
                      new DeviceInfo(R.string.device_pixel_3_generic, 3, 4, false /* uses new API */, true, R.string.os_calyx))
@@ -56,16 +55,20 @@ index fd3defe..2270aed 100644
 +                    new DeviceInfo(R.string.device_pixel_2_generic, 2, 3, true, true, R.string.os_robotnix))
 +            .put("@crosshatch_avbFingerprint@",
 +                    new DeviceInfo(R.string.device_pixel_3_generic, 3, 4, false /* uses new API */, true, R.string.os_robotnix))
++            .put("@sunfish_avbFingerprint@",
++                    new DeviceInfo(R.string.device_pixel_4a, 3, 4, false /* uses new API */, true, R.string.os_robotnix))
              .build();
      private static final ImmutableMap<String, DeviceInfo> fingerprintsStock = ImmutableMap
              .<String, DeviceInfo>builder()
-@@ -459,6 +464,9 @@ class AttestationProtocol {
+@@ -459,6 +466,11 @@ class AttestationProtocol {
              // CalyxOS
              .put("B4DE537A5F4B8FDAB6789EB2C06EC6E065E48A79EDD493A91F635004DD89F3E2",
                      new DeviceInfo(R.string.device_pixel_3_generic, 3, 4, false /* uses new API */, true, R.string.os_calyx))
 +            // Robotnix
 +            .put("@crosshatch_avbFingerprint@",
 +                    new DeviceInfo(R.string.device_pixel_3_generic, 3, 4, false /* uses new API */, true, R.string.os_robotnix))
++            .put("@sunfish_avbFingerprint@",
++                    new DeviceInfo(R.string.device_pixel_4a, 3, 4, false /* uses new API */, true, R.string.os_robotnix))
              .build();
      private static final ImmutableMap<String, DeviceInfo> fingerprintsStrongBoxStock = ImmutableMap
              .<String, DeviceInfo>builder()
@@ -82,8 +85,7 @@ index 1a9978e..eeae4b6 100644
 -- 
 2.28.0
 
-
-From 337b0c9ba1f0d8dcddcdac649413cad0e774d2e3 Mon Sep 17 00:00:00 2001
+From adc333c02f5521f0df651826b61d122d1fcaba0a Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sat, 24 Aug 2019 16:49:04 -0400
 Subject: [PATCH 3/4] Customize appId
@@ -107,7 +109,7 @@ index 0f0025f..24faa54 100644
          targetSdkVersion 30
          versionCode 22
 diff --git a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
-index 2270aed..56ad19a 100644
+index 2bf731f..6613671 100644
 --- a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
 +++ b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
 @@ -220,7 +220,7 @@ class AttestationProtocol {
@@ -122,8 +124,7 @@ index 2270aed..56ad19a 100644
 -- 
 2.28.0
 
-
-From 4c2c6e6a25df42d48355ad23297d7854dc35caf9 Mon Sep 17 00:00:00 2001
+From cac1f1d68d020e8127c6fa4c3e172ae556d332be Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sat, 24 Aug 2019 17:03:03 -0400
 Subject: [PATCH 4/4] Change application name to Robotnix Auditor for clarity

--- a/apks/auditor/default.nix
+++ b/apks/auditor/default.nix
@@ -32,6 +32,7 @@ buildGradle rec {
 
     taimen_avbFingerprint = if (deviceFamily == "taimen") then avbFingerprint else "DISABLED_CUSTOM_TAIMEN";
     crosshatch_avbFingerprint = if (deviceFamily == "crosshatch") then avbFingerprint else "DISABLED_CUSTOM_CROSSHATCH";
+    sunfish_avbFingerprint = if (deviceFamily == "sunfish") then avbFingerprint else "DISABLED_CUSTOM_SUNFISH";
   }) ];
 
   gradleFlags = [ "assembleRelease" ];

--- a/modules/apps/auditor.nix
+++ b/modules/apps/auditor.nix
@@ -18,6 +18,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = builtins.elem config.deviceFamily [ "taimen" "crosshatch" "sunfish" ];
+      message = "Device ${config.deviceFamily} is currently unsupported.";
+    } ];
+
     apps.prebuilt.Auditor = {
       # TODO: Generate this one with a script
       # TODO: Can sign with custom certs at the release stage instead

--- a/nixos/attestation-server/customized-attestation-server.patch
+++ b/nixos/attestation-server/customized-attestation-server.patch
@@ -1,4 +1,4 @@
-From e0a09c748e6b28652bfaf09da34d5ba02af72123 Mon Sep 17 00:00:00 2001
+From 0da031da71698f77f02eb2faecd15713e6dd6382 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sun, 14 Jul 2019 17:00:46 -0400
 Subject: [PATCH 1/4] Custom listen settings
@@ -23,8 +23,7 @@ index c55a648..fd8697d 100644
 -- 
 2.28.0
 
-
-From ce0af94c659bcdae3dcf8885eed80640bcb89ac6 Mon Sep 17 00:00:00 2001
+From ac3b0e584fd5fa2692d5c63cb66439a07316ee74 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sun, 14 Jul 2019 17:01:09 -0400
 Subject: [PATCH 2/4] Custom domain
@@ -247,18 +246,17 @@ index 607b58a..de6a21e 100644
 -- 
 2.28.0
 
-
-From 98d7e95845756e9d38f0a2392df7f2557c6eb2a5 Mon Sep 17 00:00:00 2001
+From 847c2655aa8314c4404fc59353e3b574adea392f Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sun, 14 Jul 2019 17:01:18 -0400
 Subject: [PATCH 3/4] Custom fingerprints
 
 ---
- .../app/attestation/server/AttestationProtocol.java   | 11 ++++++++++-
- 1 file changed, 10 insertions(+), 1 deletion(-)
+ .../attestation/server/AttestationProtocol.java   | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/src/main/java/app/attestation/server/AttestationProtocol.java b/src/main/java/app/attestation/server/AttestationProtocol.java
-index 1574d51..78be916 100644
+index 1574d51..9354181 100644
 --- a/src/main/java/app/attestation/server/AttestationProtocol.java
 +++ b/src/main/java/app/attestation/server/AttestationProtocol.java
 @@ -166,7 +166,7 @@ class AttestationProtocol {
@@ -278,7 +276,7 @@ index 1574d51..78be916 100644
  
      static class DeviceInfo {
          final String name;
-@@ -312,6 +313,11 @@ class AttestationProtocol {
+@@ -312,6 +313,13 @@ class AttestationProtocol {
                      new DeviceInfo(DEVICE_PIXEL_2_GENERIC, 2, 3, true, true, OS_CALYX))
              .put("B4DE537A5F4B8FDAB6789EB2C06EC6E065E48A79EDD493A91F635004DD89F3E2",
                      new DeviceInfo(DEVICE_PIXEL_3_GENERIC, 3, 4, false /* uses new API */, true, OS_CALYX))
@@ -287,24 +285,27 @@ index 1574d51..78be916 100644
 +                    new DeviceInfo(DEVICE_PIXEL_2_GENERIC, 2, 3, true, true, OS_ROBOTNIX))
 +            .put("@crosshatch_avbFingerprint@",
 +                    new DeviceInfo(DEVICE_PIXEL_3_GENERIC, 3, 4, false /* uses new API */, true, OS_ROBOTNIX))
++            .put("@sunfish_avbFingerprint@",
++                    new DeviceInfo(DEVICE_PIXEL_4a, 3, 4, false /* uses new API */, true, OS_ROBOTNIX))
              .build();
      static final ImmutableMap<String, DeviceInfo> fingerprintsStock = ImmutableMap
              .<String, DeviceInfo>builder()
-@@ -455,6 +461,9 @@ class AttestationProtocol {
+@@ -455,6 +463,11 @@ class AttestationProtocol {
              // CalyxOS
              .put("B4DE537A5F4B8FDAB6789EB2C06EC6E065E48A79EDD493A91F635004DD89F3E2",
                      new DeviceInfo(DEVICE_PIXEL_3_GENERIC, 3, 4, false /* uses new API */, true, OS_CALYX))
 +            // Robotnix
 +            .put("@crosshatch_avbFingerprint@",
 +                    new DeviceInfo(DEVICE_PIXEL_3_GENERIC, 3, 4, false /* uses new API */, true, OS_ROBOTNIX))
++            .put("@sunfish_avbFingerprint@",
++                    new DeviceInfo(DEVICE_PIXEL_4a, 3, 4, false /* uses new API */, true, OS_ROBOTNIX))
              .build();
      static final ImmutableMap<String, DeviceInfo> fingerprintsStrongBoxStock = ImmutableMap
              .<String, DeviceInfo>builder()
 -- 
 2.28.0
 
-
-From 8187acf88d7fd0d7d5788856ed529d564294b005 Mon Sep 17 00:00:00 2001
+From 2c41e873542b1adb5cc889046dff11a1b6d5f258 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Sat, 24 Aug 2019 16:50:29 -0400
 Subject: [PATCH 4/4] Custom appId
@@ -314,7 +315,7 @@ Subject: [PATCH 4/4] Custom appId
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/main/java/app/attestation/server/AttestationProtocol.java b/src/main/java/app/attestation/server/AttestationProtocol.java
-index 78be916..4fafe3e 100644
+index 9354181..1a3df0b 100644
 --- a/src/main/java/app/attestation/server/AttestationProtocol.java
 +++ b/src/main/java/app/attestation/server/AttestationProtocol.java
 @@ -161,7 +161,7 @@ class AttestationProtocol {

--- a/nixos/attestation-server/default.nix
+++ b/nixos/attestation-server/default.nix
@@ -33,6 +33,7 @@ buildGradle {
 
     taimen_avbFingerprint = if (deviceFamily == "taimen") then avbFingerprint else "DISABLED_CUSTOM_TAIMEN";
     crosshatch_avbFingerprint = if (deviceFamily == "crosshatch") then avbFingerprint else "DISABLED_CUSTOM_CROSSHATCH";
+    sunfish_avbFingerprint = if (deviceFamily == "sunfish") then avbFingerprint else "DISABLED_CUSTOM_SUNFISH";
   }) ];
 
   JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";

--- a/nixos/attestation-server/module.nix
+++ b/nixos/attestation-server/module.nix
@@ -51,6 +51,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [ {
+      assertion = builtins.elem cfg.deviceFamily [ "taimen" "crosshatch" "sunfish" ];
+      message = "Device ${cfg.deviceFamily} is currently unsupported.";
+    } ];
+
     systemd.services.attestation-server = {
       description = "Attestation Server";
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
I've added sunfish to the Auditor app and the Attestation server, ~however, I have to admit that I have not yet managed to make this work.  When I try to verify I receive “Scanned invalid account QR code” so I must have forgotten another spot where I have to add support for sunfish.~ EDIT: Turns out, I'm just a complete idiot and have overlooked that the app has actually been renamed to “Robotnix Auditor” and when using the correct app, attestation works flawlessly.

Also the modules now have assertions, because otherwise if your device is not supported it just silently fails to generate appropriate code.

---

BTW, you can disable registration on a public attestation instance using
```nix
{
  services.nginx.virtualHosts."${config.services.attestation-server.domain}" = {
    locations."/api/create_account".return = "404";
  };
}
```
That's not too nice of a solution because when trying to register anyway it just won't do anything instead of throwing an error or anything useful.