### PR TITLE
LineageOS OTA option fix

### DIFF
--- a/flavors/lineageos/default.nix
+++ b/flavors/lineageos/default.nix
@@ -122,4 +122,8 @@ in mkIf (config.flavor == "lineageos")
   # tried had flattened APEX packages as of 2020-07-22
   signing.apex.enable = false;
   envVars.OVERRIDE_TARGET_FLATTEN_APEX = "true";
+
+  # LineageOS needs this additional command line argument to enable
+  # backuptool.sh, which runs scripts under /system/addons.d
+  otaArgs = [ "--backup=true" ];
 }

--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -154,6 +154,11 @@ in
       ++ optionals cfg.avb.enable avbFlags
       ++ optionals cfg.apex.enable (map (k: "--extra_apks ${k}.apex=$KEYSDIR/${k} --extra_apex_payload_key ${k}.apex=$KEYSDIR/${k}.pem") cfg.apex.packageNames);
 
+    otaArgs =
+      if config.signing.enable
+      then [ "-k $KEYSDIR/${config.device}/releasekey" ]
+      else [ "-k ${config.source.dirs."build/make".src}/target/product/security/testkey" ];
+
     build.generateKeysScript = let
       # Get a bunch of utilities to generate keys
       keyTools = pkgs.runCommandCC "android-key-tools" { buildInputs = [ pkgs.python ]; } ''


### PR DESCRIPTION
Added the `--backup=true` option for `ota_from_target_files` used by LineageOS.  This should enable running `backuptool.sh` upon OTA updates, which should then run scripts in `/system/addons.d`.

See also: https://wiki.lineageos.org/signing_builds.html
Fixes #62

CC @Atemu