### PR TITLE
Documentation

### DIFF
--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -53,14 +53,8 @@
       };
     }
     ```
-    You also need to have signing enabled during build time.  Trying to build
-    for later signing with the release script doesn't build. (TODO: Probably a bug)
-    ```
-    Can't open /nix/store/a791pqlmh0npazbd6g310ga3b02mpz78-build=make-patched/target/product/security/auditor.x509.pem for reading, No such file or directory
-    140737348248832:error:02001002:system library:fopen:No such file or directory:crypto/bio/bss_file.c:69:fopen('/nix/store/a791pqlmh0npazbd6g310ga3b02mpz78-build=make-patched/target/product/security/auditor.x509.pem','r')
-    140737348248832:error:2006D080:BIO routines:BIO_new_file:no such file:crypto/bio/bss_file.c:76:
-    unable to load certificate
-    ```
+    You also need to have signing enabled during build time because the Auditor
+    app needs to know its own signing key during build.
 
  3. That's it from the Android side.  Note that the custom Auditor app will be
     named “Robotnix Auditor”.  When you build GrapheneOS the normal Auditor app
@@ -93,8 +87,8 @@
         ((builtins.fetchTarball {
           name = "robotnix";
           url =
-            "https://github.com/danielfullmer/robotnix/archive/master.tar.gz";
-          sha256 = "0000000000000000000000000000000000000000000000000000";
+            "https://github.com/danielfullmer/robotnix/archive/61b91d145f0b08cf0d4d73fb1d7ba74b9899b788.zip";
+          sha256 = "1dihmdw5w891jq2fm7mcx30ydjjd33ggbb60898841x5pzjx6ynv";
         }) + "/nixos")
       ];
 
@@ -107,12 +101,12 @@
       };
       services.nginx.virtualHosts."${config.services.attestation-server.domain}" = {
         enableACME = true;
-        #locations."/api/create_account".return = "404"; # uncomment to disable registration
+        #locations."/api/create_account".return = "404"; # uncomment to disable account creation
       };
     }
     ```
 
