### PR TITLE
require big parallel for big derivations

### DIFF
--- a/apks/chromium/default.nix
+++ b/apks/chromium/default.nix
@@ -158,6 +158,8 @@ in stdenvNoCC.mkDerivation rec {
     libdrm
   ];
 
+  requiredSystemFeatures = [ "big-parallel" ];
+
   patches =
     lib.optional enableRebranding
       (substituteAll {

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -285,6 +285,8 @@ in
 
           inherit outputs;
 
+          requiredSystemFeatures = [ "big-parallel" ];
+
           nativeBuildInputs = [ config.build.env fakeuser ];
 
           unpackPhase = ''
@@ -292,7 +294,7 @@ in
             source ${config.build.unpackScript}
           '';
 
-          configurePhase = ":";
+          dontConfigure = true;
 
           # This was originally in the buildPhase, but building the sdk / atree would complain for unknown reasons when it was set
           # export OUT_DIR=$rootDir/out


### PR DESCRIPTION
This should not affect anyone not using remote builders. Without this, when using hydra or remote builders, these can get distributed to machines where the builds fail.

Maybe this should be documented.