### PR TITLE
nixos/attestation-server: email configuration

### DIFF
--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -60,10 +60,7 @@
         device = "sunfish";
         signatureFingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         avbFingerprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
-      };
-      services.nginx.virtualHosts."${config.services.attestation-server.domain}" = {
-        enableACME = true;
-        #locations."/api/create_account".return = "404"; # uncomment to disable account creation
+        #disableAccountCreation = true; # optionally uncomment after creating your account
       };
     }
     ```

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -61,6 +61,7 @@
         signatureFingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         avbFingerprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
         #disableAccountCreation = true; # optionally uncomment after creating your account
+        #nginx.enableACME = true; # optionally uncomment if you want to use Let's Encrypt for HTTPS
       };
     }
     ```

--- a/nixos/attestation-server/module.nix
+++ b/nixos/attestation-server/module.nix
@@ -54,6 +54,11 @@ in
       default = true;
       type = types.bool;
     };
+
+    nginx.enableACME = mkOption {
+      default = false;
+      type = types.bool;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -89,6 +94,7 @@ in
         locations."/challenge".proxyPass = "http://${cfg.listenHost}:${toString cfg.port}/challenge";
         locations."/verify".proxyPass = "http://${cfg.listenHost}:${toString cfg.port}/verify";
         forceSSL = true;
+        enableACME = cfg.nginx.enableACME;
       } (optionalAttrs cfg.disableAccountCreation {
         locations."/api/create_account".return = "403";
       });


### PR DESCRIPTION
This adds email configuration to the attestation server.  Honestly, I have not really tried this out yet, because it only sends emails after a minimum interval of 32 hours without successful attestation.  Nevertheless, the attestation server starts up fine with this configuration and I see journal messages like
```
attestation-server.service AttestationServer[877]: dispatching alerts
```
without errors.  This PR also includes the trick to disable account creation and I've added a switch to enable ACME directly from the attestation server, so I don't need an extra block for nginx in my `configuration.nix`.