### PR TITLE
updater: enforce trailing slash requirement

### DIFF
--- a/modules/apps/updater.nix
+++ b/modules/apps/updater.nix
@@ -18,7 +18,10 @@ in
 
       url = mkOption {
         type = types.str;
-        description = "URL for OTA updates (requires trailing slash)";
+        description = "URL for OTA updates";
+        apply = x: if builtins.substring ((builtins.stringLength x) -1) 1 x == "/"
+          then x
+          else "${x}/";
       };
     };
   };


### PR DESCRIPTION
I needed to build another ROM to get OTA updates to work, because I didn't read the description and omitted the trailing slash.

Alternatively an `assert` could be used.