### PR TITLE
flakes: use locked nixpkgs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,0 +1,12 @@
+{ overlays ? [ ], ... }@args:
+let
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+
+  nixpkgs = fetchTarball (with lock.nodes.nixpkgs.locked; {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  });
+in
+import nixpkgs ({
+  overlays = overlays ++ [ (import ./overlay.nix) ];
+} // builtins.removeAttrs args [ "overlays" ])


### PR DESCRIPTION
The addition of flake support comes at a convenient time for me.  I'm just in the process of migrating all my systems to flakes.  Unfortunately, the first draft broke the regular evaluation.  This fixes it by re-adding `pkgs/default.nix` and loading the locked revision from the `flake.lock` file.