### PR TITLE
Keys refactor again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@ changes occur which require user intervention / configuration changes.  These
 are highlights since the last update, and are not meant to be an exhaustive
 listing of changes. See the git commit log for additional details.
 
+# 2021-06-xx
+
+## Backwards incompatible changes
+- Renamed `keyStorePath` to `signing.keyStorePath`.
+
 # 2021-05-04
 ## Highlights:
 - Updated vanilla flavor to RQ2A.210505

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ listing of changes. See the git commit log for additional details.
 
 # 2021-06-xx
 
+# Highlights:
+- Fixed building outside Nix sandbox (e.g. in Docker) by introducing `signing.buildTimeKeyStorePath` option.
+
 ## Backwards incompatible changes
 - Renamed `keyStorePath` to `signing.keyStorePath`.
 

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -28,7 +28,7 @@ $ nix-build --arg configuration ./crosshatch.nix -A generateKeysScript -o genera
 $ ./generate-keys ./keys
 ```
 This will create a `keys` directory containing the app and device keys needed for the build.
-The output of this script should be placed in the location specified by `keyStorePath` in the robotnix configuration.
+The output of this script should be placed in the location specified by `signing.keyStorePath` in the robotnix configuration.
 
 Sometimes changing your configuration will require that you generate additional new keys (e.g. for additional applications).
 Rebuilding and rerunning the generate keys script will produce the new keys (without overwriting your existing keys).
@@ -50,7 +50,7 @@ $ nix-build --arg configuration ./crosshatch.nix -A releaseScript -o release
 $ ./release ./keys
 ```
 This has the additional benefit that the build can take place on a remote machine, and the `releaseScript` could be copied using `nix-copy-closure` to a local machine which containing the keys.