- 3. Register and optionally disable the registration.  The start the “Robotnix
+ 3. Register and optionally disable account creation.  The start the “Robotnix
     Auditor” app on your phone and open the menu (three dots).  Choose “Enable
     remote verification” and scan the QR code on your attestation server.
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -1,0 +1,120 @@
+# Set up remote attestation
+
+## Android side
+
+ 1. Before you can enable the Auditor app in your configuration you have to
+    generate a signing key.  There is currently no script generated for this, but
+    it's easy enough to do using the `generateKeysScript` target.
+    ```console
+    $ nix-build \
+    	--arg configuration ./sunfish.nix \
+    	-A generateKeysScript \
+    	-o generate-keys
+    $ cp -L generate-keys auditor-keys
+    ```
+    Then delete the line with the assignment of the `KEYS`variable and replace it
+    with `KEYS=( auditor )`.  I have also changed the common name of the
+    certificate to `Robotnix auditor` because it is not device dependent.  The
+    resulting script should look something like this (with potentially different
+    hashes of course):
+    ```bash
+    #!/nix/store/2jysm3dfsgby5sw5jgj43qjrb5v79ms9-bash-4.4-p23/bin/bash
+    set -euo pipefail
+
+    export PATH=/nix/store/q0ajpzppqfrlbzbddbbzv1w6vfzydhk5-openssl-1.1.1g-bin/bin:/nix/store/8plhh65p17qlyp7k74vaiisyrhg15hwr-android-key-tools/bin:$PATH
+
+    KEYS=( auditor )
+
+    for key in "${KEYS[@]}"; do
+      if [[ ! -e "$key".pk8 ]]; then
+        echo "Generating $key key"
+        # make_key exits with unsuccessful code 1 instead of 0
+        make_key "$key" "/CN=Robotnix auditor/" && exit 1
+      else
+        echo "Skipping generating $key since it is already exists"
+      fi
+    done
+    ```
+    Run the script to generate the keys:
+    ```bash
+    $ cd keys/
+    $ bash ../auditor-keys
+    ```
+
+ 2. Now you can enable the Auditor app in the configuration:
+    ```nix
+    {
+      keyStorePath = "/dev/shm/android-keys";
+      signing.enable = true;
+
+      apps = {
+        auditor.enable = true;
+        auditor.domain = "attestation.example.com";
+      };
+    }
+    ```
+    You also need to have signing enabled during build time.  Trying to build
+    for later signing with the release script doesn't build. (TODO: Probably a bug)
+    ```
+    Can't open /nix/store/a791pqlmh0npazbd6g310ga3b02mpz78-build=make-patched/target/product/security/auditor.x509.pem for reading, No such file or directory
+    140737348248832:error:02001002:system library:fopen:No such file or directory:crypto/bio/bss_file.c:69:fopen('/nix/store/a791pqlmh0npazbd6g310ga3b02mpz78-build=make-patched/target/product/security/auditor.x509.pem','r')
+    140737348248832:error:2006D080:BIO routines:BIO_new_file:no such file:crypto/bio/bss_file.c:76:
+    unable to load certificate
+    ```
+
+ 3. That's it from the Android side.  Note that the custom Auditor app will be
+    named “Robotnix Auditor”.  When you build GrapheneOS the normal Auditor app
+    will still be there, don't get confused (like I did).
+
+## Server side
+
+ 1. Before we begin we have to obtain the fingerprint of the custom Auditor app
+    and the AVB fingerprint.  To get the Auditor app fingerprint, we simply use
+    OpenSSL to extract the fingerprint of the signing certificate:
+    ```console
+    $ openssl x509 -noout -fingerprint -sha256 -in keys/auditor.x509.pem | awk -F '=' '{gsub(/:/,""); print $2}'
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    ```
+    The AVB fingerprint is a bit more tricky.  I own a Pixel 4a (sunfish) and
+    on this device the AVB fingerprint is simply the SHA256 hash of the AVB
+    key, but this is not the case on other devices.  Check the Auditor source
+    code for details.
+    ```console
+    $ sha256sum keys/sunfish/avb_pkmd.bin | awk '{print toupper($1)}'
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+    ```
+
+ 2. Now you can import Robotnix in your NixOS configuration with the
+    aforementioned fingerprints.
+    ```nix
+    { config, lib, pkgs, ... }:
+    {
+      imports = [
+        ((builtins.fetchTarball {
+          name = "robotnix";
+          url =
+            "https://github.com/danielfullmer/robotnix/archive/master.tar.gz";
+          sha256 = "0000000000000000000000000000000000000000000000000000";
+        }) + "/nixos")
+      ];
+
+      services.attestation-server = {
+        enable = true;
+        domain = "attestation.example.com";
+        deviceFamily = "sunfish";
+        signatureFingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        avbFingerprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+      };
+      services.nginx.virtualHosts."${config.services.attestation-server.domain}" = {
+        enableACME = true;
+        #locations."/api/create_account".return = "404"; # uncomment to disable registration
+      };
+    }
+    ```
+
+ 3. Register and optionally disable the registration.  The start the “Robotnix
+    Auditor” app on your phone and open the menu (three dots).  Choose “Enable
+    remote verification” and scan the QR code on your attestation server.
+
+ 4. The attestation server keeps its state in `/var/lib/private/attestation`.
+    **Make periodic backups!**

--- a/docs/f-droid.md
+++ b/docs/f-droid.md
@@ -1,5 +1,9 @@
 # Adding F-Droid repositories
 
+F-Droid can manage multiple repositories to fetch apps from.  These can be set
+up manually in the app, but with Robotnix it is also possible to preload
+F-Droid with some repositories at build time.
+
 To add an F-Droid repository you need at least the URL and a public key.
 Obtaining the URL is in general very easy but it's not obvious where to obtain
 the public key.

