### PR TITLE
signing: major change to use app keys by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,16 @@ After creating a configuration file, generate keys for your device:
 
 ```console
 $ nix-build ./default.nix --arg configuration ./crosshatch.nix -A generateKeysScript -o generate-keys
-$ mkdir keys/crosshatch
-$ cd keys/crosshatch
-$ ../../generate-keys
-$ cd ../..
+$ ./generate-keys ./keys
 ```
 
+This will create a `keys` directory containing the app and device keys needed for the build.
 Next, build and sign your release.
 There are two ways to do this.
 The first option involves creating a "release script" which does the final build steps of signing target files and creating ota/img files outside of nix:
 ```console
 $ nix-build ./default.nix --arg configuration ./crosshatch.nix -A releaseScript -o release
-$ ./release ./keys/crosshatch
+$ ./release ./keys
 ```
 One advantage of using a release script as above is that the build can take place on a different machine than the signing.
 `nix-copy-closure` could be used to transfer this script and its dependencies to another computer to finish the release.

--- a/flavors/grapheneos/default.nix
+++ b/flavors/grapheneos/default.nix
@@ -27,44 +27,6 @@ in mkIf (config.flavor == "grapheneos") (mkMerge [
     ++ (optional (config.androidVersion != 11) "Unsupported androidVersion (!= 11) for GrapheneOS");
 }
 {
-  # TODO: Temporarily revert the SELinux improvements in GrapheneOS
-  # 2020.10.23.04, which breaks webview/Vanadium in Robotnix caused by (for
-  # example) the "remove base system app execmem" commit and others.
-  # webview/Vanadium ought to be signed by non-system keys.
-  source.dirs."system/sepolicy".src = pkgs.fetchgit {
-    url = "https://github.com/GrapheneOS/platform_system_sepolicy";
-    rev = "RP1A.201005.004.2020.10.06.02";
-    sha256 = "0wrmc9abkgrk92j18g0qvkfsw84kl3rmx5c86kycb9sbbg2hjmgn";
-  };
-  source.dirs."device/google/bonito-sepolicy".patches = [
-    (pkgs.fetchpatch {
-      url = "https://github.com/GrapheneOS/device_google_bonito-sepolicy/commit/2304fe5f0496a28158ef543dcecb3eab6d5bf3e1.patch";
-      sha256 = "0xirwffij0inwnj1svvg5na2ri8zkw5njdb5g6cc5h2gp11spfcs";
-      revert = true;
-    })
-  ];
-  source.dirs."device/google/crosshatch-sepolicy".patches = [
-    (pkgs.fetchpatch {
-      url = "https://github.com/GrapheneOS/device_google_crosshatch-sepolicy/commit/e67d01dac4917f8413118b6ba1d9ddc45e998c40.patch";
-      sha256 = "0xirwffij0inwnj1svvg5na2ri8zkw5njdb5g6cc5h2gp11spfcs";
-      revert = true;
-    })
-  ];
-  source.dirs."device/google/coral-sepolicy".patches = [
-    (pkgs.fetchpatch {
-      url = "https://github.com/GrapheneOS/device_google_coral-sepolicy/commit/bde429f13a9737b3e5ff074d4a27dc879c0c3e29.patch";
-      sha256 = "0ccmq79q0jyzqgw74wmg9w09mlymqm5g2sil6qi7y24f0wahlx8l";
-      revert = true;
-    })
-  ];
-  source.dirs."device/google/sunfish-sepolicy".patches = [
-    (pkgs.fetchpatch {
-      url = "https://github.com/GrapheneOS/device_google_sunfish-sepolicy/commit/0510011d062f96683ee923282a91ae882d5dcb95.patch";
-      sha256 = "1mwgiqbdk99vl7zrqb8n8hs7w8sxvdkrf5pz9n9i47kkdp86p6g3";
-      revert = true;
-    })
-  ];
-
   # Disable setting SCHED_BATCH in soong. Brings in a new dependency and the nix-daemon could do that anyway.
   source.dirs."build/soong".patches = [
     (pkgs.fetchpatch {

--- a/modules/apps/auditor.nix
+++ b/modules/apps/auditor.nix
@@ -24,13 +24,9 @@ in
     } ];
 
     apps.prebuilt.Auditor = {
-      # TODO: Generate this one with a script
-      # TODO: Can sign with custom certs at the release stage instead
-      # Needs a special auditor key that is the same across devices.
-      certificate = "auditor";
       apk = apks.auditor.override {
         inherit (cfg) domain;
-        signatureFingerprint = config.build.fingerprints "auditor";
+        signatureFingerprint = config.apps.prebuilt."Auditor".fingerprint;
         deviceFamily = config.deviceFamily;
         avbFingerprint = config.build.fingerprints "avb";
       };

--- a/modules/apps/fdroid.nix
+++ b/modules/apps/fdroid.nix
@@ -64,7 +64,7 @@ in
       patches = [
         (pkgs.substituteAll {
           src = ./fdroid-privext.patch;
-          fingerprint = toLower (config.build.fingerprints "releasekey");
+          fingerprint = toLower config.apps.prebuilt."F-Droid".fingerprint;
         })
       ];
     };

--- a/modules/apps/prebuilt.nix
+++ b/modules/apps/prebuilt.nix
@@ -16,8 +16,10 @@ let
     LOCAL_MODULE_TAGS := optional
 
     LOCAL_PRIVILEGED_MODULE := ${boolToString prebuilt.privileged}
-    LOCAL_CERTIFICATE := ${if builtins.elem prebuilt.certificate deviceCertificates
-      then (if (prebuilt.certificate == "releasekey") then "testkey" else prebuilt.certificate)
+    LOCAL_CERTIFICATE := ${
+      if (prebuilt.certificate == "PRESIGNED") then "PRESIGNED"
+      else if builtins.elem prebuilt.certificate deviceCertificates
+        then (if (prebuilt.certificate == "releasekey") then "testkey" else prebuilt.certificate)
       else "robotnix/prebuilt/${prebuilt.name}/${prebuilt.certificate}"
     }
     ${optionalString (prebuilt.partition == "vendor") "LOCAL_VENDOR_MODULE := true"}
@@ -187,7 +189,7 @@ in
           if [[ "$TARGET_SDK_VERSION" -lt "${builtins.toString config.apiLevel}" ]]; then
             echo "WARNING: APK was compiled against an older SDK API level ($TARGET_SDK_VERSION) than used in OS (${builtins.toString config.apiLevel})"
           fi
-        '' + optionalString (!(builtins.elem prebuilt.certificate deviceCertificates)) ''
+        '' + optionalString ((prebuilt.certificate != "PRESIGNED") && !(builtins.elem prebuilt.certificate deviceCertificates)) ''
           cp ${prebuilt.snakeoilKeyPath}/${prebuilt.certificate}.{pk8,x509.pem} $out/
         '');
       };

--- a/modules/google.nix
+++ b/modules/google.nix
@@ -66,7 +66,7 @@ in
         config_priorityOnlyDndExemptPackages = [ "com.google.android.dialer" ]; # Found under PixelConfigOverlayCommon.apk
       };
       apps.prebuilt.GoogleDialer = {
-        apk = pkgs.verifyApk {
+        apk = pkgs.robotnix.verifyApk {
           apk = "${productPath}/priv-app/GoogleDialer/GoogleDialer.apk";
           sha256 = "e2d049f3a01192f620b1240615fa8c13badc553c22bc6fddfca45c84d8fc545d";
         };
@@ -81,14 +81,14 @@ in
       google.dialer.enable = true;
       apps.prebuilt = {
         Tycho = { # Google Fi app
-          apk = pkgs.verifyApk {
+          apk = pkgs.robotnix.verifyApk {
             apk = "${productPath}/app/Tycho/Tycho.apk";
             sha256 = "4c36af4a5bdad97c1f3d8b283416d244496c2ac5eafe8226079ef6f676fd1859";
           };
           certificate = "PRESIGNED";
         };
         GCS = { # Google Connectivity Services (does wifi VPN at least)
-          apk = pkgs.verifyApk {
+          apk = pkgs.robotnix.verifyApk {
             apk = "${productPath}/priv-app/GCS/GCS.apk";
             sha256 = "8efed9b84a6320eafde625cea7bb6bae0e320473d0e3c04fb0cd43b779078e1d";
           };
@@ -97,7 +97,7 @@ in
         };
 #### Disabling for now, since calls aren't working ####
 #        CarrierServices = {
-#          apk = pkgs.verifyApk {
+#          apk = pkgs.robotnix.verifyApk {
 #            apk = "${productPath}/priv-app/CarrierServices/CarrierServices.apk"; # Google Carrier Services. com.google.android.ims (needed for wifi calls)
 #            sha256 = "c25d5afacb6783109d6136d79353fad4f6541c3545d25228a18703d043ca783f";
 #          };
@@ -105,7 +105,7 @@ in
 #          privileged = true;
 #        };
         CarrierSettings = { # com.google.android.carrier
-          apk = pkgs.verifyApk {
+          apk = pkgs.robotnix.verifyApk {
             apk = "${productPath}/priv-app/CarrierSettings/CarrierSettings.apk";
             sha256 = "383d1e1b525ec6fb8204c5bf9b8390d37fd157e78b8b7212d61487b178066d20";
           };
@@ -119,7 +119,7 @@ in
         };
       } // (optionalAttrs (config.deviceFamily == "crosshatch") { # TODO: Generalize to other devices with esim
         EuiccGoogle = {
-          apk = pkgs.verifyApk {
+          apk = pkgs.robotnix.verifyApk {
             apk = "${productPath}/priv-app/EuiccGoogle/EuiccGoogle.apk";
             sha256 = "7e26b6d5802a16799448ad635868f0345d6730310634684c0ae44e7e9f7ea764";
           };
@@ -128,7 +128,7 @@ in
         };
       }) // (optionalAttrs ((config.deviceFamily == "crosshatch") && (config.androidVersion >= 10)) {
         EuiccSupportPixel = {
-          apk = pkgs.verifyApk {
+          apk = pkgs.robotnix.verifyApk {
             apk = "${productPath}/priv-app/EuiccSupportPixel/EuiccSupportPixel.apk";
             sha256 = "e0afeca77af15aee48a25ead314c576f8f274682a8fba3365610878f7c1ddb6b";
           };

--- a/modules/microg.nix
+++ b/modules/microg.nix
@@ -40,12 +40,16 @@ in
         privappPermissions = [ "FAKE_PACKAGE_SIGNATURE" "INSTALL_LOCATION_PROVIDER" "CHANGE_DEVICE_IDLE_TEMP_WHITELIST" "UPDATE_APP_OPS_STATS" ];
         defaultPermissions = [ "FAKE_PACKAGE_SIGNATURE" ];
         allowInPowerSave = true;
+        certificate = "microg";
       };
 
-      GsfProxy.apk = verifyApk (pkgs.fetchurl {
-        url = "https://github.com/microg/android_packages_apps_GsfProxy/releases/download/v0.1.0/GsfProxy.apk";
-        sha256 = "14ln6i1qg435x223x3vndd608mra19d58yqqhhf6mw018cbip2c6";
-      });
+      GsfProxy = {
+        apk = verifyApk (pkgs.fetchurl {
+          url = "https://github.com/microg/android_packages_apps_GsfProxy/releases/download/v0.1.0/GsfProxy.apk";
+          sha256 = "14ln6i1qg435x223x3vndd608mra19d58yqqhhf6mw018cbip2c6";
+        });
+        certificate = "microg";
+      };
 
       FakeStore = {
         apk = verifyApk (pkgs.fetchurl {
@@ -56,6 +60,7 @@ in
         privileged = true;
         privappPermissions = [ "FAKE_PACKAGE_SIGNATURE" ];
         defaultPermissions = [ "FAKE_PACKAGE_SIGNATURE" ];
+        certificate = "microg";
       };
     };
   };

--- a/modules/microg.nix
+++ b/modules/microg.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   version = "0.2.14.204215";
-  verifyApk = apk: pkgs.verifyApk {
+  verifyApk = apk: pkgs.robotnix.verifyApk {
     inherit apk;
     sha256 = "9bd06727e62796c0130eb6dab39b73157451582cbd138e86c468acc395d14165"; # O=NOGAPPS Project, C=DE
   };

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -47,7 +47,7 @@ let
     ${otaTools}/releasetools/ota_from_target_files.py  \
       --block \
       ${if config.signing.enable
-        then "-k $KEYSDIR/releasekey"
+        then "-k $KEYSDIR/${config.device}/releasekey"
         else "-k ${config.source.dirs."build/make".src}/target/product/security/testkey"
       } \
       ${optionalString (prevTargetFiles != null) "-i ${prevTargetFiles}"} \

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -32,14 +32,14 @@ let
 
   runWrappedCommand = name: script: args: pkgs.runCommand "${config.device}-${name}-${config.buildNumber}.zip" {} (wrapScript {
     commands = script (args // {out="$out";});
-    keysDir = optionalString config.signing.enable "/keys/${config.device}";
+    keysDir = optionalString config.signing.enable "/keys";
   });
 
   signedTargetFilesScript = { targetFiles, out }: ''
   ( OUT=$(realpath ${out})
     cd ${otaTools}; # Enter otaTools dir so relative paths are correct for finding original keys
     ${otaTools}/releasetools/sign_target_files_apks.py \
-      -o -d $KEYSDIR ${toString config.signing.signTargetFilesArgs} \
+      -o ${toString config.signing.signTargetFilesArgs} \
       ${targetFiles} $OUT
   )
   '';

--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -126,14 +126,14 @@ in
       ];
       keyMappings = {
          # Default key mappings from sign_target_files_apks.py
-        "build/target/product/security/devkey" = "${config.device}/releasekey";
-        "build/target/product/security/testkey" = "${config.device}/releasekey";
-        "build/target/product/security/media" = "${config.device}/media";
-        "build/target/product/security/shared" = "${config.device}/shared";
-        "build/target/product/security/platform" = "${config.device}/platform";
+        "build/make/target/product/security/devkey" = "${config.device}/releasekey";
+        "build/make/target/product/security/testkey" = "${config.device}/releasekey";
+        "build/make/target/product/security/media" = "${config.device}/media";
+        "build/make/target/product/security/shared" = "${config.device}/shared";
+        "build/make/target/product/security/platform" = "${config.device}/platform";
       }
       // optionalAttrs (config.androidVersion >= 10) {
-        "build/target/product/security/networkstack" = "${config.device}/networkstack";
+        "build/make/target/product/security/networkstack" = "${config.device}/networkstack";
       }
       // optionalAttrs (config.androidVersion >= 11) {
         "frameworks/base/packages/OsuLogin/certs/com.android.hotspot2.osulogin" = "com.android.hotspot2.osulogin";

--- a/modules/webview.nix
+++ b/modules/webview.nix
@@ -60,8 +60,11 @@ with lib;
       }
     ];
 
-    apps.prebuilt = lib.mapAttrs' (name: m: nameValuePair "Webview${name}" {
+    apps.prebuilt = lib.mapAttrs' (name: m: nameValuePair "${name}webview" {
       inherit (m) apk;
+
+      # Don't generate a cert if it's the prebuilt version from upstream
+      certificate = if (name != "prebuilt") then "${name}webview" else "PRESIGNED";
 
       # Extra stuff from the Android.mk from the example webview module in AOSP. Unsure if these are needed.
       extraConfig = ''

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -46,11 +46,8 @@ let
 
     ###
 
-    inherit (super.callPackage ./build-tools {})
-      build-tools
-      apksigner
-      signApk
-      verifyApk;
+    # Robotnix helper derivations
+    robotnix = super.callPackage ./robotnix {};
   };
 in
   import nixpkgs (args // {

--- a/release.nix
+++ b/release.nix
@@ -48,9 +48,9 @@ in
     shellcheck ${generateKeysScript}
     shellcheck ${verifyKeysScript}
 
-    ${verifyKeysScript} . && exit 1 || true # verifyKeysScript should fail if we haven't generated keys yet
-    ${generateKeysScript}
-    ${verifyKeysScript} .
+    ${verifyKeysScript} $PWD && exit 1 || true # verifyKeysScript should fail if we haven't generated keys yet
+    ${generateKeysScript} $PWD
+    ${verifyKeysScript} $PWD
   '';
 
   check = lib.mapAttrs (name: c: (robotnix c).build.checkAndroid) configs;


### PR DESCRIPTION
I've delayed pushing this breaking change to master until the next GrapheneOS release (likely today/tomorrow), so I can do a final test on my own personal device. Fixes part of the issues discussed in #24

We now use new application-specific keys and certificates for included apps
like Chromium / webview, Microg, and F-Droid, instead of relying on the
device-specific `releasekey`.  This allows us to share these keys between
multiple devices, push the same app updates to multiple devices, and remove an
ugly SELinux workaround for GrapheneOS that robotnix required.

Unfortunately, changing app keys will lose any data associated with those apps.
Fortunately, most data associated with those apps should be easy to re-create.
(Re-login to services in chromium, re-add F-Droid repos, etc.)
I hope to avoid breaking changes like this in the future by getting these
changes done relatively early in the projects' life.

If you've previously generated robotnix keys, you will need to do the
following to update to the new key directory layout: Move all keys and
certificates beginning with `com.android` from the device subdir (e.g.
`crosshatch`) under your `keyStorePath` to the parent directory. The files
beginning with `releasekey`, `platform`, `shared`, `media`, `networkstack`,
and `avb`/`verity` (if you have it) are device-specific, and should remain
under the device subdirectory.  For example, I ran the following command on my
machine:
 ```shell
$ mv /var/secrets/android-keys/crosshatch/com.android.* /var/secrets/android-keys/
 ```
After this, re-run `generateKeysScript` to create new application keys (e.g.
Chromium, F-Droid).