### PR TITLE
Add ROBOTNIX_GIT_MIRRORS environment variable

### DIFF
--- a/apks/chromium/mk-vendor-file.py
+++ b/apks/chromium/mk-vendor-file.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i python -p python2 nix git nix-prefetch-git cipd -I nixpkgs=../../pkgs
+#!/usr/bin/env python2
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/cachix-push.sh
+++ b/cachix-push.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cachix -I nixpkgs=./pkgs
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/flake.nix
+++ b/flake.nix
@@ -6,16 +6,17 @@
     androidPkgs.url = "github:tadfisher/android-nixpkgs/stable";
   };
 
-  outputs = { self, nixpkgs, androidPkgs, ... }: {
-    # robotnixSystem evaluates a robotnix configuration
-    lib.robotnixSystem = configuration: import ./default.nix {
-      inherit configuration;
-      pkgs = nixpkgs.legacyPackages.x86_64-linux.appendOverlays [
+  outputs = { self, nixpkgs, androidPkgs, ... }: let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux.appendOverlays [
         (self: super: {
           androidPkgs.sdk = androidPkgs.sdk.x86_64-linux;
         })
         (import ./pkgs/overlay.nix)
       ];
+  in {
+    # robotnixSystem evaluates a robotnix configuration
+    lib.robotnixSystem = configuration: import ./default.nix {
+      inherit configuration pkgs;
     };
 
     defaultTemplate = {
@@ -29,7 +30,9 @@
     checks.x86_64-linux = {};
 
     packages.x86_64-linux = {
-      manual = (import ./docs { pkgs = nixpkgs.legacyPackages.x86_64-linux; }).manual;
+      manual = (import ./docs { inherit pkgs; }).manual;
     };
+
+    devShell.x86_64-linux = import ./shell.nix { inherit pkgs; };
   };
 }

--- a/flavors/anbox/update.sh
+++ b/flavors/anbox/update.sh
@@ -5,15 +5,6 @@
 
 set -eu
 
-if [[ "$USER" = "danielrf" ]]; then
-    mirror_args=(
-        --mirror "https://android.googlesource.com=/mnt/cache/mirror"
-        --mirror "https://github.com/anbox=/mnt/cache/anbox/anbox"
-    )
-else
-    mirror_args=()
-fi
-
 args=(
 	"https://github.com/pmanbox/platform_manifests"
     --ref-type branch
@@ -23,4 +14,4 @@ args=(
 
 export TMPDIR=/tmp
 
-../../mk-repo-file.py "${mirror_args[@]}" "${args[@]}"
+../../mk-repo-file.py "${args[@]}"

--- a/flavors/grapheneos/extract-upstream-params.sh
+++ b/flavors/grapheneos/extract-upstream-params.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p simg2img e2fsprogs
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2021 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/flavors/grapheneos/update.sh
+++ b/flavors/grapheneos/update.sh
@@ -4,14 +4,6 @@
 
 set -eu
 
-if [[ "$USER" = "danielrf" ]]; then
-    mirror_args=(
-        --mirror "https://android.googlesource.com=/mnt/cache/mirror"
-    )
-else
-    mirror_args=()
-fi
-
 args=(
     --ref-type tag
     "https://github.com/GrapheneOS/platform_manifest"
@@ -25,4 +17,4 @@ args=(
 
 export TMPDIR=/tmp
 
-../../mk-repo-file.py "${mirror_args[@]}" "${args[@]}"
+../../mk-repo-file.py "${args[@]}"

--- a/flavors/lineageos/update-device-dirs.py
+++ b/flavors/lineageos/update-device-dirs.py
@@ -17,7 +17,7 @@ import urllib.request
 
 LINEAGE_REPO_BASE = "https://github.com/LineageOS"
 VENDOR_REPO_BASE = "https://github.com/TheMuppets"
-MIRRORS = {}
+MIRRORS = dict(mirror.split("=") for mirror in os.environ.get('ROBOTNIX_GIT_MIRRORS', '').split('|'))
 REMOTE_REFS = {} # url: { ref: rev }
 
 def save(filename, data):
@@ -151,15 +151,10 @@ def fetch_vendor_dirs(metadata, filename, branch):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--branch', help="lineageos version")
-    parser.add_argument('--mirror', default=[], action='append', help="a repo mirror to use for a given url, specified by <url>=<path>")
     parser.add_argument('product', nargs='*',
                         help='product to fetch directory metadata for, specified by <vendor>_<device> (example: google_crosshatch) '
                         'If no products are specified, all products in device-metadata.json will be updated')
     args = parser.parse_args()
-
-    for mirror in args.mirror:
-        url, path = mirror.split('=')
-        MIRRORS[url] = path
 
     if len(args.product) == 0:
         metadata = json.load(open('device-metadata.json'))

--- a/flavors/lineageos/update-device-dirs.py
+++ b/flavors/lineageos/update-device-dirs.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i python -p python3 nix-prefetch-git -I nixpkgs=../../pkgs
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/flavors/lineageos/update-device-metadata.py
+++ b/flavors/lineageos/update-device-metadata.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i python -p python3 -I nixpkgs=../../pkgs
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/flavors/lineageos/update.sh
+++ b/flavors/lineageos/update.sh
@@ -4,16 +4,6 @@
 
 set -eu
 
-if [[ "$USER" = "danielrf" ]]; then
-    mirror_args=(
-        --mirror "https://android.googlesource.com=/mnt/cache/mirror"
-        --mirror "https://github.com/LineageOS=/mnt/cache/lineageos/LineageOS"
-        --mirror "https://github.com/TheMuppets=/mnt/cache/muppets/TheMuppets"
-    )
-else
-    mirror_args=()
-fi
-
 branch=$1
 
 args=(
@@ -26,5 +16,5 @@ args=(
 export TMPDIR=/tmp
 
 ./update-device-metadata.py
-../../mk-repo-file.py --out "${branch}/repo.json" "${mirror_args[@]}" "${args[@]}"
-./update-device-dirs.py --branch "$branch" "${mirror_args[@]}"
+../../mk-repo-file.py --out "${branch}/repo.json" "${args[@]}"
+./update-device-dirs.py --branch "$branch"

--- a/flavors/vanilla/update.sh
+++ b/flavors/vanilla/update.sh
@@ -4,14 +4,6 @@
 
 set -eu
 
-if [[ "$USER" = "danielrf" ]]; then
-    mirror_args=(
-        --mirror "https://android.googlesource.com=/mnt/cache/mirror"
-    )
-else
-    mirror_args=()
-fi
-
 args=(
     --ref-type tag
     "https://android.googlesource.com/platform/manifest"
@@ -21,4 +13,4 @@ args=(
 
 export TMPDIR=/tmp
 
-../../mk-repo-file.py "${mirror_args[@]}" "${args[@]}"
+../../mk-repo-file.py "${args[@]}"

--- a/mk-repo-file.py
+++ b/mk-repo-file.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i python -p python3 nix gitRepo nix-prefetch-git -I nixpkgs=./pkgs
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/mk-repo-file.py
+++ b/mk-repo-file.py
@@ -139,7 +139,6 @@ def make_repo_file(url: str, ref: str, filename: str, ref_type: ManifestRefType,
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--out', default=None, help="path to output file, defaults to repo-{rev}.json")
-    parser.add_argument('--mirror', action="append", help="a repo mirror to use for a given url, specified by <url>=<path>")
     parser.add_argument('--ref-type', help="the kind of ref that is to be fetched",
                         choices=[t.name.lower() for t in ManifestRefType], default=ManifestRefType.TAG.name.lower())
     parser.add_argument('--resume', help="resume a previous download", action='store_true')
@@ -153,10 +152,7 @@ def main():
     parser.add_argument('oldrepojson', nargs='*', help="any older repo json files to use for cached sha256s")
     args = parser.parse_args()
 
-    if args.mirror:
-        mirrors = dict(mirror.split("=") for mirror in args.mirror)
-    else:
-        mirrors = {}
+    mirrors = dict(mirror.split("=") for mirror in os.environ.get('ROBOTNIX_GIT_MIRRORS', '').split('|'))
 
     ref_type = ManifestRefType[args.ref_type.upper()]
 

--- a/modules/pixel/update.sh
+++ b/modules/pixel/update.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl go-pup jq
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2020 Daniel Fullmer and robotnix contributors
 # SPDX-License-Identifier: MIT
 

--- a/pkgs/fetchgit/builder.sh
+++ b/pkgs/fetchgit/builder.sh
@@ -1,0 +1,17 @@
+# tested so far with:
+# - no revision specified and remote has a HEAD which is used
+# - revision specified and remote has a HEAD
+# - revision specified and remote without HEAD
+source $stdenv/setup
+
+header "exporting $url (rev $rev) into $out"
+
+$SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
+  ${leaveDotGit:+--leave-dotGit} \
+  ${fetchLFS:+--fetch-lfs} \
+  ${deepClone:+--deepClone} \
+  ${fetchSubmodules:+--fetch-submodules} \
+  ${branchName:+--branch-name "$branchName"}
+
+runHook postFetch
+stopNest

--- a/pkgs/fetchgit/default.nix
+++ b/pkgs/fetchgit/default.nix
@@ -1,0 +1,75 @@
+{lib, stdenvNoCC, git, git-lfs, cacert}: let
+  urlToName = url: rev: let
+    inherit (lib) removeSuffix splitString last;
+    base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));
+
+    matched = builtins.match "(.*)\\.git" base;
+
+    short = builtins.substring 0 7 rev;
+
+    appendShort = if (builtins.match "[a-f0-9]*" rev) != null
+      then "-${short}"
+      else "";
+  in "${if matched == null then base else builtins.head matched}${appendShort}";
+in
+{ url, rev ? "HEAD", md5 ? "", sha256 ? "", leaveDotGit ? deepClone
+, fetchSubmodules ? true, deepClone ? false
+, branchName ? null
+, name ? urlToName url rev
+, # Shell code executed after the file has been fetched
+  # successfully. This can do things like check or transform the file.
+  postFetch ? ""
+, preferLocalBuild ? true
+, fetchLFS ? false
+}:
+
+/* NOTE:
+   fetchgit has one problem: git fetch only works for refs.
+   This is because fetching arbitrary (maybe dangling) commits may be a security risk
+   and checking whether a commit belongs to a ref is expensive. This may
+   change in the future when some caching is added to git (?)
+   Usually refs are either tags (refs/tags/*) or branches (refs/heads/*)
+   Cloning branches will make the hash check fail when there is an update.
+   But not all patches we want can be accessed by tags.
+
+   The workaround is getting the last n commits so that it's likely that they
+   still contain the hash we want.
+
+   for now : increase depth iteratively (TODO)
+
+   real fix: ask git folks to add a
+   git fetch $HASH contained in $BRANCH
+   facility because checking that $HASH is contained in $BRANCH is less
+   expensive than fetching --depth $N.
+   Even if git folks implemented this feature soon it may take years until
+   server admins start using the new version?
+*/
+
+assert deepClone -> leaveDotGit;
+
+if md5 != "" then
+  throw "fetchgit does not support md5 anymore, please use sha256"
+else
+stdenvNoCC.mkDerivation {
+  inherit name;
+  builder = ./builder.sh;
+  fetcher = ./nix-prefetch-git;  # This must be a string to ensure it's called with bash.
+
+  nativeBuildInputs = [ git ]
+    ++ lib.optionals fetchLFS [ git-lfs ];
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  inherit url rev leaveDotGit fetchLFS fetchSubmodules deepClone branchName postFetch;
+
+  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+    "GIT_PROXY_COMMAND" "SOCKS_SERVER"
+    "ROBOTNIX_GIT_MIRRORS"
+  ];
+
+  inherit preferLocalBuild;
+}

--- a/pkgs/fetchgit/nix-prefetch-git
+++ b/pkgs/fetchgit/nix-prefetch-git
@@ -1,0 +1,468 @@
+#! /usr/bin/env bash
+
+set -e -o pipefail
+
+url=
+rev=
+expHash=
+hashType=$NIX_HASH_ALGO
+deepClone=$NIX_PREFETCH_GIT_DEEP_CLONE
+leaveDotGit=$NIX_PREFETCH_GIT_LEAVE_DOT_GIT
+fetchSubmodules=
+fetchLFS=
+builder=
+branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
+
+# ENV params
+out=${out:-}
+http_proxy=${http_proxy:-}
+
+# populated by clone_user_rev()
+fullRev=
+humanReadableRev=
+commitDate=
+commitDateStrict8601=
+
+if test -n "$deepClone"; then
+    deepClone=true
+else
+    deepClone=
+fi
+
+if test "$leaveDotGit" != 1; then
+    leaveDotGit=
+else
+    leaveDotGit=true
+fi
+
+usage(){
+    echo  >&2 "syntax: nix-prefetch-git [options] [URL [REVISION [EXPECTED-HASH]]]
+
+Options:
+      --out path      Path where the output would be stored.
+      --url url       Any url understood by 'git clone'.
+      --rev ref       Any sha1 or references (such as refs/heads/master)
+      --hash h        Expected hash.
+      --branch-name   Branch name to check out into
+      --deepClone     Clone the entire repository.
+      --no-deepClone  Make a shallow clone of just the required ref.
+      --leave-dotGit  Keep the .git directories.
+      --fetch-lfs     Fetch git Large File Storage (LFS) files.
+      --fetch-submodules Fetch submodules.
+      --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
+      --quiet         Only print the final json summary.
+"
+    exit 1
+}
+
+# some git commands print to stdout, which would contaminate our JSON output
+clean_git(){
+    git "$@" >&2
+}
+
+argi=0
+argfun=""
+for arg; do
+    if test -z "$argfun"; then
+        case $arg in
+            --out) argfun=set_out;;
+            --url) argfun=set_url;;
+            --rev) argfun=set_rev;;
+            --hash) argfun=set_hashType;;
+            --branch-name) argfun=set_branchName;;
+            --deepClone) deepClone=true;;
+            --quiet) QUIET=true;;
+            --no-deepClone) deepClone=;;
+            --leave-dotGit) leaveDotGit=true;;
+            --fetch-lfs) fetchLFS=true;;
+            --fetch-submodules) fetchSubmodules=true;;
+            --builder) builder=true;;
+            -h|--help) usage; exit;;
+            *)
+                : $((++argi))
+                case $argi in
+                    1) url=$arg;;
+                    2) rev=$arg;;
+                    3) expHash=$arg;;
+                    *) exit 1;;
+                esac
+                ;;
+        esac
+    else
+        case $argfun in
+            set_*)
+                var=${argfun#set_}
+                eval $var=$arg
+                ;;
+        esac
+        argfun=""
+    fi
+done
+
+if test -z "$url"; then
+    usage
+fi
+
+
+init_remote(){
+    local url=$1
+    clean_git init --initial-branch=master
+    clean_git remote add origin "$url"
+    ( [ -n "$http_proxy" ] && clean_git config http.proxy "$http_proxy" ) || true
+}
+
+# Return the reference of an hash if it exists on the remote repository.
+ref_from_hash(){
+    local hash=$1
+    git ls-remote origin | sed -n "\,$hash\t, { s,\(.*\)\t\(.*\),\2,; p; q}"
+}
+
+# Return the hash of a reference if it exists on the remote repository.
+hash_from_ref(){
+    local ref=$1
+    git ls-remote origin | sed -n "\,\t$ref, { s,\(.*\)\t\(.*\),\1,; p; q}"
+}
+
+# Returns a name based on the url and reference
+#
+# This function needs to be in sync with nix's fetchgit implementation
+# of urlToName() to re-use the same nix store paths.
+url_to_name(){
+    local url=$1
+    local ref=$2
+    local base
+    base=$(basename "$url" .git | cut -d: -f2)
+
+    if [[ $ref =~ ^[a-z0-9]+$ ]]; then
+        echo "$base-${ref:0:7}"
+    else
+        echo "$base"
+    fi
+}
+
+# Fetch everything and checkout the right sha1
+checkout_hash(){
+    local hash="$1"
+    local ref="$2"
+
+    if test -z "$hash"; then
+        hash=$(hash_from_ref "$ref")
+    fi
+
+    clean_git fetch ${builder:+--progress} --depth=1 origin "$hash" || \
+    clean_git fetch -t ${builder:+--progress} origin || return 1
+
+    local object_type=$(git cat-file -t "$hash")
+    if [[ "$object_type" == "commit" ]]; then
+        clean_git checkout -b "$branchName" "$hash" || return 1
+    elif [[ "$object_type" == "tree" ]]; then
+        clean_git config user.email "nix-prefetch-git@localhost"
+        clean_git config user.name "nix-prefetch-git"
+        local commit_id=$(git commit-tree "$hash" -m "Commit created from tree hash $hash")
+        clean_git checkout -b "$branchName" "$commit_id" || return 1
+    else
+        echo "Unrecognized git object type: $object_type"
+        return 1
+    fi
+}
+
+# Fetch only a branch/tag and checkout it.
+checkout_ref(){
+    local hash="$1"
+    local ref="$2"
+
+    if [[ -n "$deepClone" ]]; then
+        # The caller explicitly asked for a deep clone.  Deep clones
+        # allow "git describe" and similar tools to work.  See
+        # https://marc.info/?l=nix-dev&m=139641582514772
+        # for a discussion.
+        return 1
+    fi
+
+    if test -z "$ref"; then
+        ref=$(ref_from_hash "$hash")
+    fi
+
+    if test -n "$ref"; then
+        # --depth option is ignored on http repository.
+        clean_git fetch ${builder:+--progress} --depth 1 origin +"$ref" || return 1
+        clean_git checkout -b "$branchName" FETCH_HEAD || return 1
+    else
+        return 1
+    fi
+}
+
+# Update submodules
+init_submodules(){
+    # Add urls into .git/config file
+    clean_git submodule init
+
+    # list submodule directories and their hashes
+    git submodule status |
+    while read -r l; do
+        local hash
+        local dir
+        local name
+        local url
+
+        # checkout each submodule
+        hash=$(echo "$l" | awk '{print $1}' | tr -d '-')
+        dir=$(echo "$l" | sed -n 's/^.[0-9a-f]\+ \(.*[^)]*\)\( (.*)\)\?$/\1/p')
+        name=$(
+            git config -f .gitmodules --get-regexp submodule\..*\.path |
+            sed -n "s,^\(.*\)\.path $dir\$,\\1,p")
+        url=$(git config --get "${name}.url")
+
+        clone "$dir" "$url" "$hash" ""
+    done
+}
+
+clone(){
+    local top=$PWD
+    local dir="$1"
+    local url="$2"
+    local hash="$3"
+    local ref="$4"
+
+    cd "$dir"
+
+    # Initialize the repository.
+    init_remote "$url"
+
+    # Download data from the repository.
+    checkout_ref "$hash" "$ref" ||
+    checkout_hash "$hash" "$ref" || (
+        echo 1>&2 "Unable to checkout $hash$ref from $url."
+        exit 1
+    )
+
+    # Checkout linked sources.
+    if test -n "$fetchSubmodules"; then
+        init_submodules
+    fi
+
+    if [ -z "$builder" ] && [ -f .topdeps ]; then
+        if tg help &>/dev/null; then
+            echo "populating TopGit branches..."
+            tg remote --populate origin
+        else
+            echo "WARNING: would populate TopGit branches but TopGit is not available" >&2
+            echo "WARNING: install TopGit to fix the problem" >&2
+        fi
+    fi
+
+    cd "$top"
+}
+
+# Remove all remote branches, remove tags not reachable from HEAD, do a full
+# repack and then garbage collect unreferenced objects.
+make_deterministic_repo(){
+    local repo="$1"
+
+    # run in sub-shell to not touch current working directory
+    (
+    cd "$repo"
+    # Remove files that contain timestamps or otherwise have non-deterministic
+    # properties.
+    rm -rf .git/logs/ .git/hooks/ .git/index .git/FETCH_HEAD .git/ORIG_HEAD \
+        .git/refs/remotes/origin/HEAD .git/config
+
+    # Remove all remote branches.
+    git branch -r | while read -r branch; do
+        clean_git branch -rD "$branch"
+    done
+
+    # Remove tags not reachable from HEAD. If we're exactly on a tag, don't
+    # delete it.
+    maybe_tag=$(git tag --points-at HEAD)
+    git tag --contains HEAD | while read -r tag; do
+        if [ "$tag" != "$maybe_tag" ]; then
+            clean_git tag -d "$tag"
+        fi
+    done
+
+    # Do a full repack. Must run single-threaded, or else we lose determinism.
+    clean_git config pack.threads 1
+    clean_git repack -A -d -f
+    rm -f .git/config
+
+    # Garbage collect unreferenced objects.
+    # Note: --keep-largest-pack prevents non-deterministic ordering of packs
+    #   listed in .git/objects/info/packs by only using a single pack
+    clean_git gc --prune=all --keep-largest-pack
+    )
+}
+
+
+clone_user_rev() {
+    local dir="$1"
+    local url="$2"
+    local rev="${3:-HEAD}"
+
+    if [ -n "$fetchLFS" ]; then
+        HOME=$TMPDIR
+        git lfs install
+    fi
+
+    # Perform the checkout.
+    case "$rev" in
+        HEAD|refs/*)
+            clone "$dir" "$url" "" "$rev" 1>&2;;
+        *)
+            if test -z "$(echo "$rev" | tr -d 0123456789abcdef)"; then
+                clone "$dir" "$url" "$rev" "" 1>&2
+            else
+                # if revision is not hexadecimal it might be a tag
+                clone "$dir" "$url" "" "refs/tags/$rev" 1>&2
+            fi;;
+    esac
+
+    pushd "$dir" >/dev/null
+    fullRev=$( (git rev-parse "$rev" 2>/dev/null || git rev-parse "refs/heads/$branchName") | tail -n1)
+    humanReadableRev=$(git describe "$fullRev" 2> /dev/null || git describe --tags "$fullRev" 2> /dev/null || echo -- none --)
+    commitDate=$(git show -1 --no-patch --pretty=%ci "$fullRev")
+    commitDateStrict8601=$(git show -1 --no-patch --pretty=%cI "$fullRev")
+    popd >/dev/null
+
+    # Allow doing additional processing before .git removal
+    eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
+    if test -z "$leaveDotGit"; then
+        echo "removing \`.git'..." >&2
+        find "$dir" -name .git -print0 | xargs -0 rm -rf
+    else
+        find "$dir" -name .git | while read -r gitdir; do
+            make_deterministic_repo "$(readlink -f "$gitdir/..")"
+        done
+    fi
+}
+
+exit_handlers=()
+
+run_exit_handlers() {
+    exit_status=$?
+    for handler in "${exit_handlers[@]}"; do
+        eval "$handler $exit_status"
+    done
+}
+
+trap run_exit_handlers EXIT
+
+quiet_exit_handler() {
+    exec 2>&3 3>&-
+    if [ $1 -ne 0 ]; then
+        cat "$errfile" >&2
+    fi
+    rm -f "$errfile"
+}
+
+quiet_mode() {
+    errfile="$(mktemp "${TMPDIR:-/tmp}/git-checkout-err-XXXXXXXX")"
+    exit_handlers+=(quiet_exit_handler)
+    exec 3>&2 2>"$errfile"
+}
+
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}" # \
+    s="${s//\"/\\\"}" # "
+    s="${s//^H/\\\b}" # \b (backspace)
+    s="${s//^L/\\\f}" # \f (form feed)
+    s="${s//
+/\\\n}" # \n (newline)
+    s="${s//^M/\\\r}" # \r (carriage return)
+    s="${s//   /\\t}" # \t (tab)
+    echo "$s"
+}
+
+print_results() {
+    hash="$1"
+    if ! test -n "$QUIET"; then
+        echo "" >&2
+        echo "git revision is $fullRev" >&2
+        if test -n "$finalPath"; then
+            echo "path is $finalPath" >&2
+        fi
+        echo "git human-readable version is $humanReadableRev" >&2
+        echo "Commit date is $commitDate" >&2
+        if test -n "$hash"; then
+            echo "hash is $hash" >&2
+        fi
+    fi
+    if test -n "$hash"; then
+        cat <<EOF
+{
+  "url": "$(json_escape "$url")",
+  "rev": "$(json_escape "$fullRev")",
+  "date": "$(json_escape "$commitDateStrict8601")",
+  "path": "$(json_escape "$finalPath")",
+  "$(json_escape "$hashType")": "$(json_escape "$hash")",
+  "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
+  "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
+  "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false)
+}
+EOF
+    fi
+}
+
+remove_tmpPath() {
+    rm -rf "$tmpPath"
+}
+
+if test -n "$QUIET"; then
+    quiet_mode
+fi
+
+if test -z "$branchName"; then
+    branchName=fetchgit
+fi
+
+if test -n "$builder"; then
+    test -n "$out" -a -n "$url" -a -n "$rev" || usage
+    mkdir -p "$out"
+    clone_user_rev "$out" "$url" "$rev"
+else
+    if test -z "$hashType"; then
+        hashType=sha256
+    fi
+
+    # If the hash was given, a file with that hash may already be in the
+    # store.
+    if test -n "$expHash"; then
+        finalPath=$(nix-store --print-fixed-path --recursive "$hashType" "$expHash" "$(url_to_name "$url" "$rev")")
+        if ! nix-store --check-validity "$finalPath" 2> /dev/null; then
+            finalPath=
+        fi
+        hash=$expHash
+    fi
+
+    # If we don't know the hash or a path with that hash doesn't exist,
+    # download the file and add it to the store.
+    if test -z "$finalPath"; then
+
+        tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")"
+        exit_handlers+=(remove_tmpPath)
+
+        tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"
+        mkdir -p "$tmpFile"
+
+        # Perform the checkout.
+        clone_user_rev "$tmpFile" "$url" "$rev"
+
+        # Compute the hash.
+        hash=$(nix-hash --type $hashType --base32 "$tmpFile")
+
+        # Add the downloaded file to the Nix store.
+        finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpFile")
+
+        if test -n "$expHash" -a "$expHash" != "$hash"; then
+            echo "hash mismatch for URL \`$url'. Got \`$hash'; expected \`$expHash'." >&2
+            exit 1
+        fi
+    fi
+
+    print_results "$hash"
+
+    if test -n "$PRINT_PATH"; then
+        echo "$finalPath"
+    fi
+fi

--- a/pkgs/fetchgit/nix-prefetch-git
+++ b/pkgs/fetchgit/nix-prefetch-git
@@ -109,6 +109,12 @@ init_remote(){
     clean_git init --initial-branch=master
     clean_git remote add origin "$url"
     ( [ -n "$http_proxy" ] && clean_git config http.proxy "$http_proxy" ) || true
+
+    # Set up git mirrors
+    while read -d'|' -r git_mirror; do
+        IFS='=' read remote_url local_url <<< "$git_mirror"
+        clean_git config url."$local_url".insteadOf "$remote_url"
+    done <<< "$ROBOTNIX_GIT_MIRRORS"
 }
 
 # Return the reference of an hash if it exists on the remote repository.

--- a/pkgs/fetchgit/nix-prefetch-git.nix
+++ b/pkgs/fetchgit/nix-prefetch-git.nix
@@ -1,0 +1,19 @@
+{ lib, stdenv, makeWrapper, gnused, nix, coreutils, findutils, gawk, git }:
+
+# Originally from nixpkgs/pkgs/tools/package-management/nix-prefetch-scripts
+stdenv.mkDerivation {
+  name = "nix-prefetch-git";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -vD ${./nix-prefetch-git} $out/bin/nix-prefetch-git
+    wrapProgram $out/bin/nix-prefetch-git \
+      --prefix PATH : ${lib.makeBinPath [ coreutils findutils gawk git gnused nix ]} \
+      --set HOME /homeless-shelter
+  '';
+
+  preferLocalBuild = true;
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -28,6 +28,7 @@ self: super: {
   fetchgerritpatchset = super.callPackage ./fetchgerritpatchset {};
 
   fetchgit = super.callPackage ./fetchgit {};
+  nix-prefetch-git = super.callPackage ./fetchgit/nix-prefetch-git.nix {};
 
   ###
 

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -27,6 +27,7 @@ self: super: {
 
   fetchgerritpatchset = super.callPackage ./fetchgerritpatchset {};
 
+  fetchgit = super.callPackage ./fetchgit {};
 
   ###
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? (import ./pkgs {}) }:
+pkgs.mkShell {
+  name = "robotnix-scripts";
+  nativeBuildInputs = with pkgs; [
+    # For android updater scripts
+    python3
+    gitRepo nix-prefetch-git
+    curl go-pup jq
+
+    # For chromium updater script
+    python2 cipd git
+
+    cachix
+  ];
+}


### PR DESCRIPTION
Removed `--mirror` args from `mk-repo-file.py`.  Now both `pkgs.fetchgit` and `mk-repo-file.py` will use `ROBOTNIX_GIT_MIRRORS` as a single source of this metadata.



I considered another alternative, which was to add a `mirrors` option to the robotnix config, and have `fetchgit` get this metadata from the `mirrors` option.  However, this makes reuse of robotnix configurations across machines only possible if they have the same local mirrors set up.

Instead, here, `fetchgit` gets `ROBOTNIX_GIT_MIRRORS` through `impureEnvVars`.  Since `fetchgit` derivations are all fixed-output, it should not change any derivation hashes to add this functionality.

---

From docs:


Robotnix can be configured to use local git mirrors of Android source code. The AOSP documentation includes instructions to [create a local mirror of the Android source code](https://source.android.com/setup/build/downloading#using-a-local-mirror). Maintaining a local mirror can save bandwidth in the long-run when repeatedly updating a flavor over time which contains incremental updates.



This functionality is enabled by setting the `ROBOTNIX_GIT_MIRRORS` environment variable. The value of `ROBOTNIX_GIT_MIRRORS` contains a number of mappings, each separated by a `|` character. Each mapping is of the format `<remote_url>=<local_url>`.
For example:
```
ROBOTNIX_GIT_MIRRORS=https://android.googlesource.com=/mnt/cache/mirror|https://github.com/LineageOS=/mnt/cache/lineageos/LineageOS
```

Both the robotnix update scripts as well as robotnix's overridden `fetchgit` derivation use `ROBOTNIX_GIT_MIRRORS`.
This environment variable is passed to `fetchgit` via `impureEnvVars` (search for `impureEnvVars` in the [Nix manual](https://nixos.org/manual/nix/stable/)). If the Nix daemon is being used, it needs to have this `ROBOTNIX_GIT_MIRRORS` in its environment, not just in the user's environment when running `nix-build` or `nix build`. The following NixOS configuration can be used to easily set this environment variable for the Nix daemon:
```nix
let
  mirrors = {
    "https://android.googlesource.com" = "/mnt/cache/mirror";
    "https://github.com/LineageOS" = "/mnt/cache/lineageos/LineageOS";
  };
in
{
  systemd.services.nix-daemon.serviceConfig.Environment = [
    ("ROBOTNIX_GIT_MIRRORS=" + lib.concatStringsSep "|" (lib.mapAttrsToList (local: remote: "${local}=${remote}") mirrors))
  ];
  # Also add local mirrors to nix sandbox exceptions
  nix.sandboxPaths = lib.attrValues mirrors;
}
```