### PR TITLE
Pre-populate mount points if necessary

### DIFF
--- a/.github/workflows/instantiate.yml
+++ b/.github/workflows/instantiate.yml
@@ -12,6 +12,17 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v12
     - run: nix-instantiate ./release.nix --option allow-import-from-derivation false --show-trace
+  robotnix-eval-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v12
+    - run: |
+        OUTPUT=$(nix-instantiate --eval --strict tests/eval.nix)
+        if [[ "$OUTPUT" != "[ ]" ]]; then
+          echo "Instantiation tests failed:"
+          echo $OUTPUT
+        fi
   generate-keys:
     runs-on: ubuntu-latest
     steps:

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -1,0 +1,32 @@
+# To run these tests:
+# nix-instantiate --eval --strict ./eval.nix
+# if the resulting list is empty, all tests passed
+
+let
+  pkgs = import ../pkgs {};
+  lib = pkgs.lib;
+  robotnixSystem = configuration: import ../default.nix { inherit configuration pkgs; };
+in
+
+lib.runTests {
+  testSourceMountPoints = {
+    expr = let
+      dirs = [ "a" "a/b" "a/c" "b/d" "b/e" ];
+    in
+      lib.filterAttrs (n: v: lib.elem n dirs)
+        ((lib.mapAttrs (name: dir: dir.postPatch))
+          (robotnixSystem {
+            source.dirs = lib.genAttrs dirs (dir: {});
+          }).config.source.dirs);
+    expected = {
+      "a" = ''
+        mkdir b
+        mkdir c
+      '';
+      "a/b" = "";
+      "a/c" = "";
+      "b/d" = "";
+      "b/e" = "";
+    };
+  };
+}


### PR DESCRIPTION
Includes first pure-evaluation test using the `runTests` from `nixpkgs`.