-You might need to manually set certain required options like `signing.avb.fingerprint` or `apps.prebuilt.<name>.fingerprint` if you build on a remote machine that does not have access to `keyStorePath`.
+You might need to manually set certain required options like `signing.avb.fingerprint` or `apps.prebuilt.<name>.fingerprint` if you build on a remote machine that does not have access to the `signing.keyStorePath`.
 
 ## Binary Cache
 Robotnix now has an optional binary cache provided by [Cachix](https://cachix.org/) on [robotnix.cachix.org](https://robotnix.cachix.org/).

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -42,8 +42,9 @@ The first option is to build the final products entirely inside Nix.
 ```console
 $ nix-build ./default.nix --arg configuration ./crosshatch.nix -A img --option extra-sandbox-paths /keys=$(pwd)/keys
 ```
-This, however, will require a nix sandbox exception so the secret keys are available to the build scripts.
+If the Nix sandbox is enabled (it normally is), this will require a sandbox exception so the secret keys are available to the build scripts.
 To use `extra-sandbox-paths`, the user must be a `trusted-user` in `nix.conf`.
+If the Nix sandbox is not enabled, we can instead set `signing.buildTimeKeysStorePath` in addition to `signing.keyStorePath` to a string of the absolute path to the generated keys.
 Additionally, the nix builder will also need read access to these keys.
 This can be set using `chgrp -R nixbld ./keys` and `chmod -R g+r ./keys`.
 

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -29,6 +29,9 @@ $ ./generate-keys ./keys
 ```
 This will create a `keys` directory containing the app and device keys needed for the build.
 The output of this script should be placed in the location specified by `signing.keyStorePath` in the robotnix configuration.
+If you intend to build the `img`/`factoryImg`/`ota` Nix outputs instead of using the `releaseScript`, do not apply a passphrase to your keys here.
+(You can still encrypt them at rest on your own through other means.)
+This is because we cannot prompt you for your passphrase during the Nix build, but we can outside of Nix using `generateKeysScript`.
 
 Sometimes changing your configuration will require that you generate additional new keys (e.g. for additional applications).
 Rebuilding and rerunning the generate keys script will produce the new keys (without overwriting your existing keys).

--- a/example.nix
+++ b/example.nix
@@ -18,9 +18,8 @@ in
   # If you make new changes to your build that you want to be pushed by the OTA updater, you should set this yourself.
   # buildDateTime = 1584398664; # Use `date "+%s"` to get the current time
 
-  # A _string_ of the path for the key store.
-  # keyStorePath = "/var/secrets/android-keys";
   # signing.enable = true;
+  # signing.keyStorePath = "/var/secrets/android-keys"; # A _string_ of the path for the key store.
 
   # Build with ccache
   ccache.enable = true;

--- a/modules/apps/prebuilt.nix
+++ b/modules/apps/prebuilt.nix
@@ -49,7 +49,7 @@ let
         then "${keyStorePath}/${config.device}/${name}"
         else "${config.source.dirs."build/make".src}/target/product/security/${lib.replaceStrings ["releasekey"] ["testkey"] name}") # If not signing.enable, use test keys from AOSP
       else "${keyStorePath}/${name}";
-  keyPath = name: _keyPath config.keyStorePath name;
+  keyPath = name: _keyPath config.signing.keyStorePath name;
   sandboxKeyPath = name:
     if config.signing.enable
       then _keyPath "/keys" name

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -8,7 +8,7 @@ let
 
   otaTools = config.build.otaTools;
 
-  wrapScript = { commands, keysDir ? "" }: ''
+  wrapScript = { commands, keysDir }: ''
     export PATH=${otaTools}/bin:$PATH
     export EXT2FS_NO_MTAB_OK=yes
 
@@ -26,6 +26,7 @@ let
       NEW_KEYSDIR=$(mktemp -d /dev/shm/robotnix_keys.XXXXXXXXXX)
       trap "rm -rf \"$NEW_KEYSDIR\"" EXIT
       cp -r "$KEYSDIR"/* "$NEW_KEYSDIR"
+      chmod u+w -R "$NEW_KEYSDIR"
       KEYSDIR=$NEW_KEYSDIR
     fi
 
@@ -34,7 +35,7 @@ let
 
   runWrappedCommand = name: script: args: pkgs.runCommand "${config.device}-${name}-${config.buildNumber}.zip" {} (wrapScript {
     commands = script (args // {out="$out";});
-    keysDir = lib.optionalString config.signing.enable "/keys";
+    keysDir = config.signing.buildTimeKeyStorePath;
   });
 
   signedTargetFilesScript = { targetFiles, out }: ''

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -30,8 +30,6 @@ let
     fi
 
     ${commands}
-
-    if [[ "$KEYSDIR" ]]; then rm -rf "$KEYSDIR"; fi
   '';
 
   runWrappedCommand = name: script: args: pkgs.runCommand "${config.device}-${name}-${config.buildNumber}.zip" {} (wrapScript {

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -16,9 +16,8 @@
       # If you make new changes to your build that you want to be pushed by the OTA updater, you should set this yourself.
       # buildDateTime = 1584398664; # Use `date "+%s"` to get the current time
 
-      # A _string_ of the path for the key store.
       # keyStorePath = "/var/secrets/android-keys";
-      # signing.enable = true;
+      # signing.keyStorePath = "/var/secrets/android-keys"; # A _string_ of the path for the key store.
 
       # Build with ccache
       # ccache.enable = true;


### PR DESCRIPTION
Renames `keyStorePath` to `signing.keyStorePath`. Also introduces a `signing.buildTimeKeyStorePath` option, which is useful if we can't use the Nix sandbox to bind-mount our keys under `/keys`.

If you use the Nix sandbox normally, there's no need to use `signing.buildTimeKeyStorePath`, since using it makes the signing derivations contain a string of the path your keys are located  under.

(I needed `signing.buildTimeKeyStorePath` so I could produce a derivation which would sign the build with snakeoil keys under `/nix/store`.)

Closes #41