--- a/docs/f-droid.md
+++ b/docs/f-droid.md
@@ -1,0 +1,46 @@
+# Adding F-Droid repositories
+
+To add an F-Droid repository you need at least the URL and a public key.
+Obtaining the URL is in general very easy but it's not obvious where to obtain
+the public key.
+
+We'll take the microG repository as an example.  The repository is located at
+https://microg.org/fdroid/repo.  To obtain the repository index download the
+`index.jar` file from the repository root:
+```console
+$ curl -LO https://microg.org/fdroid/repo/index.jar
+```
+Java Archives are simply ZIP files with a certain structure, so to get the
+repository index out of this file, we unzip the contained `index.xml`:
+```console
+$ unzip index.jar index.xml
+```
+The content of this XML file contains metadata about the repository, including
+the public key:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<fdroid>
+	<repo name="microG F-Droid repo" icon="fdroid-icon.png" url="https://microg.org/fdroid/repo" version="19" timestamp="1606314565" pubkey="308202ed308201d5a003020102020426ffa009300d06092a864886f70d01010b05003027310b300906035504061302444531183016060355040a130f4e4f47415050532050726f6a656374301e170d3132313030363132303533325a170d3337303933303132303533325a3027310b300906035504061302444531183016060355040a130f4e4f47415050532050726f6a65637430820122300d06092a864886f70d01010105000382010f003082010a02820101009a8d2a5336b0eaaad89ce447828c7753b157459b79e3215dc962ca48f58c2cd7650df67d2dd7bda0880c682791f32b35c504e43e77b43c3e4e541f86e35a8293a54fb46e6b16af54d3a4eda458f1a7c8bc1b7479861ca7043337180e40079d9cdccb7e051ada9b6c88c9ec635541e2ebf0842521c3024c826f6fd6db6fd117c74e859d5af4db04448965ab5469b71ce719939a06ef30580f50febf96c474a7d265bb63f86a822ff7b643de6b76e966a18553c2858416cf3309dd24278374bdd82b4404ef6f7f122cec93859351fc6e5ea947e3ceb9d67374fe970e593e5cd05c905e1d24f5a5484f4aadef766e498adf64f7cf04bddd602ae8137b6eea40722d0203010001a321301f301d0603551d0e04160414110b7aa9ebc840b20399f69a431f4dba6ac42a64300d06092a864886f70d01010b0500038201010007c32ad893349cf86952fb5a49cfdc9b13f5e3c800aece77b2e7e0e9c83e34052f140f357ec7e6f4b432dc1ed542218a14835acd2df2deea7efd3fd5e8f1c34e1fb39ec6a427c6e6f4178b609b369040ac1f8844b789f3694dc640de06e44b247afed11637173f36f5886170fafd74954049858c6096308fc93c1bc4dd5685fa7a1f982a422f2a3b36baa8c9500474cf2af91c39cbec1bc898d10194d368aa5e91f1137ec115087c31962d8f76cd120d28c249cf76f4c70f5baa08c70a7234ce4123be080cee789477401965cfe537b924ef36747e8caca62dfefdd1a6288dcb1c4fd2aaa6131a7ad254e9742022cfd597d2ca5c660ce9e41ff537e5a4041e37">
+		<description>This is a repository of microG apps to be used with F-Droid. Applications in this repository are signed official binaries built by the microG Team from the corresponding source code. </description>
+	</repo>
+	<application id="...">
+		<!-- ... list of contained applications ... -->
+	</application>
+</fdroid>
+```
+Simply copy the `name` and `pubkey` fields and use them as the name and public
+key for the corresponding Nix expression respectively.
+```nix
+{
+  apps.fdroid.additionalRepos = {
+    "microG F-Droid repo" = {
+      enable = true;
+      url = "https://microg.org/fdroid/repo";
+      pubkey = "308202ed308201d5a003020102020426ffa009300d06092a864886f70d01010b05003027310b300906035504061302444531183016060355040a130f4e4f47415050532050726f6a656374301e170d3132313030363132303533325a170d3337303933303132303533325a3027310b300906035504061302444531183016060355040a130f4e4f47415050532050726f6a65637430820122300d06092a864886f70d01010105000382010f003082010a02820101009a8d2a5336b0eaaad89ce447828c7753b157459b79e3215dc962ca48f58c2cd7650df67d2dd7bda0880c682791f32b35c504e43e77b43c3e4e541f86e35a8293a54fb46e6b16af54d3a4eda458f1a7c8bc1b7479861ca7043337180e40079d9cdccb7e051ada9b6c88c9ec635541e2ebf0842521c3024c826f6fd6db6fd117c74e859d5af4db04448965ab5469b71ce719939a06ef30580f50febf96c474a7d265bb63f86a822ff7b643de6b76e966a18553c2858416cf3309dd24278374bdd82b4404ef6f7f122cec93859351fc6e5ea947e3ceb9d67374fe970e593e5cd05c905e1d24f5a5484f4aadef766e498adf64f7cf04bddd602ae8137b6eea40722d0203010001a321301f301d0603551d0e04160414110b7aa9ebc840b20399f69a431f4dba6ac42a64300d06092a864886f70d01010b0500038201010007c32ad893349cf86952fb5a49cfdc9b13f5e3c800aece77b2e7e0e9c83e34052f140f357ec7e6f4b432dc1ed542218a14835acd2df2deea7efd3fd5e8f1c34e1fb39ec6a427c6e6f4178b609b369040ac1f8844b789f3694dc640de06e44b247afed11637173f36f5886170fafd74954049858c6096308fc93c1bc4dd5685fa7a1f982a422f2a3b36baa8c9500474cf2af91c39cbec1bc898d10194d368aa5e91f1137ec115087c31962d8f76cd120d28c249cf76f4c70f5baa08c70a7234ce4123be080cee789477401965cfe537b924ef36747e8caca62dfefdd1a6288dcb1c4fd2aaa6131a7ad254e9742022cfd597d2ca5c660ce9e41ff537e5a4041e37";
+    };
+  };
+}
+```
+The name can really be anything, but the one that is provided here is the one
+that shows up before refreshing the F-Droid repo list for the first time, so if
+you want that to look pretty, give it a pretty name here.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,12 +2,20 @@
 
 It is assumed that you have successfully built your image and signed it with
 your own keys.  Make sure that you know the location of the image and the AVB
-signing key.
+signing key.  The instructions in this document were tested on the Google Pixel
+4a (sunfish).  For other devices please refer to
+https://source.android.com/setup/build/running
 
  0. Before you can begin you have to boot the stock OS and go to “Settings /
     System / Advanced / Developer options” and enable “OEM unlocking”.  On my
     device I had to insert a SIM card and connect to the network for that, so
     it looks like you have to connect your device with Google at least once.
+    This is part of Google's so called Factory Reset Protection (FRP) for
+    anti-theft protection
+    (https://grapheneos.org/install#enabling-oem-unlocking).  However, [this
+    comment](https://www.kuketz-blog.de/grapheneos-das-android-fuer-sicherheits-und-datenschutzfreaks/#comment-52681)
+    on a German IT privacy blog suggests that it is sufficient to allow access
+    to the captive portal such that the phone thinks it is online.
 
  1. First reboot into the bootloader. You can either do that physically by
     turning off your phone and then holding both the POWER and the VOLUME DOWN
@@ -23,11 +31,9 @@ signing key.
     09071JEC217048  device
     ```
 
