### PR TITLE
Pixel 5 (redfin) / Pixel 4a (5g) (bramble) support

### DIFF
--- a/flavors/vanilla/default.nix
+++ b/flavors/vanilla/default.nix
@@ -156,7 +156,7 @@ in mkIf (config.flavor == "vanilla") (mkMerge [
     })
   ];
 }
-(mkIf (elem config.deviceFamily phoneDeviceFamilies && config.device != "redfin") (let
+(mkIf (elem config.deviceFamily phoneDeviceFamilies && (!(elem config.deviceFamily != "redfin"))) (let
   kernelTag = {
     "taimen" = "android-11.0.0_r0.34";
     "muskie" = "android-11.0.0_r0.34";

--- a/flavors/vanilla/default.nix
+++ b/flavors/vanilla/default.nix
@@ -5,7 +5,7 @@ let
 
   phoneDeviceFamilies =
     (optional (config.androidVersion <= 10) "marlin")
-    ++ [ "taimen" "muskie" "crosshatch" "bonito" "coral" "sunfish" ];
+    ++ [ "taimen" "muskie" "crosshatch" "bonito" "coral" "sunfish" "redfin" ];
   supportedDeviceFamilies = phoneDeviceFamilies ++ [ "generic" ];
 
   # Replaces references to SystemUIGoogle with SystemUI in device source tree
@@ -156,7 +156,7 @@ in mkIf (config.flavor == "vanilla") (mkMerge [
     })
   ];
 }
-(mkIf (elem config.deviceFamily phoneDeviceFamilies) (let
+(mkIf (elem config.deviceFamily phoneDeviceFamilies && config.device != "redfin") (let
   kernelTag = {
     "taimen" = "android-11.0.0_r0.34";
     "muskie" = "android-11.0.0_r0.34";

--- a/modules/pixel/default.nix
+++ b/modules/pixel/default.nix
@@ -25,7 +25,7 @@ let
     coral = { family = "coral"; name = "Pixel 4 XL"; };
     flame = { family = "coral"; name = "Pixel 4"; };
     sunfish = { family = "sunfish"; name = "Pixel 4a"; };
-    bramble = { family = "bramble"; name = "Pixel 4a (5G)"; };
+    bramble = { family = "redfin"; name = "Pixel 4a (5G)"; };
     redfin = { family = "redfin"; name = "Pixel 5"; };
   };
 

--- a/release.nix
+++ b/release.nix
@@ -17,6 +17,7 @@ let
     { device="coral";      flavor="vanilla"; }
     { device="flame";      flavor="vanilla"; }
     { device="sunfish";    flavor="vanilla"; }
+    { device="bramble";    flavor="vanilla"; }
     { device="redfin";     flavor="vanilla"; }
 
     { device="x86_64";     flavor="grapheneos"; }

--- a/release.nix
+++ b/release.nix
@@ -17,6 +17,7 @@ let
     { device="coral";      flavor="vanilla"; }
     { device="flame";      flavor="vanilla"; }
     { device="sunfish";    flavor="vanilla"; }
+    { device="redfin";     flavor="vanilla"; }
 
     { device="x86_64";     flavor="grapheneos"; }
     { device="arm64";      flavor="grapheneos"; }


### PR DESCRIPTION
Uploading this here in case anyone has a Pixel 5 and would like to test. Upstream `android-prepare-vendor` support is nearly done.  
 Pixel 4a (5g) support is reportedly similar. https://github.com/danielfullmer/robotnix/issues/52

I still need to build the kernel from source, as it currently just uses the prebuilt kernel.

Tested building with:
```
nix-build --arg configuration '{device="redfin"; flavor="vanilla";}' -A img
```