### PR TITLE
base: add shebang to debug-enter-env

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -479,6 +479,7 @@ in
         export SAVED_UID=$(${pkgs.coreutils}/bin/id -u)
         export SAVED_GID=$(${pkgs.coreutils}/bin/id -g)
         ${pkgs.utillinux}/bin/unshare -m -r ${pkgs.writeScript "debug-enter-env2.sh" ''
+        #!${pkgs.runtimeShell}
         export rootDir=$PWD
         source ${config.build.unpackScript}
         ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "export ${name}=${value}") config.envVars)}


### PR DESCRIPTION
I was playing around with the FHS env to build Android on Ubuntu with Nix. Because the default shell on Ubuntu is Dash instead of Bash, things like `source` don't work unless the correct shell is selected with the shebang.