### PR TITLE
attestation-server: add basic nixos test

### DIFF
--- a/nixos/attestation-server/test.nix
+++ b/nixos/attestation-server/test.nix
@@ -12,11 +12,12 @@ import "${pkgs.path}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
       device = "crosshatch";
       signatureFingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
       avbFingerprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
-      email = {
-        host = "example.com";
-        username = "test";
-        passwordFile = "${pkgs.writeText "fake-password" "testing123"}"; # NOTE: Don't use writeText like this with a real password!
-      };
+      # TODO: Uncomment when https://github.com/danielfullmer/robotnix/issues/80 is resolved
+      # email = {
+      #   host = "example.com";
+      #   username = "test";
+      #   passwordFile = "${pkgs.writeText "fake-password" "testing123"}"; # NOTE: Don't use writeText like this with a real password!
+      # };
       nginx.enable = false;
     };
   };

--- a/nixos/attestation-server/test.nix
+++ b/nixos/attestation-server/test.nix
@@ -1,0 +1,28 @@
+{ pkgs }:
+
+import "${pkgs.path}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
+  name = "attestation-server";
+
+  machine = { ... }: {
+    imports = [ ../default.nix ];
+
+    services.attestation-server = {
+      enable = true;
+      domain = "example.com";
+      device = "crosshatch";
+      signatureFingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+      avbFingerprint = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+      email = {
+        host = "example.com";
+        username = "test";
+        passwordFile = "${pkgs.writeText "fake-password" "testing123"}"; # NOTE: Don't use writeText like this with a real password!
+      };
+      nginx.enable = false;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("attestation-server.service")
+    machine.wait_until_succeeds("curl http://127.0.0.1:8085/")
+  '';
+})

--- a/release.nix
+++ b/release.nix
@@ -91,4 +91,8 @@ in
       (lib.mapAttrs (name: c: c.config.build.kernel)
         (lib.filterAttrs (name: c: c.config.kernel.useCustom) builtConfigs));
   };
+
+  tests = lib.recurseIntoAttrs {
+    attestation-server = import ./nixos/attestation-server/test.nix { inherit pkgs; };
+  };
 }


### PR DESCRIPTION
Adds a basic test of the attestation server, which currently just ensures it starts correctly.  This test currently fails due to https://github.com/danielfullmer/robotnix/issues/80.  It does work, however, if the email configuration is not set.

If/when we have the cuttlefish virtual device working well with NixOS tests, it might be possible told do a more complete end-to-and test!

Tested using `nix-build ./release.nix -A tests.attestation-server`

CC @hmenke