### PR TITLE
Fix evaluation error for incrementalOta

### DIFF
--- a/modules/release.nix
+++ b/modules/release.nix
@@ -105,9 +105,9 @@ in
 
   config = {
     prevBuildNumber = let
-        metadata = builtins.readFile (prevBuildDir + "/${device}-${channel}");
+        metadata = builtins.readFile (config.prevBuildDir + "/${config.device}-${config.channel}");
       in mkDefault (head (splitString " " metadata));
-    prevTargetFiles = mkDefault (prevBuildDir + "/${device}-target_files-${prevBuildNumber}.zip");
+    prevTargetFiles = mkDefault (config.prevBuildDir + "/${config.device}-target_files-${config.prevBuildNumber}.zip");
   };
 
   config.build = rec {
@@ -116,7 +116,7 @@ in
     signedTargetFiles = runWrappedCommand "signed_target_files" signedTargetFilesScript { targetFiles=unsignedTargetFiles;};
     targetFiles = if config.signing.enable then signedTargetFiles else unsignedTargetFiles;
     ota = runWrappedCommand "ota_update" otaScript { inherit targetFiles; };
-    incrementalOta = runWrappedCommand "incremental-${config.prevBuildNumber}" otaScript { inherit targetFiles prevTargetFiles; };
+    incrementalOta = runWrappedCommand "incremental-${config.prevBuildNumber}" otaScript { inherit targetFiles; inherit (config) prevTargetFiles; };
     img = runWrappedCommand "img" imgScript { inherit targetFiles; };
     factoryImg = runWrappedCommand "factory" factoryImgScript { inherit targetFiles img; };
 

--- a/nixos/attestation-server/module.nix
+++ b/nixos/attestation-server/module.nix
@@ -118,9 +118,12 @@ in
             "('emailLocal', '${if local then "1" else "0"}')"
           ];
         in optionals (passwordFile != null) [
-          # Note the leading + on the first command. The passwordFile could be
+          # Note the leading + on the second command. The passwordFile could be
           # anywhere in the file system, so it has to be copied as root and
-          # permissions fixed to be accessible by the service.
+          # permissions fixed to be accessible by the service.  However, if the
+          # first command is run as root the allocation of uid and gid for the
+          # service seems to be delayed, so we just run something else first.
+          "${pkgs.coreutils}/bin/touch %S/attestation/emailPassword"
           "+${pkgs.coreutils}/bin/install -m 0600 -o %N -g %N ${passwordFile} %S/attestation/emailPassword"
           ''${pkgs.sqlite}/bin/sqlite3 %S/attestation/attestation.db "INSERT OR REPLACE INTO Configuration VALUES ${values}"''
           "${pkgs.coreutils}/bin/rm -f %S/attestation/emailPassword"


### PR DESCRIPTION
https://github.com/danielfullmer/robotnix/commit/5e6510b57b546a43e02e8c5d95511710c6f1759f broke `incrementalOta`. This fixes the evaluation error.

Further on my own server I have experienced some random startup errors of the attestation server similar to this:
```
install[1466]: /nix/store/z1qvlavy35wanw5k54fvvfffws5bvigj-coreutils-8.31/bin/install: invalid user ‘attestation-server’
systemd[1]: attestation-server.service: Control process exited, code=exited, status=1/FAILURE
```
I guess that systemd sets up the dynamic user lazily, i.e. when the first command runs as root the dynamic user doesn't exist yet.  Hence I just added another command before that and haven't had any startup errors since.