### PR TITLE
Remove "import from derivation" (IFD) from release.nix

### DIFF
--- a/.github/workflows/instantiate.yml
+++ b/.github/workflows/instantiate.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v12
-    - run: nix-instantiate ./release.nix --show-trace
+    - run: nix-instantiate ./release.nix --option allow-import-from-derivation false --show-trace
   generate-keys:
     runs-on: ubuntu-latest
     steps:

--- a/modules/apps/fdroid.nix
+++ b/modules/apps/fdroid.nix
@@ -56,7 +56,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    apps.prebuilt."F-Droid".apk = apks.fdroid;
+    apps.prebuilt."F-Droid" = {
+      apk = apks.fdroid;
+      fingerprint = mkIf (!config.signing.enable) "7352DAE94B237866E7FB44FD94ADE44E8B6E05397E7D1FB45616A00E225063FF";
+    };
 
     # TODO: Put this under product/
     source.dirs."robotnix/apps/F-DroidPrivilegedExtension" = {

--- a/modules/apv.nix
+++ b/modules/apv.nix
@@ -9,7 +9,7 @@ let
   apiStr = builtins.toString config.apiLevel;
   android-prepare-vendor = pkgs.android-prepare-vendor.override { api = config.apiLevel; };
 
-  configFile = android-prepare-vendor.src + "/${config.device}/config.json";
+  configFile = "${android-prepare-vendor.evalTimeSrc}/${config.device}/config.json";
   apvConfig = builtins.fromJSON (builtins.readFile configFile);
 
   # TODO: There's probably a better way to do this


### PR DESCRIPTION
While IFD is convenient, it has a number of downsides. I believe its use was the cause of recent CI failures.  This also makes evaluation much quicker.

This should remove any uses of IFD in the derivations checked in `release.nix`.

However, IFD is still to get the key/cert fingerprints used in user-signed builds.  This may be tackled at some point in the future.

---

_(edit: new theory for CI failure is that evaluation memory usage is too high)_