### PR TITLE
seedvault: add includedInFlavor option

### DIFF
--- a/flavors/grapheneos/default.nix
+++ b/flavors/grapheneos/default.nix
@@ -60,12 +60,11 @@ in mkIf (config.flavor == "grapheneos") (mkMerge [
   webview.vanadium.enable = mkDefault true;
   webview.vanadium.availableByDefault = mkDefault true;
 
-  apps.seedvault.enable = mkDefault true;
+  apps.seedvault.includedInFlavor = mkDefault true;
 
   # Remove upstream prebuilt versions from build. We build from source ourselves.
-  removedProductPackages = [ "TrichromeWebView" "TrichromeChrome" "webview" "Seedvault" ];
+  removedProductPackages = [ "TrichromeWebView" "TrichromeChrome" "webview" ];
   source.dirs."external/vanadium".enable = false;
-  source.dirs."external/seedvault".enable = false;
 
   # Override included android-prepare-vendor, with the exact version from
   # GrapheneOS. Unfortunately, Doing it this way means we don't cache apv

--- a/modules/apps/seedvault.nix
+++ b/modules/apps/seedvault.nix
@@ -4,16 +4,24 @@
 { config, pkgs, apks, lib, ... }:
 
 let
-  inherit (lib) mkIf mkMerge mkEnableOption;
+  inherit (lib) mkIf mkMerge mkOption mkEnableOption types;
 
   cfg = config.apps.seedvault;
 in
 {
   options = {
-    apps.seedvault.enable = mkEnableOption "Seedvault (backup)";
+    apps.seedvault = {
+      enable = mkEnableOption "Seedvault (backup)";
+
+      includedInFlavor = mkOption {
+        default = false;
+        type = types.bool;
+        internal = true;
+      };
+    };
   };
 
-  config = mkIf cfg.enable (mkMerge [
+  config = mkIf (cfg.enable && (!cfg.includedInFlavor)) (mkMerge [
   {
     # In order to switch to using this if it's not set on the first boot, run these:
     # $ bmgr list transports


### PR DESCRIPTION
Submitting as a PR in case there are any comments about this way of handling packages which could be included by either the upstream flavor or by a robotnix module.

---

Previously, we have stripped out upstream versions of packages if we
have a corresponding robotnix module which has the same functionality.
To better match upstream builds for reproducibility, we should not do
this _unless_ the upstream package is a prebuilt APK that we want to
build ourselves.

Since Seedvault (as of Android 11) can be built inside AOSP, and does
not have to be included as a prebuilt APK, we can use the flavor's
version instead, if it exists.


We introduce an internal option called apps.seedvault.includedInFlavor,
which is meant to be set by the flavor, and indicates that Seedvault
would be included automatically by the flavor if no additional changes
are made.  The robotnix module is only used if `enable=true` and
`includedInFlavor=false` under `apps.seedvault`.

If the user really wants to use the robotnix-provided version, they'll
need to set:
```nix
{
  apps.seedvault.enable = true;
  apps.seedvault.includedInFlavor = false;

  # Also remove the upstream version
  removedProductPackages = [ "Seedvault" ];
  source.dirs."external/seedvault".enable = false;
}
```