- 3. If you 
-
  3. First flash your custom AVB signing key using
     ```console
-    $ fastboot erase avb_custom_key 
+    $ fastboot erase avb_custom_key
     $ fastboot flash avb_custom_key avb_pkmd.bin
     $ fastboot reboot bootloader
     ```
@@ -50,6 +56,22 @@ signing key.
     $ fastboot flashing lock
     ```
     This step has to be confirmed on the device.
+
+ 6. After rebooting you will be greeted with an orange exclamation mark and a
+    message like
+
+    > Your device is loading a different operating system.
+    >
+    > Visit this link on another device:
+    > g.co/ABH
+    >
+    > ID: BA135E0F
+
+    This is expected because Android Verified Boot is designed to warn the user
+    when not booting the stock OS, see
+    https://source.android.com/security/verifiedboot/boot-flow.  In fact, the
+    ID on the last line are the first eight characters of the fingerprint of
+    your AVB key.
 
 # Installing OTA updates with adb
 

--- a/docs/sunfish.md
+++ b/docs/sunfish.md
@@ -1,0 +1,93 @@
+# Installing for the first time and verified boot
+
+It is assumed that you have successfully built your image and signed it with
+your own keys.  Make sure that you know the location of the image and the AVB
+signing key.
+
+ 0. Before you can begin you have to boot the stock OS and go to “Settings /
+    System / Advanced / Developer options” and enable “OEM unlocking”.  On my
+    device I had to insert a SIM card and connect to the network for that, so
+    it looks like you have to connect your device with Google at least once.
+
+ 1. First reboot into the bootloader. You can either do that physically by
+    turning off your phone and then holding both the POWER and the VOLUME DOWN
+    button to turn it back on, or your can connect the phone to your computer
+    with USB Debugging turned on and issue
+    ```console
+    $ adb reboot bootloader
+    ```
+
+ 2. Connect your phone to your computer and run
+    ```console
+    $ fastboot devices
+    09071JEC217048  device
+    ```
+
+ 3. If you 
+
+ 3. First flash your custom AVB signing key using
+    ```console
+    $ fastboot erase avb_custom_key 
+    $ fastboot flash avb_custom_key avb_pkmd.bin
+    $ fastboot reboot bootloader
+    ```
+
+ 4. To flash you image use
+    ```console
+    $ fastboot -w --skip-reboot update sunfish-img-2020.11.06.04.zip
+    $ fastboot reboot bootloader
+    ```
+    This will erase the `userdata` partition (`-w`) and prevent the automatic
+    reboot after flashing (`--skip-reboot`). Instead it reboots back into the
+    bootloader from where the user can then manually trigger the reboot using
+    ```console
+    $ fastboot reboot
+    ```
+
+ 5. At this point you want to relock the bootloader to enable the verified boot
+    chain.
+    ```
+    $ fastboot flashing lock
+    ```
+    This step has to be confirmed on the device.
+
+# Installing OTA updates with adb
+
+To install OTA updates you have to put the device in sideload-mode.
+
+ 1. First reboot into the bootloader. You can either do that physically by
+    turning off your phone and then holding both the POWER and the VOLUME DOWN
+    button to turn it back on, or your can connect the phone to your computer
+    with USB Debugging turned on and issue
+    ```console
+    $ adb reboot recovery
+    ```
+    If you used the physical method, at the bootloader prompt use the VOLUME
+    keys to select “Recovery Mode” and confirm with the POWER button.
+
+ 3. Now the recovery mode should have started and you should see a dead robot
+    with a read exclamation mark on top. If you see “No command” on the screen,
+    press and hold POWER. While holding POWER, press VOLUME UP and release
+    both.
+
+ 4. At the recovery menu use the VOLUME keys to select “Apply update from ADB”
+    and use POWER to confirm.
+
+ 5. Connect your phone to your computer and run
+    ```console
+    $ adb devices
+    List of devices attached
+    09071JEC217048  sideload
+    ```
+    The output should show that the device is in sideload mode.
+
+ 6. Now you can proceed to sideload the new update.
+    ```console
+    $ adb sideload sunfish-ota_update-2020.11.26.17.zip
+    ```
+    The sideload might terminate at 94% with “adb: failed to read command:
+    Success”.  This is not an error even though it is not obvious, see also
+    [here](https://np.reddit.com/r/LineageOS/comments/dt2et4/adb_failed_to_read_command_success/f6u352m).
+
+ 7. Once finished and the device doesn't automatically reboot just select
+    reboot from the menu and confirm.


### PR DESCRIPTION
These are just some notes I made during setting up my sunfish with GrapheneOS.

The file `sunfish.md` contains notes regarding the device (mostly all the power-volume-key combos that you have to press).

For some time I was quite clueless about where to find public keys for F-Droid repos, so I documented that in `f-droid.md`.

Finally my experiences setting up the attestation server are written down in `attestation.md`.

---

Instead of dumping everything into a `docs` folder in the main repo, we could also use the GitHub Wiki but to contribute on your GitHub Wiki I probably need push access which is not great.  The GitHub permission system is not exactly fine-grained.