### PR TITLE
waydroid: initial implementation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ let
       ./flavors/grapheneos
       ./flavors/lineageos
       ./flavors/vanilla
+      ./flavors/waydroid
       ./modules/10
       ./modules/11
       ./modules/12

--- a/flavors/waydroid/anbox.xml
+++ b/flavors/waydroid/anbox.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <!-- Remove replaced Projects -->
+  <remove-project name="platform/system/libhidl" />
+  <remove-project name="LineageOS/android_system_libhwbinder" />
+  <remove-project name="platform/external/libdrm" />
+  <remove-project name="platform/external/mesa3d" />
+  <remove-project name="platform/hardware/intel/common/libva" />
+
+  <project path="system/libhidl" name="Anbox-halium/android_system_libhidl" />
+  <project path="system/libhwbinder" name="Anbox-halium/android_system_libhwbinder" />
+  <project path="external/libdrm" name="Anbox-halium/android_external_libdrm" />
+  <project path="external/mesa3d" name="Anbox-halium/android_external_mesa3d" />
+  <project path="hardware/intel/common/libva" name="Anbox-halium/android_hardware_intel_common_libva" />
+
+  <!-- Anbox Projects -->
+  <project path="anbox-patches" name="Anbox-halium/anbox-patches" />
+  <project path="device/halium/anbox" name="Anbox-halium/android_device_halium_anbox" />
+  <project path="hardware/anbox/interfaces" name="Anbox-halium/android_hardware_anbox_interfaces" />
+
+  <!-- Audio -->
+  <project path="external/alsa-lib" name="Anbox-halium/android_external_alsa-lib" />
+  <project path="external/alsa-plugins" name="Anbox-halium/android_external_alsa-plugins" />
+  <project path="external/libsndfile" name="Anbox-halium/android_external_libsndfile" />
+  <project path="external/pulseaudio" name="Anbox-halium/android_external_pulseaudio" />
+
+  <!-- Display -->
+  <project path="external/llvm90" name="Anbox-halium/android_external_llvm90" />
+  
+  <!-- Media -->
+  <project path="external/ffmpeg" name="Anbox-halium/android_external_ffmpeg" />
+  <project path="external/stagefright-plugins" name="Anbox-halium/android_external_stagefright-plugins" />
+
+</manifest>

--- a/flavors/waydroid/default.nix
+++ b/flavors/waydroid/default.nix
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2021 Daniel Fullmer
+# SPDX-License-Identifier: MIT
+
+{ config, pkgs, lib, ... }:
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkBefore
+  ;
+  repoDirs = lib.importJSON (./. + "/repo-lineage-17.1.json");
+  patchMetadata = lib.importJSON ./patch-metadata.json;
+in mkIf (config.flavor == "waydroid")
+{
+  buildDateTime = mkDefault 1629060864;
+
+  androidVersion = mkDefault 10;
+  productNamePrefix = "lineage_anbox_";
+  variant = mkDefault "userdebug";
+
+  source.dirs = mkMerge [
+    repoDirs
+    (lib.mapAttrs (relpath: patches: {
+      patches = (builtins.map (p: "${config.source.dirs."anbox-patches".src}/${relpath}/${p}") patches);
+    }) patchMetadata)
+  ];
+
+  envVars.RELEASE_TYPE = mkDefault "EXPERIMENTAL";  # Other options are RELEASE NIGHTLY SNAPSHOT EXPERIMENTAL
+
+  # Traceback (most recent call last):
+  #   File "external/mesa3d/src/panfrost/bifrost/bi_printer.c.py", line 203, in <module>
+  #     from mako.template import Template
+  # ModuleNotFoundError: No module named 'mako'
+  # TODO: mkBefore here is a hack
+  envPackages = with pkgs; mkBefore [
+    (python2.withPackages (p: with p; [ Mako ]))
+    (python3.withPackages (p: with p; [ Mako ]))
+  ];
+
+  build = {
+    waydroid = config.build.mkAndroid {
+      name = "robotnix-${config.productName}-${config.buildNumber}";
+      makeTargets = [ "systemimage" "vendorimage" ];
+      installPhase = ''
+        mkdir -p $out
+
+        cp -t $out \
+          $ANDROID_PRODUCT_OUT/android-info.txt      \
+          $ANDROID_PRODUCT_OUT/build_fingerprint.txt \
+          $ANDROID_PRODUCT_OUT/installed-files.txt
+
+        cp --reflink=auto -r $ANDROID_PRODUCT_OUT/system.img $out
+        cp --reflink=auto -r $ANDROID_PRODUCT_OUT/vendor.img $out
+      '';
+    };
+  };
+}

--- a/flavors/waydroid/extract-patch-metadata.py
+++ b/flavors/waydroid/extract-patch-metadata.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import json
+import os
+
+from robotnix_common import checkout_git, save
+
+
+def main() -> None:
+    data = json.load(open('repo-lineage-17.1.json'))
+    anbox_patches = data['anbox-patches']
+    git_info = checkout_git(anbox_patches['url'], anbox_patches['rev'])
+    topdir = git_info['path']
+
+    output = {}
+    for dirpath, dirs, files in os.walk(topdir):
+        if any(f.endswith('.patch') for f in files):
+            if dirpath.startswith(topdir):
+                dirpath = dirpath[len(topdir)+1:]
+            output[dirpath] = sorted(files)
+
+    save('patch-metadata.json', output)
+
+
+if __name__ == '__main__':
+    main()

--- a/flavors/waydroid/patch-metadata.json
+++ b/flavors/waydroid/patch-metadata.json
@@ -1,0 +1,98 @@
+{
+  "bionic": [
+    "0001-hybris-don-t-fail-because-of-fsetxattr.patch",
+    "0002-anbox-add-vendor_extra-lib-folders-to-default-librar.patch"
+  ],
+  "build/soong": [
+    "0001-anbox-do-not-fail-on-VNDK-ABI-mismatch.patch"
+  ],
+  "external/wayland-protocols": [
+    "0001-stable-Add-xdg-shell.patch"
+  ],
+  "frameworks/av": [
+    "0001-libcameraservice-Use-listByInterface.patch",
+    "0002-media-xmlparser-Add-host-dirs-to-search-path.patch",
+    "0003-mediacodec-Use-vendor_extra-seccomp-minijail.patch",
+    "0004-media-Add-host-media_profiles-search-paths.patch",
+    "0005-drm-Fix-drm-on-older-vendors.patch",
+    "0006-codec2-Fix-media-on-older-vendors.patch",
+    "0007-SW-encode-Fix-output-buffer-size.patch",
+    "0007-apex-Add-vendor_extra-to-ld-search-paths.patch",
+    "0008-Change-max-width-and-height-supported-by-H.263-decod.patch",
+    "0009-FLACExtractor-Add-more-sample-rates-support.patch",
+    "0010-Don-t-use-YV12-color-format-for-video-decoding.patch",
+    "0011-Allow-screenrecord-usage-on-Android-x86.patch",
+    "0012-media-enable-dithering-for-RGB565-conversion.patch",
+    "0013-nuplayer-skip-bad-SAR-values.patch",
+    "0014-stagefright-Add-support-for-loading-a-custom-OMXPlug.patch",
+    "0015-stagefright-allow-multiple-custom-OMXPlugins.patch",
+    "0016-libstagefright-Extended-media-support-via-FFMPEG.patch",
+    "0017-Add-paths-and-system-libraries-for-swcodec-APEX.patch",
+    "0018-Setup-FFMPEG-audio-mpeg-L2-codec-correctly.patch"
+  ],
+  "frameworks/base": [
+    "0001-anbox-disable-SELinux-parts.patch",
+    "0002-anbox-disable-suspend-control.patch",
+    "0003-temp-anbox-neutralize-sound-pool-audio-sample-loadi.patch",
+    "0004-anbox-core-jni-start-thread-pool-for-host-hwbinder-w.patch",
+    "0005-fwb-Don-t-check-vintf-compatibility.patch",
+    "0006-Prevent-the-system-from-entering-a-sleep-state.patch",
+    "0007-core-Add-support-for-MicroG.patch",
+    "0008-AndroidManifest-add-a-permission-group-for-signature.patch",
+    "0009-Zygote-Disable-seccomp.patch"
+  ],
+  "frameworks/native": [
+    "0001-anbox-installd-run-without-SELinux.patch",
+    "0002-halium-disable-SELinux-checks-in-ServiceManager.patch",
+    "0003-halium-never-set-FLAT_BINDER_FLAG_TXN_SECURITY_CTX-f.patch",
+    "0004-Hack-EventHub-until-it-works-with-our-fake-evdev-eve.patch",
+    "0005-surfaceflinger-Provide-layer-names-and-stuffs.patch",
+    "0006-EventHub-Add-wayland-inputs-support.patch",
+    "0007-inputflinger-add-absolute-event-support-for-cursor.patch",
+    "0008-RenderEngine-support-non-RGBA_8888-format.patch",
+    "0009-libEGL-select-pixel-format-by-EGL_NATIVE_VISUAL_ID.patch"
+  ],
+  "hardware/libhardware": [
+    "0001-anbox-add-vendor_extra-lib-hw-to-HAL-search-path.patch",
+    "0002-libhardware-Don-t-check-for-ro.hardware.patch"
+  ],
+  "packages/apps/PermissionController": [
+    "0001-Utils-add-FAKE_PACKAGE_SIGNATURE-to-platform-permiss.patch"
+  ],
+  "packages/apps/Settings": [
+    "0001-Settings-Disable-double_tap_sleep_gesture-by-default.patch"
+  ],
+  "system/core": [
+    "0001-anbox-init-start-inside-LXC-container-without-SELinu.patch",
+    "0002-anbox-init-modify-mount_all-to-skip-mounts-and-trigg.patch",
+    "0003-anbox-healthd-adjust-backup-service-name-to-avoid-co.patch",
+    "0004-temp-anbox-temporary-disable-adbd.patch",
+    "0005-anbox-add-vendor_extra-path-as-a-clone-of-vendor-ent.patch",
+    "0006-libsync-Add-sw_sync-symbols-to-map.patch",
+    "0007-sdcard-Bring-back-fuse.patch",
+    "0008-sdcard-Add-full-mount-directory.patch"
+  ],
+  "system/hardware/interfaces": [
+    "0001-suspend-Set-mUseSuspendCounter-to-true.patch"
+  ],
+  "system/hwservicemanager": [
+    "0001-halium-disable-SELinux-parts.patch"
+  ],
+  "system/netd": [
+    "0001-netd-Fix-networking.patch"
+  ],
+  "system/nfc": [
+    "0001-nfc-Add-host-search-paths.patch"
+  ],
+  "system/security": [
+    "0001-keystore-Supress-SELinux-errors.patch"
+  ],
+  "system/tools/hidl": [
+    "0001-anbox-Allow-host_hwbinder-to-be-used-for-HALs.patch"
+  ],
+  "system/vold": [
+    "0001-vold-Fix-fuse-sdcard.patch",
+    "0002-vold-Drop-selinux-checks-on-prepare_subdirs.patch",
+    "0003-Revert-Remove-waitpid-on-UnMount.patch"
+  ]
+}

--- a/flavors/waydroid/repo-lineage-17.1.json
+++ b/flavors/waydroid/repo-lineage-17.1.json
@@ -1,0 +1,8195 @@
+{
+  "anbox-patches": {
+    "groups": [],
+    "rev": "dcd6c820817c5d225b358e0e8f8c9124e990b1db",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0z9nacfvmyx9gvbjclrz6c58k8a0bn4mhih1bb9vm7afkvhbavmp",
+    "url": "https://github.com/Anbox-halium/anbox-patches"
+  },
+  "android": {
+    "groups": [],
+    "rev": "ae706e721efbd1faa490cd685ea8f0343c33b663",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0rradp6hjx7f3lyn1whv4pa873yk0j0dh8w8biq53c3zwmq3286v",
+    "tree": "eae9d9d6b6add682a64400216ad38d5c77a48a27",
+    "url": "https://github.com/LineageOS/android"
+  },
+  "art": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2311566b9f24023b84501b8429c40c69f6f6be23",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1np4bcg54zn1qz89bgjkbm1fy3nkcf73mvgvg6c71z5va84qrkq9",
+    "tree": "94a8ea70a1f3a2657dc8aa25f732dce565fb707f",
+    "url": "https://github.com/LineageOS/android_art"
+  },
+  "bionic": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40e6fdba0b80a99c240603eecfb5b1d7c2ee1ed2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1ysa49bvhiriwyi2ri0123vhmz4vazc6ndysfjbah7iqribgv3zk",
+    "tree": "2af24a679591111c4d167d568ce0f0d77f1f3477",
+    "url": "https://github.com/LineageOS/android_bionic"
+  },
+  "bootable/recovery": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ea1b260ce0eedbcd162a138b11127456d288e51e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0k31rqfvlja6hn843jqivba5j2i6v9hydwmdpg565j10gfac4lwn",
+    "tree": "d9b5ff159385cda46a65ca116cafe491ada57488",
+    "url": "https://github.com/LineageOS/android_bootable_recovery"
+  },
+  "build/blueprint": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "f80fffc9164a30b4ab1cc5a672b8c250ff2534ab",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "01i8a6dgy1naz4hpnrzx2vrgfh94z3rnmyffl6p2ic9hzi6j9wbh",
+    "tree": "629f14a05a0d881e39c1d60abbf566fafedd78ab",
+    "url": "https://github.com/LineageOS/android_build_blueprint"
+  },
+  "build/kati": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "62ed7c9d6c9431222547c4346065917120aec9b0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15jlrm8sg36pplnzsya3bq5506krznfaskhdirlswj5qfzwfykbm",
+    "tree": "693c3a9b063ea42a57fb27995f58ff91faff9369",
+    "url": "https://android.googlesource.com/platform/build/kati"
+  },
+  "build/make": {
+    "copyfiles": [
+      {
+        "dest": "Makefile",
+        "src": "core/root.mk"
+      }
+    ],
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "build/CleanSpec.mk",
+        "src": "CleanSpec.mk"
+      },
+      {
+        "dest": "build/buildspec.mk.default",
+        "src": "buildspec.mk.default"
+      },
+      {
+        "dest": "build/core",
+        "src": "core"
+      },
+      {
+        "dest": "build/envsetup.sh",
+        "src": "envsetup.sh"
+      },
+      {
+        "dest": "build/target",
+        "src": "target"
+      },
+      {
+        "dest": "build/tools",
+        "src": "tools"
+      }
+    ],
+    "rev": "70033db465a854403984320fc829d76140a94192",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0prsnlic8sg84ccqpi0frippbvhnbzwv70nk000nff1yhl326qzw",
+    "tree": "df502655bef73746f1a1baf5d1c159cdac59fd10",
+    "url": "https://github.com/LineageOS/android_build"
+  },
+  "build/soong": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "linkfiles": [
+      {
+        "dest": "Android.bp",
+        "src": "root.bp"
+      },
+      {
+        "dest": "bootstrap.bash",
+        "src": "bootstrap.bash"
+      }
+    ],
+    "rev": "533913d8dc8f76bdbf036c5d955b43cc080024d4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "111r8za156qva41z6v4hqi86klzgqvl17zrav6gvdnw9l19ql2d7",
+    "tree": "882498bbdf2320508a96d1c7e07829ecd6b34128",
+    "url": "https://github.com/LineageOS/android_build_soong"
+  },
+  "cts": {
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8dd03e06253f7a00f7c5e75da4e277e7da0c0789",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0wbsk2lx53gywbpycsn835a8s2pxsbnmmzms38c1bjvsix5nxz76",
+    "tree": "754ea6747d45cdabdd0627e11c2ed578ebf4e976",
+    "url": "https://android.googlesource.com/platform/cts"
+  },
+  "dalvik": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0c3c0faca679a810ed517208555d8fd93f7db0e5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1x9wcmp5d0cdzb6f51ghpkmrxrcwhi3an4cpv5q01x78ygyk5gsz",
+    "tree": "73ea7b17d529b31d2818cbdafdd46d9c83d9280b",
+    "url": "https://android.googlesource.com/platform/dalvik"
+  },
+  "developers/build": {
+    "groups": [
+      "developers",
+      "pdk"
+    ],
+    "rev": "e1efd9102e8958a238cae59506cfab4aed17c83e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1bp6sdr1dpjdbg44d8micvq8z99l2vk15fbfk4biq8ywq3xv0184",
+    "tree": "cc73d63fef7a4d4b4116f1537d28855f6d7dc9de",
+    "url": "https://android.googlesource.com/platform/developers/build"
+  },
+  "development": {
+    "groups": [
+      "developers",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "381803470ee7248d9c59f6774a52dea0e2cb6ef2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0gxs5jnwnkmkibbhzbnhijfx4id5bm2ra8kn0bcpv7yy7922iybl",
+    "tree": "c08fbd11bb1f358db14d77333e83d6d3a7adc979",
+    "url": "https://github.com/LineageOS/android_development"
+  },
+  "device/common": {
+    "groups": [
+      "pdk",
+      "pdk-cw-fs"
+    ],
+    "rev": "37452aa657af9558fe24af41ced4612f1a3e1f3f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0snbbp7hacsqnl7vfcq1bavh8ayzhhzl27ga0rvbi18ky1sdmkkv",
+    "tree": "0e90574064878f9b89fc9f9c01de3b033c55c153",
+    "url": "https://android.googlesource.com/device/common"
+  },
+  "device/generic/arm64": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ec1220ece369b0029523da7d16794011a9cd626",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "024vs52hn04kbvmishdj9wcqgjjnl2zzmr6c62v6lk2za79r8bjx",
+    "tree": "82723d02f6826fa1dc435345b555be5d6850cca8",
+    "url": "https://android.googlesource.com/device/generic/arm64"
+  },
+  "device/generic/armv7-a-neon": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b474d561a8c51b5c9adb6cdbc5e85a9af6a5b98d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sq6hcaw6vq6pwkwhc12n6hah94vb5l910ngnhmvsrd41rrkmqdf",
+    "tree": "fbfba66e46e8eb41ed5f18eee646b5cd72dd4583",
+    "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
+  },
+  "device/generic/car": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07b0cbe19d327985e339e94aa60a296aef4798f1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gdglky1pq1n35c70968i59a2am0s5h6m28w4w4cv7ms6izxcrnq",
+    "tree": "9c1569d22ae4cb593c37744f4929c464ce329085",
+    "url": "https://android.googlesource.com/device/generic/car"
+  },
+  "device/generic/common": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6194a1b107ce7a705c6201c6e717c336d7440177",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "131wqkm6dj0jsja80967ykxgqqp3p1vzsnfz7y6rxliyb98j8396",
+    "tree": "08b21f535c3ab0791a9d6468af56866bebfaef40",
+    "url": "https://android.googlesource.com/device/generic/common"
+  },
+  "device/generic/goldfish": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9cf803e7e4f0ce139de4a3e01998cf180d150409",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mmrinsi0xwr5lyvjyyn39flfm3nfqqsffssv0w2r8wfdv0mmaz2",
+    "tree": "0e5802759d06227b613a1c953e06af3e121a6d9b",
+    "url": "https://github.com/LineageOS/android_device_generic_goldfish"
+  },
+  "device/generic/goldfish-opengl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6594f39e99bf3ebdced7eeecf8a63daaf2b44634",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1hrx9ggccqsr5y2ffdz1wfxgzwnk7fdpjdkv1a1valbhs7x96a7r",
+    "tree": "fbfd7951e485863f26ca729d850ee6d4eced946c",
+    "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
+  },
+  "device/generic/mini-emulator-arm64": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a8f7c34b99dba447edcd92b430ac7845adf48e6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0kd3kcg70nl6y8zsd6zc93qd85drhiy26gnxr994v5cnzmwfj4kb",
+    "tree": "12b4ba4b5c1c62465cd8983e0f0e95f89e9c5b5f",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
+  },
+  "device/generic/mini-emulator-armv7-a-neon": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e1d0c2e8799cddafaf29515bb62f7ee6a429dd0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0afhwz3lcjpm0c316nklpijvc35692z29v338wy96q20xiq1x2rm",
+    "tree": "0a055f0ef5e7459ca7db3df6b861cae7f15d6a99",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
+  },
+  "device/generic/mini-emulator-x86": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0643360830b6487c1dceeb733c4629f1fa35d2b1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1091am2rk5kyfsjbh39mblrj6n8q8lfwaq5wsd996q0bgj63hp93",
+    "tree": "fe500695e7001a040b25592e8499e616f00ecd3a",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
+  },
+  "device/generic/mini-emulator-x86_64": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "afa139a4b85b12ad85f0cf6245bec2b0055e826c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1a1ldxrm06smsf2nnj7gmfg2myzajfd10al0sv3h1a6zkr9rm0rs",
+    "tree": "8c93387cf728f31a36b4a1ff192dd819c0028087",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
+  },
+  "device/generic/qemu": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa51244703a584b1232a1e292442fb661ff45f44",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1pc33kaygcvzrjk1vdxzh7d7j58kdn0pjysfx140apkx8idb60ac",
+    "tree": "a333b7f3d40801f002366936a96fdfb572ceda7e",
+    "url": "https://android.googlesource.com/device/generic/qemu"
+  },
+  "device/generic/trusty": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a68d3ccce3da03ce567e4f0cc2b66e7cc49fb92b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "198f68s3hv81k53qlm1jdawamvpcsghzpy1d917gvcsjiad19g75",
+    "tree": "7033a171a3517fe4bb0790591c7fe977aaa0092f",
+    "url": "https://android.googlesource.com/device/generic/trusty"
+  },
+  "device/generic/uml": {
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "d1690d9c818ae622c6d9f7ea8007d7ef3d7709c2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lcqkcwvad6qbf6fzpqwaac4zzw7qkwqr1wrs7qi6b3khg5l4hik",
+    "tree": "b8547a5b8774c80f5efb1994f9236dfb05f7d12d",
+    "url": "https://android.googlesource.com/device/generic/uml"
+  },
+  "device/generic/x86": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f9df564c943338d0c0421bf6260238eab313aeda",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1d39khi8kby6glbjnckbcx2wdgk6zqnmgspivpm54chjzqf1gif9",
+    "tree": "a8561f3006f133c128034ee9ac5f4b22cece09fe",
+    "url": "https://android.googlesource.com/device/generic/x86"
+  },
+  "device/generic/x86_64": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d227f7ed85336960cad1087d9c6726e7e265b74",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "00y4ii6ylrqa8zjg1ijm4sw5dnsbdpsv7vwc0hnfgbphv7awp9w4",
+    "tree": "d5c8093d957654362f2bd99d82c50390c2874d0b",
+    "url": "https://android.googlesource.com/device/generic/x86_64"
+  },
+  "device/google/atv": {
+    "groups": [
+      "broadcom_pdk",
+      "device",
+      "generic_fs",
+      "pdk"
+    ],
+    "rev": "5706c573d0fae17694feb91a8e90a7d0cd1d53b2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0715qqz6qsj8dcrgijrafpin919a0bpzd337dr9nqxs0crcjd87n",
+    "tree": "02f36bff35e9babe8f11f05484529ce49abf1231",
+    "url": "https://github.com/LineageOS/android_device_google_atv"
+  },
+  "device/google/contexthub": {
+    "groups": [
+      "device",
+      "marlin",
+      "pdk"
+    ],
+    "rev": "3302ae232bda774bf70bda1ef5fd4b5ae9e465f2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1p7jgvkik15m6jj05n2l5lgi5b50clx3jvyh2l3n9ha3r65m476k",
+    "tree": "8199552775c079da756a4adb245428fd59ddccf3",
+    "url": "https://android.googlesource.com/device/google/contexthub"
+  },
+  "device/halium/anbox": {
+    "groups": [],
+    "rev": "fb36347edde278dd640b855b669877188540d176",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0avick4gx62m5ncrdf4n4ay4rp3cpix55s2qarfwp6kb2m437pzb",
+    "url": "https://github.com/Anbox-halium/android_device_halium_anbox"
+  },
+  "device/lineage/atv": {
+    "groups": [],
+    "rev": "076ade157fca7dbb1b1c7f13dd360be1da25fd10",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1i0zrf6khrljwa5mj0cjl0lagkbi4d0jj0jp5z06i72z8nakvpz5",
+    "tree": "12efaeab9870203cf01e689c5751689e42242a69",
+    "url": "https://github.com/LineageOS/android_device_lineage_atv"
+  },
+  "device/lineage/sepolicy": {
+    "groups": [],
+    "rev": "72049da6bc559ad5e57a2824b975fba5102258a0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "06cx7kiglc50ddglsfaw1lrf66qgl1442871rvq5cpkdali1d7nv",
+    "tree": "8560e5d62be61580413eaf31eba93fdf989d9ec7",
+    "url": "https://github.com/LineageOS/android_device_lineage_sepolicy"
+  },
+  "device/qcom/sepolicy": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "ea29bfda6ae3296997710dedc1fa7c5935f93ad1",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1wn7hspss5x6vhpbflqgjxmq39dvg2snhgrbgz3iq62llhwnz19y",
+    "tree": "51f92662b97cf9884a5578b9aa1eea231da62255",
+    "url": "https://github.com/LineageOS/android_device_qcom_sepolicy"
+  },
+  "device/qcom/sepolicy-legacy": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "22b912cbdddc152f56368d75f508e95bc0967ea6",
+    "revisionExpr": "lineage-17.1-legacy",
+    "sha256": "1ldqa0fg7wiiqzdxdq377bkp1w80rwyrr0kl8y3sdk7zjpwgy0k1",
+    "tree": "d5d0742b387219b71b452e6be0c737da65697a8a",
+    "url": "https://github.com/LineageOS/android_device_qcom_sepolicy"
+  },
+  "device/qcom/sepolicy-legacy-um": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "f8f8387170f4d153e0c25a76add08718da9eed5e",
+    "revisionExpr": "lineage-17.1-legacy-um",
+    "sha256": "1wq1rhh1w02q84wlw2w280chc2v4i1nh73lzv5amjd3yrik9wms6",
+    "tree": "ede2dce58e20e5d5030ea0699c387aea15a9b97b",
+    "url": "https://github.com/LineageOS/android_device_qcom_sepolicy"
+  },
+  "device/sample": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c954af71bb61a6b557152ad61ee65aaad6fbceb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1l27kbfvx579lnvx24w6vgxlcvhcb2b4zyfxncszfym2rmn6vcrx",
+    "tree": "869d9fa7834c1cbac61ffb9eeea87e0eadf1a3dd",
+    "url": "https://android.googlesource.com/device/sample"
+  },
+  "external/ARMComputeLibrary": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f13d6a569a9979bc89d62bcf10b217867bc4a22",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/external/ARMComputeLibrary"
+  },
+  "external/ImageMagick": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb8bce9200a20f2affdbfa0ae4a9c8be841a425f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1h5ldasdf2nqkxc01ixnrmy0k22ibkrjh0xgll8rvca488wc1wr5",
+    "tree": "3c6d19241b551a067e22a6ace8198e01260346af",
+    "url": "https://android.googlesource.com/platform/external/ImageMagick"
+  },
+  "external/Microsoft-GSL": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72ebc70ffdc4d5b576da123099c962ceeac3ffab",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "18g3534h4yxlbv3sdpvih98rg319bmxp4p4ykb98c78vrshy3i4p",
+    "tree": "051e6a6105b6a9e535a4373f30b8e3736310b78e",
+    "url": "https://android.googlesource.com/platform/external/Microsoft-GSL"
+  },
+  "external/Reactive-Extensions/RxCpp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab08608522f95b963b88ee04b3740c044513a8e2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xz6j5j727gddi96q4cb7bl3q4hd4wjwgybwdnyln4aa89jk3cg3",
+    "tree": "391d723483a8ca67aaea9245bf8ce98cbe52c216",
+    "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
+  },
+  "external/aac": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8125b4ef989a47c47f4f5e6a9eefeea60a94209e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0x1rf5rm20brvky9r6yrkdprp17sganig0ykqnhw064cv9z78hzx",
+    "tree": "55a5550d56ced9d0e1f8c06b061077acd26df3e6",
+    "url": "https://github.com/LineageOS/android_external_aac"
+  },
+  "external/adeb": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49cd8bda6c779e9cc44331a649785bc36ce06b9c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0b1kp37jhn46dx3k6r7lispn95d3fx6arri62sc3fnbqdjxzk44s",
+    "tree": "e9843502819664c90843af07173b5890d5a696f6",
+    "url": "https://android.googlesource.com/platform/external/adeb"
+  },
+  "external/adhd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3733e6cb007667f8c460c78d6384ca4b75b8dde9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sgdkqzygclyl23y548lyjp25wdkcgl07a92fk9vh4n54256bnw3",
+    "tree": "2c210c704845790156ebcb561905728f7278fd79",
+    "url": "https://android.googlesource.com/platform/external/adhd"
+  },
+  "external/alsa-lib": {
+    "groups": [],
+    "rev": "41c32784554eb1f99a8f88f62b570a4592c99a42",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0k8dmkk74dfmx1ywl95kddmvmvpqs3k572c16yhqrydj6kl7mnjd",
+    "url": "https://github.com/Anbox-halium/android_external_alsa-lib"
+  },
+  "external/alsa-plugins": {
+    "groups": [],
+    "rev": "1eee0509088f9521d59f0e777b480d5c1adbda5e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1sg56y1lpb5wg1npsgfr2bicwbi0fbkdgqfrl0x8pvllzx9zn2v8",
+    "url": "https://github.com/Anbox-halium/android_external_alsa-plugins"
+  },
+  "external/android-clat": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1aa6051c5698e17b7319f07c6bf31b8a5f5b92f6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1djf7hvgb9rcmc89hvin8j56yhfq5cy4mkm9x26f9hij1ijjf76h",
+    "tree": "ac9a90d6280e22785aaca68db210bf5612ea1b13",
+    "url": "https://android.googlesource.com/platform/external/android-clat"
+  },
+  "external/androidplot": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d710b6ea2a50c07419684f81310b55235d1ab141",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1lxzwrjjbx3dvkrihwasjm2rvgwnskf6q20152s5zhx2fhwxy2av",
+    "tree": "0ecb1830f21e80c88b2a76b9abb56fd32f7a71a3",
+    "url": "https://android.googlesource.com/platform/external/androidplot"
+  },
+  "external/ant-glob": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e55601e3a32634ea1df8645b9cc3ebb86beb7777",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "100g1b6dph78l3bg9rxxw5ljqnlrb920c5d29djnys8f0g9hl915",
+    "tree": "46857f89317634383570b2977f717690e16f4783",
+    "url": "https://android.googlesource.com/platform/external/ant-glob"
+  },
+  "external/ant-wireless/ant_native": {
+    "groups": [],
+    "rev": "df797ba024a4b7e25c1dfe28024bb6d0f05afdf8",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "15b74p8i2a8lh96014p06g06lbxbr020sla16kw1mgmnlkdrbf8s",
+    "tree": "a11d484299a284262109b0750f05fed1c5b5f2a6",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_ant_native"
+  },
+  "external/ant-wireless/ant_service": {
+    "groups": [],
+    "rev": "865b1857eaebe7961c64fac260f385211c9aa759",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "12wdzr5wfhb4g743pf9jvhc9qm40p3xb6wdj3h33w219g27cdgyg",
+    "tree": "169d3032b51f9531b0078db66e39729fb359e889",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_ant_service"
+  },
+  "external/ant-wireless/antradio-library": {
+    "groups": [],
+    "rev": "85290ef0527d2f4cf82fdc3ffc290c970ca57f6b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "041pk07nwj23nxf95q2pmfxga2pk3qf3gvwwksmn6dhdymscr0gp",
+    "tree": "c3cdfdc04994f7032f405e86fc85f154242c82b4",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_antradio-library"
+  },
+  "external/antlr": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "525b9189ec8de8413f42fc85b99600a96c08ebd8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1z5dmd0w279qwn208l0fi3ya2b6h4309zz5ab9s00mml018fwqgk",
+    "tree": "06cdf6908729e464b2b6ae46df7a8408ab217a76",
+    "url": "https://android.googlesource.com/platform/external/antlr"
+  },
+  "external/apache-commons-bcel": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8c920e0126ed4976526b5f2ae08df213658a7aca",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1dvlzrk5vkczq9kjy2099242icc6drbb77n0pni4s661i3c9p6bg",
+    "tree": "06828ccfd7bfb44c3cf9ba61d0682ef0ee4f198d",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
+  },
+  "external/apache-commons-compress": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1de9662828970aed209ae60e87cca7216fc4649",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "06r6gpz375scmsv1ykgjc4msfz68xganj2r29iqic522rz96v4dr",
+    "tree": "541d59c69b6a418b40eb3e027603566cb8e6ad84",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
+  },
+  "external/apache-commons-math": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb2031a78dd72029b620667f7ae50b6686478c70",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1mgjjs15gpvnisqqkf1cnjvmqsr9bxf746wdi24c63hzpab133qx",
+    "tree": "1fad69e9ccfdc7153e19f9e46638b31010a65e4e",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-math"
+  },
+  "external/apache-harmony": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11ea0e95658cee3b26e8997ce4ede1d5a7336789",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0p18rdy0drdskqmq0jc4l24vv18sjgjw3854yvp9fqyj8sjblaxr",
+    "tree": "720d2b2d76a78fe0ba19b8a48e19a488d616ec7f",
+    "url": "https://android.googlesource.com/platform/external/apache-harmony"
+  },
+  "external/apache-http": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0626b3d9245fa9c5fbf8415ea49f4da3aa7c507c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0bksipggy6h4zrrh58v7s4xnynzfiixqg61b68vm0lk8m274j33g",
+    "tree": "28901a4b6ff7ca432ac72dacbdffcf43697cc0eb",
+    "url": "https://android.googlesource.com/platform/external/apache-http"
+  },
+  "external/apache-xml": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5eb7c5152f006a211d585a56f54dc622728a6819",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i7f4pkl62i5dzs9jmkhp2l3wr6aagyi8sa248cnb5zn6q9m8yh9",
+    "tree": "a8cf575ac548993813cfb461c13a14576b7e6f91",
+    "url": "https://android.googlesource.com/platform/external/apache-xml"
+  },
+  "external/archive-patcher": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "60c27dd0543658184600030a58d61b8b91bb29e2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0b6kx346mqx4b1z0dgvpb1kagwqacmdcfwzy1yp9scyq8rlfr8by",
+    "tree": "eb4c5bc71fbe473034679b635399c753d30351e0",
+    "url": "https://android.googlesource.com/platform/external/archive-patcher"
+  },
+  "external/arm-neon-tests": {
+    "groups": [
+      "vendor"
+    ],
+    "rev": "778c63a5bd64740812cd4ae5eeb30c46b8a32e27",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qgsmwgszgircsp53va7p3v7jsdzv8pkld3fjk039b484w8ivlpr",
+    "tree": "fe8fa9bf6d35d54df55549c64f033adf95457a13",
+    "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
+  },
+  "external/arm-optimized-routines": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5de9b44c07256a3edfed78642d9a6995947f434c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "11b7yv6q9h3rbl2qkdhr5n99yzqnhdnl4lpqzn55f15ry29f3jhr",
+    "tree": "214a76a76c5aa792f775d4084f66c8c96070ca28",
+    "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
+  },
+  "external/autotest": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "87e6a0c0e5e710ed37de18650e58bde729dc5df2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1yra3n67q3ckvy890fjgzqh6705zfad57rsnwsxhxgk5jasn9w6j",
+    "tree": "c93704f071449f8d14db9a2c768b4ad951ef721d",
+    "url": "https://android.googlesource.com/platform/external/autotest"
+  },
+  "external/avb": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e252dc5e24ef6183286eb5f493b0cb75089b8f9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0q5k2rniby4xq7b0ar58vxv7ma9wxlclfzcq4aqgl90ajxvxhmfy",
+    "tree": "4e0288dcd8457d6cfbee7e3f66a6fb5608245a13",
+    "url": "https://android.googlesource.com/platform/external/avb"
+  },
+  "external/bash": {
+    "groups": [],
+    "rev": "5f857b9e5a9accf0fc9c35be4cb024766d556275",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1qzqzcbf54rdlwy8gsjmx1hcmg4w13z55sxg33kq8s9q0b2jdlrw",
+    "tree": "8f612faa6a77c4469035f764daebca314afe22c0",
+    "url": "https://github.com/LineageOS/android_external_bash"
+  },
+  "external/bcc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b170b5a5d543f9d3d2c8db929e78b2c53fc477b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1adigrzz1z36ixswmcpkz3jnm2kpvdh3s8wz4qb5g2s9py9anynr",
+    "tree": "bce42a46d75de5e3ccd1d7470af79810bc2cd19d",
+    "url": "https://android.googlesource.com/platform/external/bcc"
+  },
+  "external/blktrace": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25ff76436d8ef9c5fa59b5bbee026896dcf94c1a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "11ryj45x5ldb5hxxpsnnyr756y68dky56i149zgbxab6ylkwwarq",
+    "tree": "28ce16b16a7e52db33e3f6e094e396893e0d2001",
+    "url": "https://android.googlesource.com/platform/external/blktrace"
+  },
+  "external/boringssl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ced82376d88c22d5b8ec51655233f1fc3339b3a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f9q468cnh07mph5rjxsbjjxl0pzs2yxiyyv4yjsalxc1gclgl4l",
+    "tree": "626e5760d024ba621183d506e78f0dcda4792302",
+    "url": "https://android.googlesource.com/platform/external/boringssl"
+  },
+  "external/bouncycastle": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa1a1fb7cc3f69d46d1e97243724d2127a0d7829",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1mimnmgrk4dh1q3vay58jfzzcgm7pkkjlxradqb6rivxk7ylwvih",
+    "tree": "16b30287d1aae0c26e4e761a023136f1ee8fb2ff",
+    "url": "https://android.googlesource.com/platform/external/bouncycastle"
+  },
+  "external/brotli": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02ada852240faf9539247a1593086fae7a0caec3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "16a312m08xq2r2glhya41fpy4dlnqzg35nwnfc695hbd4lg6yxmm",
+    "tree": "44fc6e1be0564e3c0df7ea681d9c9420fc5af884",
+    "url": "https://android.googlesource.com/platform/external/brotli"
+  },
+  "external/bsdiff": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "016de2949edb62da76be32ed77832aa2d8bb5251",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "02g3xnxz6b97slyqdclysxm9njd7926sn0kswrmvgzw7nyxj7phv",
+    "tree": "cd50340b6a02196b25774f17505ce70d4ad76268",
+    "url": "https://android.googlesource.com/platform/external/bsdiff"
+  },
+  "external/bzip2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51a40820893b46a5967e762859e83b8d4e1ea31a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03l05045a7irpjdg00whxpja5zfng4iljjm5jhgp7v5syv0y5qjc",
+    "tree": "752e8abb4031b24d3656e3fec6469439d6c17671",
+    "url": "https://android.googlesource.com/platform/external/bzip2"
+  },
+  "external/caliper": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc7180b6b597b0738d9393d95b9376615a2d9334",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hifwzwi154iir3pg7z4v1qbhjbj9p9879gq8rd86cblxrpfb811",
+    "tree": "100525f5e98bcc45d26d28045641d76ab7a6337b",
+    "url": "https://android.googlesource.com/platform/external/caliper"
+  },
+  "external/capstone": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "368e5cd5bd6cdb84c3be5877c1c9f842add83c1b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vh9y4x4jrcdk5ixmx561aqh7yfani47w02m3v8167zia8kv795n",
+    "tree": "97103a0172b781a0a442423b2a59e75729e3364b",
+    "url": "https://android.googlesource.com/platform/external/capstone"
+  },
+  "external/catch2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d00812e8eeae225864596cf9d84f24266490a5eb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zrizv81084ixa12370s8mpzqz75xrcxz35jl774qjs88jvbbcc9",
+    "tree": "c5816e4c2a2225e1967bc5d5ab22b3f49397f3b1",
+    "url": "https://android.googlesource.com/platform/external/catch2"
+  },
+  "external/cblas": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8f7d0438f0c955654eb9d47bacb6ffb42d271a2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1ih079ajmn0g9745f946sz2aq8d67yila823d9c4waa9xxfbrssl",
+    "tree": "e00defbcc0a9ae59001ad71df5a67470eaee0124",
+    "url": "https://android.googlesource.com/platform/external/cblas"
+  },
+  "external/chromium-libpac": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c98fc96035e6fdc5b84d953d2bd38d2dcd175467",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0agmkp0w04w20l773zbnm3v7inn55dn1dsaa8a7rl4a459s724dl",
+    "tree": "c6a6a792ad634d3f48f6dbdcef04f2410bb781ef",
+    "url": "https://github.com/LineageOS/android_external_chromium-libpac"
+  },
+  "external/chromium-trace": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "47a8f80e6f6b79e81cca199329d290051700f1a3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0iq4vbi5wy6d948d6v14083fwp7pw1adzkxbp7q414bbj69iyvmp",
+    "tree": "4b32ed3904208724a5b1ec4a5481861c67677c99",
+    "url": "https://android.googlesource.com/platform/external/chromium-trace"
+  },
+  "external/chromium-webview": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16176f61e737732b6ac92542358bede08a18bdb6",
+    "revisionExpr": "master",
+    "sha256": "17fx0x6f5x5sjv5pnyw64gdhda514fswj0rb14g5is6r3ihkvpw6",
+    "tree": "a274724b1a843491fb6a365f2ec61553843d5326",
+    "url": "https://github.com/LineageOS/android_external_chromium-webview"
+  },
+  "external/clang": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "32587ea69b98d99b220bea6beb9d57e6b027cab5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "18k7xi3r3x56k2xk1rm0i6hq7diy2660d76w9j485jv5bf769pfi",
+    "tree": "cf9a61f962f9b7f94d2deabc4fa696a0b40d2d65",
+    "url": "https://android.googlesource.com/platform/external/clang"
+  },
+  "external/cldr": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb4aac2099d269b59e934a053cfd8e425d5bc00a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1qc90qp0dgh704v7fzh6zfc1zyvdj10drwfp0q4bws24q51wqb62",
+    "tree": "ce061be1b4d48097ee45a3ccbdd596c66fa29959",
+    "url": "https://github.com/LineageOS/android_external_cldr"
+  },
+  "external/cmockery": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c3174ee109142d0c59aff07b15358fb95c96df1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "08van7f0mpxr36mc17j67srrnxy3cq8y1dfzjk2sd0kcm3fafb03",
+    "tree": "b3ebea8ad312e50e513f60c984cc818140611a7f",
+    "url": "https://android.googlesource.com/platform/external/cmockery"
+  },
+  "external/cn-cbor": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f58d8ee44ef92fc64ed3763b51e17b75560a897",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "16xvy66s66xn8991sfcxaxhgd1sx46gq6hpdj6hfxbanjv4xb4xr",
+    "tree": "d018a6acd32a9e3700bbe9d4d6b7b5cca533cf51",
+    "url": "https://android.googlesource.com/platform/external/cn-cbor"
+  },
+  "external/compiler-rt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "edb3a32461b2080cef7fefd15b3a37051d8e2457",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vf9cg5h4i57ncb8c12w7a9gfasr6sam3nz410mmhzq31as3mzm2",
+    "tree": "3709c9aa7f5ca32616cc0797fdddb3057ddc20d3",
+    "url": "https://android.googlesource.com/platform/external/compiler-rt"
+  },
+  "external/connectivity": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "0bcb1672a85eaa9e0e198a1aa7b5f6fe37884a7a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1d5z94mxhbn13v2pbjqmn19k1fsxcqfi642my8ka2fpcxry6dggs",
+    "tree": "c44645dfaa1be35bcbdbe5d155d6c3a3aac7c3a6",
+    "url": "https://github.com/LineageOS/android_external_connectivity"
+  },
+  "external/conscrypt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b9fe2df5202f96c79870d06de87f11864bf356f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03sgnp3d1bblflkdbbvzl5jyagcim4y9i6g3mpi0bqwwcm104lny",
+    "tree": "294c4f9d74f7d0428d577199a209e95c1a3f6973",
+    "url": "https://android.googlesource.com/platform/external/conscrypt"
+  },
+  "external/crcalc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a200050a42a7d603d7b79ba8886c3c5b258bb08f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1fhdi5k8yfbk0a5z0alpfldz64hvfj3v6722lyhbmz1gx8rvqr2p",
+    "tree": "9159ef66bd6dd746709e3627a186e1c6cfec61d8",
+    "url": "https://android.googlesource.com/platform/external/crcalc"
+  },
+  "external/cros/system_api": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1adb24eb559ec37d4102bc1b16c3045bfe2a6d99",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1d5akjrgk5g6piw26z89qsqfbcgqghxy6rs8cmxizf0xjx7h3bln",
+    "tree": "2d3b95b2f1495933a8a7b4996dda6ff2f370c3e5",
+    "url": "https://android.googlesource.com/platform/external/cros/system_api"
+  },
+  "external/curl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8dc38bd2f5338dd412f1ae6b6fd5e9f821522743",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0mkjkpl028db60sv6w3bi229fpvmmjzzjrbb7sm4a50zdw7n87pr",
+    "tree": "ebe8c7124d97c89aa99d0b3ef30fde8f4938789f",
+    "url": "https://android.googlesource.com/platform/external/curl"
+  },
+  "external/dagger2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2aebbb796a00d2d8a08da408f634f7203f00f83",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qzqkdnir71jqrwpjzfm979p06b1g428lgjjp9mz21kcaq56h4fq",
+    "tree": "e2e1198c13347ce623d5d2e61905f61582b59b85",
+    "url": "https://android.googlesource.com/platform/external/dagger2"
+  },
+  "external/deqp": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "60c53f08585c185ac7444d136a12c3896a46ad71",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13bbd6m5m0hzn9v9xc7pcy7ii987c0zbj2sr5linwcqab795p51v",
+    "tree": "b01e51392f21d9c80460ae391b299d50ecf88f51",
+    "url": "https://android.googlesource.com/platform/external/deqp"
+  },
+  "external/deqp-deps/SPIRV-Headers": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "704e17bdb8cd42fa76b81da6cccd6d789a2bc007",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rlpk16ypmr48wcslw66ia5szfayl25msy2vf7zz109j6xnvlnq4",
+    "tree": "626f75a09310aec6060f7d6db1e1cb898cb25094",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
+  },
+  "external/deqp-deps/SPIRV-Tools": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "db7d93f8352dd10adbb42fba4be6a9a9cf2bfd10",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0p8fljrjjq6h2isnpdcabx8hsfj64yr263kl1zzdad5w3nyg40vp",
+    "tree": "2552178d8459e02ac87d88b24c7d58f8b0083b98",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
+  },
+  "external/deqp-deps/glslang": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ccdfbcf0fda13a834e54448279ecec168af742d3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xwccg5yzfkmv2dlw6l4hsknrsvdnzxgyqk7j2mvxvf4p0fwgqi3",
+    "tree": "581a303c6116eb4afd780226d21fed037f9129a3",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
+  },
+  "external/desugar": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "852953af5ff6389d6b23659839af51044de42787",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "10lsb09phixxr37xxpxq519r9hb12fa3zqb0gnzdqk7dzyx20bzf",
+    "tree": "e11956a7b1f81ac84084eb02597dc7c240d1903d",
+    "url": "https://android.googlesource.com/platform/external/desugar"
+  },
+  "external/dexmaker": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "786098737472cfe3e0650985bb5ccb2b33f5d5cd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1fkhc536hrijh09176hw324d59796vg294cyl9kn2b3rxwqmxl7k",
+    "tree": "9f5b6a310428db651a5ff986d39e455a96177970",
+    "url": "https://android.googlesource.com/platform/external/dexmaker"
+  },
+  "external/dlmalloc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd35c6922b9d9237737f189b05f27a9fa3ff3af4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0fqaczxgirc2hck0slbnd1wq394svqs24kbzaw7x2zhy1sakxf08",
+    "tree": "938694023aa0136a1c996b347dd0799b4ac94983",
+    "url": "https://android.googlesource.com/platform/external/dlmalloc"
+  },
+  "external/dng_sdk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20bfe7f9ea6cdc5808be2b05e9abf92b300a6a90",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1m62h8az4r5vgmv98kkyqa1myx83k4zmmgpcd9hcgwdq4hbxj9qk",
+    "tree": "d2bd15857f5bff3e418772dffcfb6d6782663730",
+    "url": "https://android.googlesource.com/platform/external/dng_sdk"
+  },
+  "external/dnsmasq": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41c5a6cceda526587fe50657161396b0dfd2816a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0qp816gvm5z4izg3sl6773sjm3l73lb43rpd12r3229b5gwxxn3y",
+    "tree": "3fbd9a5c0e6f5eede6b41159eabf2e898b0561c6",
+    "url": "https://github.com/LineageOS/android_external_dnsmasq"
+  },
+  "external/doclava": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3bca87b7024ff07748c1eb159c7cf580fabeaacc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vx37w1bynw207zxqdwgzsg8hdbl0k635gvvh5vn36ipqaahwx1g",
+    "tree": "55ed0773e6e7b9165f667cbfb326da0ea6665c8e",
+    "url": "https://android.googlesource.com/platform/external/doclava"
+  },
+  "external/dokka": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f3a789111578ea1664e6f45b652de92faf542178",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "083lrizn8270ajrj7vwqyyyl5p71ppq59ylz1zz6ypd7fkayslmn",
+    "tree": "443afd9045c8d3989ce4dac34bd6ebb378b5ddab",
+    "url": "https://android.googlesource.com/platform/external/dokka"
+  },
+  "external/drm_hwcomposer": {
+    "groups": [
+      "drm_hwcomposer",
+      "pdk-fs"
+    ],
+    "rev": "7f0b01879eb644d0157088f222d6b0198a984e1a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "18j2bg8l2mgw23x6hl7mfcp4j412xppwp3bjwrrmp4skylq333r8",
+    "tree": "73261c611fa5ffbb9b4ed0db8878606e12ae7058",
+    "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
+  },
+  "external/droiddriver": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "822f52d5e2feaf9198877d6c1d808e3b7ecd2dc7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0bnyv9wqpnlczmgz8lqbc12szgcjin2n9hggrgjrnpzi75d3s836",
+    "tree": "35950b15531836715da1980005502ab50e5222b8",
+    "url": "https://android.googlesource.com/platform/external/droiddriver"
+  },
+  "external/drrickorang": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fce85afdc4a07c51788efb85c079562771cbb75a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hvvswcr384dgfyz4ivw6x837pdslx2mj80kf6vmvb0lny157sm9",
+    "tree": "3e4059b0fcf350b58a95cb23e1d4adda48064468",
+    "url": "https://android.googlesource.com/platform/external/drrickorang"
+  },
+  "external/dtc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7861a4a7f654fdc859817609ef476d2c638c7ae",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f4lbjrrwipq4c9vkdkgcx5zc1si0645wldga20ajlhzckgpqp5p",
+    "tree": "2a4f916eaace6ba25ed99590c11297e426e7874f",
+    "url": "https://android.googlesource.com/platform/external/dtc"
+  },
+  "external/dynamic_depth": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e59529849fbcc136e622ef8b25502e82e74bfcc5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ry2bki31s08wsni3kf800r5v0yhbm0h0gqsipjdz1qzshgjn9mk",
+    "tree": "cd524d1c44ed5ba56e86e6ff9a0fbf7505cc0160",
+    "url": "https://android.googlesource.com/platform/external/dynamic_depth"
+  },
+  "external/e2fsprogs": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2b145280baaf6a9d67c6d6c142e00938d5a125d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1h5nmdczfm7hah2g9kz9hyzrkrwwwzyaqq3ifslhcscrxg22a90r",
+    "tree": "0e06d7a52fa568e1463538bc7b21e60d280af522",
+    "url": "https://github.com/LineageOS/android_external_e2fsprogs"
+  },
+  "external/easymock": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff44da0a58590adfe042cbb1837d279cb33c9335",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "04jl5q53xqdcr8j830abc4hdiiwbj4gwnnrdbrcjnimp09scdqh1",
+    "tree": "b684bfc3136d65b767738f2e89c0078063cd2791",
+    "url": "https://android.googlesource.com/platform/external/easymock"
+  },
+  "external/eigen": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "258dac73b1f5a75aa79c057a9ac961040db56eda",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1y8as6vfcd8xla3iw7nb59glh3g3k3dyhn8q8a2hip3clxkk46i0",
+    "tree": "c6e8287856924e1c996a70471709eebc9f107ecd",
+    "url": "https://android.googlesource.com/platform/external/eigen"
+  },
+  "external/elfutils": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3e1df0f8b6f7eb999d161d42e82566512be8ac4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03gp6i0sg2vcmnz0rkmndfal3g7k8l15kj7809kr6rss4vivdysr",
+    "tree": "0b0fcef0fbc1d1fa061e8ea90ed976414b341900",
+    "url": "https://android.googlesource.com/platform/external/elfutils"
+  },
+  "external/emma": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ab05a41718dd937981513f7a98d5960ef948043",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "103xvcj37hn0ggcs4rdwhrjmzy3m8arzdi06r07gk1wmxg134g2z",
+    "tree": "b35844196027573fe7793ec48cde4b350534b802",
+    "url": "https://android.googlesource.com/platform/external/emma"
+  },
+  "external/epid-sdk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c86825fcab1334d55155c01a257ec1e7ad8d616",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1cncdsnhwyhxy7vdj3f9k800hczhz7bfwqgwn451md371byw7zfb",
+    "tree": "5acf266863308ea4d4c6e226cfd322730ac74e4c",
+    "url": "https://android.googlesource.com/platform/external/epid-sdk"
+  },
+  "external/error_prone": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e662564f130d8a41bae39ed42e3fb4a07fe5d09",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f6fs7qhkgjll66p6j1jayzs5jjpvg6hyd9w2y7nchy3ykyfvy3q",
+    "tree": "999922b0320315a381707c4b5d668fe4e4678964",
+    "url": "https://android.googlesource.com/platform/external/error_prone"
+  },
+  "external/exfat": {
+    "groups": [],
+    "rev": "bd0f60193a3775dff3dc1754d76beb2fd10c63e4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1ph2nz8ikfkhrv19faqnirj35gw3bldv7rn56ji08hdwxssdq531",
+    "tree": "ce6ccd926087b00cfbf2a889f7e89d10f6e04eb5",
+    "url": "https://github.com/LineageOS/android_external_exfat"
+  },
+  "external/expat": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "430846a288e21f6af50ecc28c0bc39c1d88efdd7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "168n6igsa3b0wlbkn0p7rhcxikyysg8m37ca6lqrcj4bw12264ls",
+    "tree": "8fc33b74da64ed07c51b386a4c90759b2cda97fb",
+    "url": "https://android.googlesource.com/platform/external/expat"
+  },
+  "external/f2fs-tools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71b3e38b6f529942c02fc6ffc57dae1e91f0eaa2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1nqdkpvnhvq0dpcs4zvfszr29i9mp3sk2ys2an07r3pxn9wg48pp",
+    "tree": "1f0b16ac55633a568e697ddcdb1322db054792eb",
+    "url": "https://android.googlesource.com/platform/external/f2fs-tools"
+  },
+  "external/fdlibm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0894c14495e5130441aed132966e8d951cb6be48",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0dm2dg9598mqvsvf124b250vgnjvi6xdm0m9rl7hpaak5flaifwr",
+    "tree": "7afbb4b63efe591732ae9f17482f7b802a6ed22c",
+    "url": "https://android.googlesource.com/platform/external/fdlibm"
+  },
+  "external/fec": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63433b169596e088966c9b1c8303c4fdfa95f314",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0nrcjxxdp537vm83ycpyrjlgl9hzvk7v238in1wn8ckw1hhbadc7",
+    "tree": "3f977c16cd48e1a6bfc5b51d1d944409bce29dce",
+    "url": "https://android.googlesource.com/platform/external/fec"
+  },
+  "external/ffmpeg": {
+    "groups": [],
+    "rev": "1d5f475c9cfd002ae5962d130ac492c8ebd8d796",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0l3viyhx297424r3f2zki242bb66jfbdal82pjlzpf5gb44g68bi",
+    "url": "https://github.com/Anbox-halium/android_external_ffmpeg"
+  },
+  "external/flac": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b98604a6642734acf3d0010afe831c1371dd17f7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "02vk46z0d3slikqn23wvy33b9xbm1d86kb2wwdxdyjz6cpppb4q3",
+    "tree": "dc3ce14fd53a0de19a5c4510e267b2418e5d87aa",
+    "url": "https://android.googlesource.com/platform/external/flac"
+  },
+  "external/flatbuffers": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e549edde6e9c795ea49010dfa10cf7c57a44fa51",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13fi4kaa87irp8msyiqay475a371k1bmjm01551b4fr0xx3cw4vf",
+    "tree": "fd25ec75c9366dd3bcb25422a892ddf03214176b",
+    "url": "https://android.googlesource.com/platform/external/flatbuffers"
+  },
+  "external/fonttools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ca34c514ebd423d92f5697ac10f3432aaed8bb9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0yyknc0lk4fp6sssxdv2268xpd3j90akzbql0c75aad484lr05d3",
+    "tree": "fd26782cbbf4c73650f8c5b42ebcb2b2e2b2be10",
+    "url": "https://android.googlesource.com/platform/external/fonttools"
+  },
+  "external/freetype": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b963bd26efdd806e01f3ecde030cca3193c38d49",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0l6zzln3czzwpf003fri88yzxasqga2dzjjlaahx54qjaqf204k7",
+    "tree": "2ea2e5ccc4b04d97bfcd0eadd617b27fe2876f9a",
+    "url": "https://github.com/LineageOS/android_external_freetype"
+  },
+  "external/fsck_msdos": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddaa309b20687c3c791862674d366dd57b9adf83",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1ynbwvv1p5npgwwb9jy18acdpqj0r29z952267g69yi1mpqhzcm6",
+    "tree": "2a7a51fda3383a86848454a6e6473a3db6fdccc0",
+    "url": "https://android.googlesource.com/platform/external/fsck_msdos"
+  },
+  "external/fsverity-utils": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09655a7b4f1cb5f15c2c93ab0310ad764167ecdd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lvdbhfbzs4fdphcgrhc76ljbmg52s5r86mjk3yl3nycr4kxkdh9",
+    "tree": "e0baab7f6bc1bee081ec19d8207b1f2a6079980b",
+    "url": "https://android.googlesource.com/platform/external/fsverity-utils"
+  },
+  "external/gemmlowp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c37038e16646197c44027089ca6c2167396fafa3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0nyc1hdfa3a828ajw416hz54pphq999kn91kgamd9ws6rfw4xibq",
+    "tree": "278a366e69da8a93305525307fb9bb0f94e1a183",
+    "url": "https://android.googlesource.com/platform/external/gemmlowp"
+  },
+  "external/gflags": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1fab4421799db172356e9d59b84462d389e81443",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "161hk524yvflasbi0vchlx85rjgzpjfqpxma0vn3idwr54bf4yld",
+    "tree": "8f4006244a9ed3b41ee85c8b9e225640ab0ee0f6",
+    "url": "https://android.googlesource.com/platform/external/gflags"
+  },
+  "external/giflib": {
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "8bb734337f0532efcbb7554f6d848b98a3786fbb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "128chls2a2qzivc8wm3qx9k5diy5w04lh44krdg69sjfrmahmkkp",
+    "tree": "e75ff8c3ac5ed83697596e0d978b464bdf7d5280",
+    "url": "https://android.googlesource.com/platform/external/giflib"
+  },
+  "external/glide": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1ea70242d5e226e98dfca2b2b01523287f7421a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hdpqmvy933qcpplr6w89cxd667mvmf0b250h4f8ziwycyr70vs2",
+    "tree": "77725eed982ce5fe170c05bc11cc07903b88ca77",
+    "url": "https://android.googlesource.com/platform/external/glide"
+  },
+  "external/golang-protobuf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17a04b93cdaea750adca47c9abe255aecf2631a0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1bqw09yxmp3fb8192b7qc778allaspppqz3mgqb17pq0zvb6mcgm",
+    "tree": "08fc71635901493ea4c81458fe343755543ad4e6",
+    "url": "https://android.googlesource.com/platform/external/golang-protobuf"
+  },
+  "external/google-benchmark": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "181cbbb0312091bd24be07b0b4e5cc26f84eb460",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0513jzvyk12f1125xvqz06r9zzm24g7250nww96ibnn590qglrmf",
+    "tree": "e223e4f0faa8917ed3bb4aa33382949455ef3f17",
+    "url": "https://android.googlesource.com/platform/external/google-benchmark"
+  },
+  "external/google-breakpad": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "331f90df5c68efb18adfbd8e722b0e6f6a554b23",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03fnan3b9aiyddf7q5s04dd5iazxnw084n07vai57nbg42ydrbr9",
+    "tree": "6fbc03022923cf277f6dd4dc13008bfd8cc73523",
+    "url": "https://android.googlesource.com/platform/external/google-breakpad"
+  },
+  "external/google-fonts/arbutus-slab": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ce4dd81882a9acc9d67a53ef0908e22d99628b51",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "027qn08al4jzwnf9kn8s72lpbg8j3pkaaqy2wb1ra65ysx6gmb7m",
+    "tree": "f7f70a6df00f3cdc92573280024463ce265139ce",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
+  },
+  "external/google-fonts/arvo": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b7bf10e8848e2233864b1d9fb1709dfb9979f8a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0pgrm6nz7x5wgvfd1nbr0pajz4j481k88f12gz6im13lbnnh8w6h",
+    "tree": "cd3d8de84de69d8e95e947330f2918322afab2a7",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
+  },
+  "external/google-fonts/carrois-gothic-sc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "97e43e04abf8fb62ac28967959b8e5dfc373a80a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1mr71ra0bc87a9dn7190krnn3nay39vhlwnfp031146vwqlfb6k5",
+    "tree": "66a3570c32cec1ec8abc5adb201133f7b6d6ec6b",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
+  },
+  "external/google-fonts/coming-soon": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "85b633199e150a3b91b96a0528fc561be1c1cd59",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zqn67w6zyncypn1rpqwj9cv2jsk18yhjcrgsbrd3824b21cbjs9",
+    "tree": "3825f69204a83af7463ff4c9dfe70dee334df7ed",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
+  },
+  "external/google-fonts/cutive-mono": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11731b968bd81b0b12d5c98a9b6d81f00606cf86",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "095j0gzaaqalvyymlvhpkr0yyy2knl0h8hdhrknbdxcya4isimhy",
+    "tree": "f5f6687293c4c0a4a6ee48e06ffb66bedfe81b34",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
+  },
+  "external/google-fonts/dancing-script": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6104718b0305a996897f27e1f6972d7c85bc4c12",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ankhg3dafylgmp343vyhpr5j1g6nx57ykzph98n41qixx8mi3hl",
+    "tree": "37d6770c6a63cc3c3c5789cc6ad6d81600ec18b8",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
+  },
+  "external/google-fonts/lato": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e613b27cc4cd7f7bb7251ee761e01304bf9b1fa8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f86g7chwyca8xlw6fgbmr2bzagbs854qkak69zr3g7gv13fvcvj",
+    "tree": "a78e6ccfd42801a1f86ec983462b8a3953888e46",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
+  },
+  "external/google-fonts/rubik": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f62ec73fa1af79833ddc19fb5894eaf0c4c27d9b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1da36a7d1zn2w579lrjzvckn8xm81sgcf9yr9q1yrrgn08wsr21f",
+    "tree": "ffef07cb3f9742aa68fab5d6a43de16f80bfccc6",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
+  },
+  "external/google-fonts/source-sans-pro": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9127dea3c4e1f9a04ceb07f3859974dfc1baa16d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "16csfhsxrb8l0wsy455cgavalz4xljngc9d8q6dgzv18srf0z230",
+    "tree": "4b2935c6af88c22b6386e9b48cf5f4fb6c3350d7",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
+  },
+  "external/google-fonts/zilla-slab": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7f3b6139b556cec9dac4ff3fa44d2c3272f4f601",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0m0r6z33ypg06d1pidansqgy80598m2n4axfa9cpq8jlrza620pn",
+    "tree": "6fbb878feabe80f42cacefdd824d703867cc7670",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
+  },
+  "external/google-fruit": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b893138e1bac2c8565d6bd4b7eb5e7c5fbcab6e7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07pcbjj8vz083mxf3w4sc0cymp9bf586rvrl3g716amh2mjgfvyn",
+    "tree": "656ac4f7bbaa0390bc8e49b5b22229d0e6170e6c",
+    "url": "https://android.googlesource.com/platform/external/google-fruit"
+  },
+  "external/google-styleguide": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c20f6a9f047fa5bfa15be3d31516cac1c350b19",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vx48gvdidxg8fgr1h5gwgk2bmw0l847y2pyy525pxk6qzmhylkk",
+    "tree": "5bb51bf6c3d96228f092e6d01f5ccfd73be7bb77",
+    "url": "https://android.googlesource.com/platform/external/google-styleguide"
+  },
+  "external/googletest": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3fa35128d75902e4bebf1fd499d552e7a034ac91",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "10rhpzb08mv7ralj11zhgdvikxnv97jvkkj0kac7zhc3dh228pqy",
+    "tree": "d0b7c9126c5c4cec58a4eccf23fa6c1123bc4e19",
+    "url": "https://android.googlesource.com/platform/external/googletest"
+  },
+  "external/gptfdisk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f49f553641ef7464858af44e6498f7661cb7156b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1i46fx7hixwihlhjadq9b60qgjn95j3436g50a7xik0yzh56rhwr",
+    "tree": "383e70f1c3fe9caa28d5a2db3eb51f228a58d3da",
+    "url": "https://github.com/LineageOS/android_external_gptfdisk"
+  },
+  "external/grpc-grpc": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "e7670db6f0af3496f967fa0c162fd2b1f19c72f1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ssfb9qfv08hrvfy9v9m5ds59rfbch2zlvvmzk07ghhlfg470kfa",
+    "tree": "b99f98a0d2fe0d5d49d6283b80dafea9f199636a",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc"
+  },
+  "external/grpc-grpc-java": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "3300b867e3c50019076958b6fbde76af53cd0d7c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1m6v6apdqqvhn5in0hxavy8mlj4mpgn4d463d9b70rpmcac8fgzs",
+    "tree": "e070edf555e8356c5509d8aaabd645e008597462",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
+  },
+  "external/guava": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e76ca1bd563f6ba6b888ff2e12f84b0fe3c26e7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1afg7phl08hyjmmb9cgi194jwmp14lhl5krswsxr3kz9yivqhvdf",
+    "tree": "90668b97ff1af38d611daededc00e0f1d2659d91",
+    "url": "https://android.googlesource.com/platform/external/guava"
+  },
+  "external/guice": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3c906186e448152d212e1e4013896ca5c2e3468",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gbib1a2sp5izyzmmj4j50izscrbazzlz8qv1wklsrg266cbnazk",
+    "tree": "931127c92d94ac53de2fb3ed4c36f728c051249a",
+    "url": "https://android.googlesource.com/platform/external/guice"
+  },
+  "external/hamcrest": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "759325b7f5716d5999b6388cdeca164394e363d6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "04wdm1k60si1c2y1ca98w549z0ka80l3fgjgpyrv28wix3bkj8hm",
+    "tree": "bc573e3c2dc842b067b99ca87ada7383c56dc64e",
+    "url": "https://android.googlesource.com/platform/external/hamcrest"
+  },
+  "external/harfbuzz_ng": {
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "7932b34aa2b11b5e97daa5f8ffbfcb9f1936aca1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1v0a0x054r6il47lhd203c4ii208zirp3xqaslil4a3hb0gl8di2",
+    "tree": "f3e1739f666058e1674c1cb01332eed505134b41",
+    "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
+  },
+  "external/honggfuzz": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76b09da2b8d78908c5d13c8ed9f289c51379562f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "138bkca1hxb1dbclh3416mmqikhamg08r8873jcx778njq76gy1b",
+    "tree": "0216d428d963507374a444f568ff2b53ae0cf266",
+    "url": "https://android.googlesource.com/platform/external/honggfuzz"
+  },
+  "external/htop": {
+    "groups": [],
+    "rev": "0c222e0b29f15baab0fd6492f3f691aeec4268ae",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "005sl74pbh21l3l48gzznlh8rwnwankyp9jx018zk03xbq7c6q7g",
+    "tree": "cc3e704fc5d6e49e9065460c67f7dc740b7d09b8",
+    "url": "https://github.com/LineageOS/android_external_htop"
+  },
+  "external/hyphenation-patterns": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6c6ceeb699cfa8d37d664efa4d0cf1583ed0789",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03kig3clzj4jsxyrjhbv8wi3hpbpk0b62q3b34yqf3sjcrmh0bky",
+    "tree": "e1e1bb9ed2949ad902db333efdbd2994737277a0",
+    "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
+  },
+  "external/icu": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5721611b71dce766af2a5a9f4bb92a8f970e0fb4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1jr660vnahw3v8z7z70bgy0rw2z0sr16d7h4l7xsgk1s1grrjkc1",
+    "tree": "8d1d76765394afb7e552948ac5e945ac68d2cbe1",
+    "url": "https://github.com/LineageOS/android_external_icu"
+  },
+  "external/image_io": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7c8d306b645f099b757dfa20d2911068f4f4e94",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "05knkfpg802vfzm07qxsa3gn24v0sizd66v1wkrgi91chanw6b4j",
+    "tree": "3f35106aea16c6ee8588ae1ad5eef633c14ce5d4",
+    "url": "https://android.googlesource.com/platform/external/image_io"
+  },
+  "external/ims": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "adc4efa490ef1eeb00650367a9ea150236e42f33",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xgvqp1drrvcx9wjbhn1i9a61cfrh3qxi4kg591zdbjlg9xyvdmh",
+    "tree": "98909170d1b9a0bbc04c9cd19a5eaf54c93270f7",
+    "url": "https://android.googlesource.com/platform/external/ims"
+  },
+  "external/iperf3": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6e29b5d1942f5cc21bea9107a4e6954d347cf25",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03mhyackl4yl1qcgl502blfgs3yl6k656qjs4603wjsy9dr2gh5b",
+    "tree": "77ac36456ee21bf38a0c64127612026699c91fa2",
+    "url": "https://android.googlesource.com/platform/external/iperf3"
+  },
+  "external/iproute2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1b9f03aae029540537f19ac591d6d72aa588c8d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1c2bryz93ddhqgkmyxnvms6n1vz73gl7a7kqf59a04vpdnvphlsj",
+    "tree": "b194c00a26b73b5afd5eb590d25bc3d428bda09c",
+    "url": "https://android.googlesource.com/platform/external/iproute2"
+  },
+  "external/ipsec-tools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b621f0864a956d48e72f9651889a89f79b21c8fb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "186lfhwmagjk7h12fr80hgyh4yflywaz55c7i6ccsms8s9xqsqfk",
+    "tree": "da1b2552070ebade53e6416db3547fd179b17f26",
+    "url": "https://android.googlesource.com/platform/external/ipsec-tools"
+  },
+  "external/iptables": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d558c0439a640c83d3f00638bafb54a35e13a8e1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1x1f66lj496lfdh9fkm23bvya58kifl5kq09nshp6gd2nqyl17ks",
+    "tree": "738791d82e3df6348ac1fb68db5613aa44ce4c15",
+    "url": "https://android.googlesource.com/platform/external/iptables"
+  },
+  "external/iputils": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34344406d2d8ccf3a7acda4015157aadc3508a5a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1amh8qn43gi8w2kxgypvqyisaallli1bclb6grmgmnskm3q3ms6g",
+    "tree": "a512c36053a3b4338d3feae80818c0f98b55c69d",
+    "url": "https://android.googlesource.com/platform/external/iputils"
+  },
+  "external/iw": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dbc21d3c3ed7fabdb79c68d918805675f216c93c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0s5wmqasn10aqhksqqr5liamm1xrjwipd8m1viydid727ff52j4s",
+    "tree": "642feb4917489306d73988ae7168b30143b83552",
+    "url": "https://android.googlesource.com/platform/external/iw"
+  },
+  "external/jacoco": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c53149378e43721bc2a95e57034e80547eee694",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vwr29nksgz87rdvmmkmxgwndkrhvj4f4a8673d7fvlq99xwycbc",
+    "tree": "f7a25f8c8df2959454ad4f2b77b2c8c2453b0250",
+    "url": "https://android.googlesource.com/platform/external/jacoco"
+  },
+  "external/jarjar": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f752ae7b5c2d30a22c50329d3d232256bee3a48",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "10nbvhxcdxbn1s1lx1i7pr1g9h8pjgmj0j2pa93id3pza0np0rpp",
+    "tree": "0e866710d44d20bd6b9dc530982877d79e70114a",
+    "url": "https://android.googlesource.com/platform/external/jarjar"
+  },
+  "external/javaparser": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6272f0f844f196fed4d2bf7ecf237709ad8f77a0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1jzaphflfxplagy2vxxg5ijw9q55smjsy4lsl002yhy313vaklax",
+    "tree": "3c5ca313aea6f3f557b781cd08ea619946cb2fda",
+    "url": "https://android.googlesource.com/platform/external/javaparser"
+  },
+  "external/javapoet": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69dd2f63ae5040f65c4721d8bcf5f9ab7c271561",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0va3kdl7lhadzrjgwdada803mcqikbcbzdjwrcpg115c7vy3lkav",
+    "tree": "a8da16823f5fb9c08b85aa4ab52948b51b700a99",
+    "url": "https://android.googlesource.com/platform/external/javapoet"
+  },
+  "external/javasqlite": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "10d73c1f3e7f88328090ec60962ee6639f6c0bb0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1brp5hhm9121dyl50fy5l6yblqkhccv1zcxrky7bx6xkzvk1y019",
+    "tree": "ec29c8bc08dfb931d268448bbbc1732770ab225d",
+    "url": "https://android.googlesource.com/platform/external/javasqlite"
+  },
+  "external/jcommander": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8116c59d07b4fa094771311cce62e61bb612ca03",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "093x4dl09p7gj8aq7y3513bdm1d9acla8xxamccd4gnagsklxc0r",
+    "tree": "21e24ad88a1608e6f2a057f4b06cb68cac6a7a04",
+    "url": "https://android.googlesource.com/platform/external/jcommander"
+  },
+  "external/jdiff": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af68ff99b85ad4b07353b7eccfbc0a1e25e0bbbc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hbg1blxdmcdywmiifvkkw2by64wnpirkqa8h2fks68d00h0yq12",
+    "tree": "a1a984e8c94750699cbb0931b59a6d5890a947f8",
+    "url": "https://android.googlesource.com/platform/external/jdiff"
+  },
+  "external/jemalloc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5a7e1e173473bfeaf3e39067c2af0450c44c8631",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qbmfzg3cnjfk062qblpbszb8nlli47ndk65sqc0gji7xp2bxqm7",
+    "tree": "33158fbd4e14be29e5f32d45aed8cb954e6d7934",
+    "url": "https://android.googlesource.com/platform/external/jemalloc"
+  },
+  "external/jemalloc_new": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35df27aad21d85e2e09fd9ee2108d718e45173bc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1rk7hvxgszb9yqrgcw279la63w0gzbdj4fbm02z1f32dzkjmx3dv",
+    "tree": "5d0471227f485ce69c3df9e65b93e1186ad9fee8",
+    "url": "https://android.googlesource.com/platform/external/jemalloc_new"
+  },
+  "external/jline": {
+    "groups": [
+      "pdk",
+      "pdk-fs",
+      "tradefed"
+    ],
+    "rev": "9b8baaa5ad2a7feda431d7c5c976371b6e802a89",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1wzawzpaxifkf84ifdjx9kxm084yhq47s3qa4iv9hcqczmnzh2lk",
+    "tree": "3a82f2506905459c512fe9e59f3d83c5f725826e",
+    "url": "https://android.googlesource.com/platform/external/jline"
+  },
+  "external/jsilver": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5a14ba58ba9aab1860fc163456e4251cf303628",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ngw5a87h905646v4jwlhcarq7p1zd6zb6kq2j1jz5bybx0rxjzk",
+    "tree": "2fd39df87ca9c57c4cf803ea664fc1bdb7f37c5e",
+    "url": "https://android.googlesource.com/platform/external/jsilver"
+  },
+  "external/jsmn": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aecf57dbfe37112a062e8cf4c79f0ea456c71398",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qh5499dnnp34l29wiraaa4vs5qsg40cgsym16z6ysj48dcif6aj",
+    "tree": "915c73cea023105cf9c1958617ed0383f889f8ea",
+    "url": "https://android.googlesource.com/platform/external/jsmn"
+  },
+  "external/json-c": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "76ff6c3b4d9b6dcc9b6cc97e400d7792d543cd0e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "16ax4817v1c3i6h8nzyhqgbq3326ixr3zfbc304b0p645qd27pd0",
+    "tree": "a9c6b73b0744654db669e99cf9e29787d6a3f037",
+    "url": "https://github.com/LineageOS/android_external_json-c"
+  },
+  "external/jsoncpp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c42e2809c85ebc64d46a1f03fa692e5f1768a32",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0pfvp2qmhrapv2qaq9n35g7cgm3kgrc39bxahf782p4kxz1kynl5",
+    "tree": "5542344a76634ae30bd49784d136ab801508d47e",
+    "url": "https://android.googlesource.com/platform/external/jsoncpp"
+  },
+  "external/jsr305": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43629f5f51bf91db9f0cc5ed0b5f5b3cdb519d10",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13zbffw65vwljw0jk20rwsyaq0d3fk82ljx70bh71hiqa6nsbjb5",
+    "tree": "cd42f9cbb712c39c0c0d09216d5a4a22d0ad461f",
+    "url": "https://android.googlesource.com/platform/external/jsr305"
+  },
+  "external/jsr330": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "66673da6750eec482ffec441a8231bf82ecd9f3a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15j0sa85b122l8j1v7yjx33r7njqqz3bq6dm0qc8cdgnscn1l72q",
+    "tree": "152af26f169a10312760a874a554d3f9b31f7056",
+    "url": "https://android.googlesource.com/platform/external/jsr330"
+  },
+  "external/junit": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5beb3646e37f39b8961df4cf62aa437d7816543",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1hwrrk8rbdzp2g9p585yn37fg965qf3chs8hwqgwzb5sr2nzx989",
+    "tree": "c61186255f67ad2936ec4f3fbf77851bd5ab1100",
+    "url": "https://android.googlesource.com/platform/external/junit"
+  },
+  "external/junit-params": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "041a5e042ea372ae544cdd837cff9f77f9c44a4b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "14rwkpwzqffq36g165bn1j3p7as7dra14gmakbmxksw6v1hzcrw3",
+    "tree": "d23221da274f2eb57777051c1ca045e3281313e7",
+    "url": "https://android.googlesource.com/platform/external/junit-params"
+  },
+  "external/kernel-headers": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "74d4fec5c24117d4a0977a8bd1e97aa74c3a95ca",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xjyj53ga1fm0afny733fihckazznbyp3rj8253rgr5lvqpkgm0h",
+    "tree": "b90f01bdb8e8183cd40425b4012e4dfb1e3b0fc4",
+    "url": "https://android.googlesource.com/platform/external/kernel-headers"
+  },
+  "external/kmod": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d000b9d387087608413115c3303a8c4f866bde6e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lz4i84jpggzcg7s0l2fp8x4cq2pyikwzfac76idy2az1wii0cl3",
+    "tree": "394819776819b6eb8804939c051c1f6b700ace73",
+    "url": "https://android.googlesource.com/platform/external/kmod"
+  },
+  "external/kotlinc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6bba7574187b2e91bfaddd1f37d70136dc0e2dba",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1d2cmm9kb1xf233n5d3bszanws82f60hkxfgx4gpgnyhggfpm0ii",
+    "tree": "33812203753dd3dcf1c0cd4392630bbb25128054",
+    "url": "https://android.googlesource.com/platform/external/kotlinc"
+  },
+  "external/ksoap2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "91d8ad6cf592cb75b95eefd6e5b2afeb47ff4733",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "00gr9l02602qbfr7kvx7dbg61skh3c5m99zzqjrzpwdcjwcr38a6",
+    "tree": "202f22b06b90bff2fc9dd36abff5017cb012cbbe",
+    "url": "https://android.googlesource.com/platform/external/ksoap2"
+  },
+  "external/libaom": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d59a4843bdf8ceb25f22712f3009f160b6ccef30",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0j20lhhmvb5kw755l040633f070w2c2izl9x26arlbrvqchqmicq",
+    "tree": "b2861993edd19748ca98f07bbb87f74f8ae30180",
+    "url": "https://github.com/LineageOS/android_external_libaom"
+  },
+  "external/libavc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b57afeddcc3ce16102f3d3f56c799eaf1713a0e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07wazvkhknakr7fmi5xmxa2xmxsx1a4xbcalx0w8isihxmfdvbyn",
+    "tree": "9fcfc077cb4c15ae308a653da14a7ffd09c55d44",
+    "url": "https://github.com/LineageOS/android_external_libavc"
+  },
+  "external/libbackup": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "676bacc329636c896a2b6635888d2620c005b2f7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1rh1010x3jb3n8g7k8d001cjna7wi0xf9ca4hpflhrk1c3f0mz3s",
+    "tree": "dd0a3c2e5de8fad20d286fd56a24aa23044cea86",
+    "url": "https://android.googlesource.com/platform/external/libbackup"
+  },
+  "external/libbrillo": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0e322efaa5f5180c04a09d62d6029f5beebc9cf2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0dvvw09xx3rqbsrk0m00y0i142mk88npa9phvmy55xfx8nak34n1",
+    "tree": "96e8cb6baee3ca1edfc0e2e6f34be5e7dfb37bac",
+    "url": "https://android.googlesource.com/platform/external/libbrillo"
+  },
+  "external/libcap": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a424e00f647254626e2ea357b6af1855fb8b5e76",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "01w16xh3ffj1lhj8q70kzdlgkxsrpcb2yv13bpn1vdgjsf3xcbyh",
+    "tree": "707d81a30f5d1025a0bfe15e893e637bdb3e6db2",
+    "url": "https://android.googlesource.com/platform/external/libcap"
+  },
+  "external/libcap-ng": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0530548c04c166c69ade003b63087f30d91b32c0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i7caf8bmdw0aw53bbdpcajqc8mnk5ql1v4rcwdasri4yk3fm7v1",
+    "tree": "1c009996c3f370242317861e580f8e32677f410a",
+    "url": "https://android.googlesource.com/platform/external/libcap-ng"
+  },
+  "external/libchrome": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2b21b250f69b838f9778aebc678078cf74d1656",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "19bh8ccllyyffn1c9jng9bl23kys66p7zaij6z0dqgjmwca8lcnk",
+    "tree": "62e711670035bf235c7a387aaf8ec570576e7b11",
+    "url": "https://android.googlesource.com/platform/external/libchrome"
+  },
+  "external/libcups": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "33346877325f654eea5b5a8e3fb9325eac43902a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1nabh0h49a7fygf4gnqciydlf07hzclhd4sk4zyrixcy95kv7lpv",
+    "tree": "efb081348103d7f0be9caf54146720f48dae1f71",
+    "url": "https://android.googlesource.com/platform/external/libcups"
+  },
+  "external/libcxx": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0dfca9975f466d77ebb15f4d3cf4442b15384ae4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1vj98i1l8fvxvlmxzhkxzia9mmcgamw9xy9r5w312vv324kxzmf6",
+    "tree": "11f66834825ced1a6480499b8ffa021d3b03f7e7",
+    "url": "https://github.com/LineageOS/android_external_libcxx"
+  },
+  "external/libcxxabi": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04e998af58fb8c41a00b039866701cb1cf0f2143",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hv6z8cl9k8slvyr31fda0phhmfwxw40a5id1akks7ixyhk7laja",
+    "tree": "83ef20c91a76e1349a30190438e49ad3f05169b1",
+    "url": "https://android.googlesource.com/platform/external/libcxxabi"
+  },
+  "external/libdaemon": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "abfaa65601ee56c0da103600a4ee4a8f3a1c9388",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rncih86y8iqyn61xd09cdc8knwzw5nv5mq7vmipb2wxlhkhlbwd",
+    "tree": "2e78761e0690d6b32b674695c5b187796ddf8990",
+    "url": "https://android.googlesource.com/platform/external/libdaemon"
+  },
+  "external/libdivsufsort": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03599d7eb56929b352923aec02f00b62bbd2aafd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "150d0zx4wdh2gdfsk1gczsmm0lgd0y5irmh1ygiq0cqfx78c2pzr",
+    "tree": "852b4679691cb96296d9704d686f28ccf29c29f4",
+    "url": "https://android.googlesource.com/platform/external/libdivsufsort"
+  },
+  "external/libdrm": {
+    "groups": [],
+    "rev": "e4d322cadad1d8e833ce6ceee94425bf48e01a0d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0qzfbw8wfq9mvamj43rklv4hp9pkns8vr9h1kpwxssbgxi9x1chv",
+    "url": "https://github.com/Anbox-halium/android_external_libdrm"
+  },
+  "external/libese": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fdd5d3fe4fce5a5204b30870a5571259249a31ce",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i5g4iwnq0bh0rzy0q78i7yyns3zfk5f9m5vnfxzkyyipwc9kd06",
+    "tree": "4ff6124d3ca5e24f3bcaf457363b51bf28276ae3",
+    "url": "https://android.googlesource.com/platform/external/libese"
+  },
+  "external/libevent": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f2606bdeb9475995ce8be002a1df2c0c628da0f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "18vm4dd0ay9a32f2dlj2jl5khnqirycnzc3lp3apkhdwnl715gal",
+    "tree": "54430c0253b69af17ddb47aac6515b5eb93eac65",
+    "url": "https://android.googlesource.com/platform/external/libevent"
+  },
+  "external/libexif": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "149d33562a57cf73ae35fe600c43210480ebf595",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "03ysxmrxhphzwpkic9mx1hsip7bijacg5mzqbnhslj6vykc1hzr3",
+    "tree": "9d3ec28d5531f84294d805b27476f2e62c9d88be",
+    "url": "https://github.com/LineageOS/android_external_libexif"
+  },
+  "external/libffi": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a037bb126d158c1557d42dbc824bfce3b1d681f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qsm9xadna62qslpcgzkqasgs7n6pm7byd68wqxvijljaspvdqb0",
+    "tree": "9ebe7cf2f41c2029016f8c48339fd3b7d58bb873",
+    "url": "https://android.googlesource.com/platform/external/libffi"
+  },
+  "external/libgav1": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "848edda90b55ce9e5bfa9f4ec3f6104066f4eaa5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vrnxjk1f1d573dk35dm7xw6q8rgnsj868i91p4422l2mcc5c76a",
+    "tree": "9cc8122fcdb1c77798e218231b85f1464c63c05f",
+    "url": "https://android.googlesource.com/platform/external/libgav1"
+  },
+  "external/libgsm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f8983a91ef389e664f235b8221bab7e30f1c2d8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lf8jixx5sapf9vrq9p5ysakyn1yr4qa3vxlaj5hpjid0bxqxvg6",
+    "tree": "26f7320f2f23e7e09d452f85fc6d678b2a092549",
+    "url": "https://android.googlesource.com/platform/external/libgsm"
+  },
+  "external/libhevc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9bd2ff8ccaefc464c2302768d2a1e7d45aa6816a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "08llf97z27jl4v5javqjs4gzb9lrhdvpybiwi0fklfy237paxi00",
+    "tree": "9e667d437772ddc78104bd2345bce96443044581",
+    "url": "https://github.com/LineageOS/android_external_libhevc"
+  },
+  "external/libjpeg-turbo": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1b59acbf4727d11fa090e9fdc192cbe02c1eee3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f505bqa0qaidyxg6jzz7ccdq4rnmwcwjbm6jyk441d3bin364gs",
+    "tree": "74ff998f72c18bdf7efba586b9b4a7a2f4075df9",
+    "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
+  },
+  "external/libkmsxx": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0a8d5b5e6cfdfd23faeed12482e0182737c89900",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1nhcaf6hrdqs3ll1b1shmjnxnf1hxvbik3jah7i3s47bvqhqaji6",
+    "tree": "dea7a30f3bdd636d3617eb6d98d4acb9df7c1d01",
+    "url": "https://android.googlesource.com/platform/external/libkmsxx"
+  },
+  "external/libldac": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0074a2310d9e8f13e52d14214d6d5d8993ce8b82",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "19da8r2lvrf1ilm4jgpq2ajbkk7shwzfzkf4yyzxyc7bxsj403hf",
+    "tree": "fa5ce81022dd92e3d95aea1eb8cc3a8310c80ff1",
+    "url": "https://android.googlesource.com/platform/external/libldac"
+  },
+  "external/libmpeg2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3050677942fa1ee4eff7bcf79b22dd2150e532d9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0svdp0av4bqmw12p8w5bq8dlk0cw5vvz75lwj6pxp1nnv63apaa4",
+    "tree": "c38084927c6fbda0c62cbc5d13bbdafff55f6593",
+    "url": "https://android.googlesource.com/platform/external/libmpeg2"
+  },
+  "external/libmtp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04a3f2496282ce85a6994aed13071187d3cc1daf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03lw1ybvxg9pcclcafifi0x0rlx03bliq0fix23lv1r5hgzls093",
+    "tree": "d9c46f313ff6fff37f977324a60e1d330d38077f",
+    "url": "https://android.googlesource.com/platform/external/libmtp"
+  },
+  "external/libncurses": {
+    "groups": [],
+    "rev": "92c37f7964a447b0c9133065597f46a3e9b9e9da",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0si7i2jkznbzfw45f0sqvsxag8mahraa3x6kcbq8vz6dfs72zf5z",
+    "tree": "c2f8dcff8307a08eb01714dc117c55ff3e0efe3e",
+    "url": "https://github.com/LineageOS/android_external_libncurses"
+  },
+  "external/libnetfilter_conntrack": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "722ced994298ed2404d887b6221e6e7d6ee3216a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "11bwfmqgagf92068c0yr91x2lac5k6wfqlc8mk4byqb9bfl699nx",
+    "tree": "4e2273872fd1b6c074ba68f47e9103e2fd162033",
+    "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
+  },
+  "external/libnfc-nxp": {
+    "groups": [],
+    "rev": "e4fb0694ac4eb888f098598bd895587b71747ce5",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0l4nbdk31xbhn853xgiag10gf7x6659vnxxi0386jfp36myfmhbz",
+    "tree": "c4b006ec6a508a2c85252bb22986db194c472175",
+    "url": "https://github.com/LineageOS/android_external_libnfc-nxp"
+  },
+  "external/libnfnetlink": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1fdeb4cad6ea382a2e0ad7c2ccb07748eb68e1d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17rz38qg4sjyqdyah4c2nwm766xvvzh14gb4ykxl8707jhvhqv2g",
+    "tree": "fe64e1bc8ee000493537cdb2c140e827df8bb031",
+    "url": "https://android.googlesource.com/platform/external/libnfnetlink"
+  },
+  "external/libnl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8721f2ee45153795a2cbb5453005d7d954794dfb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0l78wcs4s61wbgcxwnx9s0f8kv1awmvgq29nvz8cxdzmv18jp155",
+    "tree": "5de66969129f256b0fead0aa54a2b39d2669a250",
+    "url": "https://android.googlesource.com/platform/external/libnl"
+  },
+  "external/libogg": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cdf0dac0c056ec9e021dd2374b50f923b8dd647c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zkaj2xdqv4d9gnypw17kj142yiyhjbb8k6xc8ig0vjvs3gmwpx0",
+    "tree": "ce202cbbfd6f17de3df40daa0951cbb6e073128a",
+    "url": "https://android.googlesource.com/platform/external/libogg"
+  },
+  "external/libopus": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e16375bc57c66dc5d1ca92676697c4a5384bcedc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1jmax466yrkmq0viqm7nwq7gg2bhkfx876iibwsk47r73dmhs19r",
+    "tree": "92b213cf1c81a89895c63d1840c68c2e14208802",
+    "url": "https://android.googlesource.com/platform/external/libopus"
+  },
+  "external/libpcap": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e74d721a0501d533faf979248ccb626581167690",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "089ks3vq7a86ly5bznmfrm9nfcq98xhhcjgjs5ll3js3j06ingch",
+    "tree": "88b2fdc1cc6a99a3f5ead86dd725eca50eaf012a",
+    "url": "https://android.googlesource.com/platform/external/libpcap"
+  },
+  "external/libphonenumber": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d7b2b8af76cb88cd9d43186e9e5c86e6e5d74d65",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0x692rvxn0xm1mx0q826g5yb5pk600nqqsf5mznpnh6r0k9wghgh",
+    "tree": "6e1916f86162e354a352b2799fff25b481538e2c",
+    "url": "https://android.googlesource.com/platform/external/libphonenumber"
+  },
+  "external/libpng": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "83a4add1f6df7ced082b2bab96891c66ab16b89d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "06j95rlimbxim5gzcyavn5iwhmkkrnmzxv0krwvl4c5s5fgv1gip",
+    "tree": "4a39655b471d64a519e9c46c469f400f03c9096e",
+    "url": "https://android.googlesource.com/platform/external/libpng"
+  },
+  "external/libprotobuf-mutator": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5651610fedcd761b1df825dcc5274d1f5f77f94",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0jw4mp4cs4hy0jipg7fkx8p9wh241va8rcnd5lfsl42yn6pdfjxl",
+    "tree": "5f093ed4cbdec8bd1d307db508a2033713682cfe",
+    "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
+  },
+  "external/libsndfile": {
+    "groups": [],
+    "rev": "a98ebd6db43760db0130997e3b0141e00222d582",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "13fw5sxkl7gj73mgzhbcg09w8r1llh1c0658zxij5x5hab06rb6p",
+    "url": "https://github.com/Anbox-halium/android_external_libsndfile"
+  },
+  "external/libtextclassifier": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1379d493bc37823221de4f5de40f969ed974e8d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0hs3nvcq7y7kwlhwmxym33g13smlc9b2qls74zxpzg8x6s4f7win",
+    "tree": "147c01d4332948be2a296ab3e4e72eda719027e0",
+    "url": "https://github.com/LineageOS/android_external_libtextclassifier"
+  },
+  "external/libunwind": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ad64a3b677449a23ff8a2161066287f2e15faf6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0abb49d8p6ihqxmbrrlrvcpwr1190i40zyqz0r2850n6jzllvbk6",
+    "tree": "6ab08f285856ffc6858ab574f11f42ec0e7a1c80",
+    "url": "https://android.googlesource.com/platform/external/libunwind"
+  },
+  "external/libunwind_llvm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "896d0600a811437cc5cfa5b75e45448ee541b5e0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03pf01krmjiwfh8f7j6f6kqmq1gynqf03cs07c15hwd0a450zc72",
+    "tree": "eee7241cdd58a861b1eb25522165c2dc06dad92e",
+    "url": "https://android.googlesource.com/platform/external/libunwind_llvm"
+  },
+  "external/libusb": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "77e096e40ac36ebd0ee6e809b655bf567c9b000c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i8dwci0c4cqbn3y8lq6mvncy4z6ahp10dic0cxfrcpkmyahkxr3",
+    "tree": "64125238272ee9676d54c1e28c1afe8545d8330c",
+    "url": "https://android.googlesource.com/platform/external/libusb"
+  },
+  "external/libusb-compat": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "357e2b956ab78cb6789c622cba15e0932090017a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1254vk5qvs2ff4xhyb2ic7rgrhbqlzcpdbjq6r0fxdyfln7p2jws",
+    "tree": "6aed5b3b8af198b6ace9c3dc551aad1fdd09e4e6",
+    "url": "https://android.googlesource.com/platform/external/libusb-compat"
+  },
+  "external/libutf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab567a4531bc6396ebfbb5757554b7d9337a345e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zn109mfbyjih6rr0w49x4xaav2c6z3r3vfr24ylk29cqxha6s12",
+    "tree": "c726626b32a4f4985af34c5a042e89eeebe619b0",
+    "url": "https://android.googlesource.com/platform/external/libutf"
+  },
+  "external/libvpx": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c86f24a4ed753e3a0335d6099dd366ca2e4047f9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0wv62v1swrarizk2xy4sgv6q3ad7rk2z26v5gicc0g8bd8w9jj44",
+    "tree": "3ad62ed60696295ea2a29cbf26bf0d3ae25a30d5",
+    "url": "https://android.googlesource.com/platform/external/libvpx"
+  },
+  "external/libvterm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5da9fe787b3c76952d70af55c17e5af69ab72b8e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0iah0mjgg6pzvxfpr0gcn1kvy8yzy8k377zbywsszx14djdd6iny",
+    "tree": "fb3c6a9ea8d56a41bd61e437b8a8997416db046f",
+    "url": "https://android.googlesource.com/platform/external/libvterm"
+  },
+  "external/libxaac": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a8e5fd78cb6d0211279d6db121963497c7f86f8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1lx79v0w7hz1dji55nrlj7l450hp2rc9bnk34r502rb47rawy52f",
+    "tree": "236c2f850d073ecb85f53854c9c64e2a87c3a9f6",
+    "url": "https://android.googlesource.com/platform/external/libxaac"
+  },
+  "external/libxcam": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8d93e483dfeb425da2ba62d66b7f3f438f99635",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17a8qdw3jrrrm52v11wd2f5glamn7y5sr65jg2nhcqjfr6qn8cvq",
+    "tree": "5e6dfdb098437c76176568daedddbd7397a67198",
+    "url": "https://android.googlesource.com/platform/external/libxcam"
+  },
+  "external/libxkbcommon": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d519ff982eca86cd5e6fa097f50fc6c507f43bcc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0yhgr5l3k0rvjm6540l5rsl5x9dzjijhjx6h6isa900h2v8jyjf9",
+    "tree": "3b285c280a21bd896bc723a9ca01dce4d6cc692a",
+    "url": "https://android.googlesource.com/platform/external/libxkbcommon"
+  },
+  "external/libxml2": {
+    "groups": [
+      "libxml2",
+      "pdk"
+    ],
+    "rev": "c3699cb386717dd6eb937b242c5f4008c56befc8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0cvn5cfkj95xzrirqdmhgkijpcarkg42ax2k6q9s0j0hiz6rb7r3",
+    "tree": "0c4abd037bb8409356cb92ff44299a3feb210bd6",
+    "url": "https://android.googlesource.com/platform/external/libxml2"
+  },
+  "external/libyuv": {
+    "groups": [
+      "libyuv",
+      "pdk"
+    ],
+    "rev": "6786583f31a8db5d3d415e61f960b554310598f1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xan6j2havvld8zqja2fscmc09im818m1d30jh31hakhkgvyzw89",
+    "tree": "aee43c081ed8e1bc355272c1417693b719acb770",
+    "url": "https://android.googlesource.com/platform/external/libyuv"
+  },
+  "external/linux-kselftest": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0a981fe9875a88ef04eaa6bccf5b39e95d8d1707",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "012xj35s6gcsfa41cdqx4hz9wd6vfdpaw8gwjrspm959w99fn9a3",
+    "tree": "7332c2dc2c1488954834c763ef1ab381d036fc39",
+    "url": "https://android.googlesource.com/platform/external/linux-kselftest"
+  },
+  "external/llvm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "33f3d93567d9718ccd75f0e83f82389a147e4f90",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "161vfjaqbaddxxcjkd8hlq040p75ymr0vsp1n6vh1qyn4qny6v8n",
+    "tree": "ee8c35c4ddeac07d2de430d3d449aac25f505ef4",
+    "url": "https://android.googlesource.com/platform/external/llvm"
+  },
+  "external/llvm90": {
+    "groups": [],
+    "rev": "6d54722d0e28568469d49c4adad844a8762a5825",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07gd4lra8z1pyqj01vr4igjl91rbj5ibyy29ldrflp6wl17q37l2",
+    "url": "https://github.com/Anbox-halium/android_external_llvm90"
+  },
+  "external/lmfit": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "008e5d4ae55e7e01226395b1ce83a7102cf180b9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1zl32nyjgdh8wcyr7a81fi2d608z361hfq0bp68fly9gijpwaljn",
+    "tree": "33d62720de5c7640a3dc11f29c85fc36ae6c980b",
+    "url": "https://android.googlesource.com/platform/external/lmfit"
+  },
+  "external/ltp": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "e3abe742747e7dae4798cf4781b95d99fe71ce46",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xzj0z05nkrq8rhnwxaf0bklh62r0yzfy1s2f25yz5m92zq3iv3l",
+    "tree": "897d45f2601301b1f5aad20fc783cace1428fa74",
+    "url": "https://android.googlesource.com/platform/external/ltp"
+  },
+  "external/lua": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30f45bebb5a06117b4b28671bd00566a29e70707",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "05b5cxrz5i1pdv33n8jhgsf7gp3399ba0avfqkxqvvb9ykjyr36a",
+    "tree": "139f3fb68499373521983fb31e003e63ff3c3721",
+    "url": "https://android.googlesource.com/platform/external/lua"
+  },
+  "external/lz4": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90767e672439387a933598fb8d8d9e076e9b0c8e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zjcqqn3n02mlv2lqf2zdcdn38b6kn3bs0mqgkcycfqkdwppjj2b",
+    "tree": "dc9bfa4ed6e7af486f62319b1ac3c58f396a81a6",
+    "url": "https://android.googlesource.com/platform/external/lz4"
+  },
+  "external/lzma": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab14e856925c48eda14e32e787b0fd2ca19874be",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "05igg6vc3nvxb6yzndk0zc45l6hj9hfj3qw9vg5shfhp92k1xrdx",
+    "tree": "f2834c84e8da8433a3d2af57ed55e81f2fbbe493",
+    "url": "https://android.googlesource.com/platform/external/lzma"
+  },
+  "external/markdown": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d0c5891688a23f5e23178b2090df27305aa6eb73",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hbqwnqf1pxdzxic81g2lyb5c3a5fgglliqnf4f8b467zxv8py9l",
+    "tree": "e0089b0aab2c906532c589703b9b4515775234f8",
+    "url": "https://android.googlesource.com/platform/external/markdown"
+  },
+  "external/mdnsresponder": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aed05e933d4a7251e1da64020aa37eec03f62763",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1brim7dhys6022crwa5r4ljac95z83kaarcpif713b27n0hj1dzd",
+    "tree": "ad0eddc2ce357f596397ae16e4c4afafb89a1a60",
+    "url": "https://android.googlesource.com/platform/external/mdnsresponder"
+  },
+  "external/mesa3d": {
+    "groups": [],
+    "rev": "f1a6f5c78c659b4296831728a1a681f0da1a1ab3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0f63i58650ixybbds42l04z93d959cj6142rvm11yckdb1bmiaaj",
+    "url": "https://github.com/Anbox-halium/android_external_mesa3d"
+  },
+  "external/minigbm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07b78afd6014638bd25e9454b5c7e8cf687db838",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "151accf53xnm1mqixmdxhizsas0952kfd9wdyd5b8ygvlxabgxms",
+    "tree": "bdb04667e03c2babb3674b86d6aaedcfb0f8ff55",
+    "url": "https://android.googlesource.com/platform/external/minigbm"
+  },
+  "external/minijail": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d744fb847b5691db636af49a3ae7300334df8c4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gcfsyim1krrddcklydqfxl8mamaxgail2xl5qp9yclq60km8f22",
+    "tree": "78e86640c6d23a6fb5e69a659077d9f5d56d5514",
+    "url": "https://android.googlesource.com/platform/external/minijail"
+  },
+  "external/mksh": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ae5f5fa46f734a7976f0d2a52eeefd0e521b5cdd",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "10qmnpk6z0agplyf96mm3lfirazykrz5kxf3fnjzxhval9gj48c3",
+    "tree": "ab87b583fc3a3101bc90dd8ad354f7be7c494608",
+    "url": "https://github.com/LineageOS/android_external_mksh"
+  },
+  "external/mockftpserver": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5428cb417a6adc287fa608f5a0863cc5d7bea398",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0jixlpi74r4h80v62fsxg24h325nqnz4rcq2byh40ifb1wbwviqs",
+    "tree": "543c8abe06803049a317b3d885f475e51885b4b3",
+    "url": "https://android.googlesource.com/platform/external/mockftpserver"
+  },
+  "external/mockito": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac8965c40d05a170ac25aec3e1dd319f6c58a9b3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0yx6qq7arjwi6hyr8dls2a5azfn0arb5zm2b4kbzxfjxpf0gxcs8",
+    "tree": "ac07ec55e5046cec9bef9ba79eef264147087213",
+    "url": "https://android.googlesource.com/platform/external/mockito"
+  },
+  "external/mockwebserver": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ad8cc25fa8194f7bd0d268ed9f2ea74c99e1899",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "14hnp6lggc18b60n61n46mlwrg42xlf96q034cm5y3zvrmms9gfy",
+    "tree": "845eb08db951a06c99fca694cb1b835097d4293b",
+    "url": "https://android.googlesource.com/platform/external/mockwebserver"
+  },
+  "external/modp_b64": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e2a00796bb69d5b12dba4daa9a51bba2939a776",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1n13bb3gz5d5j1jx16sp2fwc927jz1inlfvf6ngglp4cmlvd5di2",
+    "tree": "c59b7d18b0f5c5194a8e2d5ff24920f8c278f238",
+    "url": "https://android.googlesource.com/platform/external/modp_b64"
+  },
+  "external/mp4parser": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e64f681e06c0a68e646b7530bf8578bff92a9bc4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i7k3hg5r9hqnfnn761jhqnwdkap5iwrnxzaa014raic3h332xb9",
+    "tree": "121b1728c02d0f324f0b9bbcbea4cbb118bfbbaa",
+    "url": "https://android.googlesource.com/platform/external/mp4parser"
+  },
+  "external/mtpd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4e4843d92734ae6e33d2acc9bf5607a470fdb37",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "152shavl578j7vmrgkgnlwq1ycdlbg1w2w5p3253ixfdx58z0jg5",
+    "tree": "5116604d4b0e995537cee174d9174a650307691a",
+    "url": "https://android.googlesource.com/platform/external/mtpd"
+  },
+  "external/nano": {
+    "groups": [],
+    "rev": "ed50c9df69e00e0dc142c7e04474463efa73f5c4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07bn21k0wjh46ishk1i1ak52bkdcamqara33s3m3q32vvanvcihn",
+    "tree": "5d6cdae1b8c0c921fbb182a91418e3c19ceb0845",
+    "url": "https://github.com/LineageOS/android_external_nano"
+  },
+  "external/nanohttpd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "54ef2c493ef43b3ec938a273eb3f964d9009c3e3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1sqcvhfjshdpyjfp912yklbr98ndrygs536pbc7n6dzaf8gzfpam",
+    "tree": "5a49bf1f2dc7017bded0a31658c22563ae37ea8b",
+    "url": "https://android.googlesource.com/platform/external/nanohttpd"
+  },
+  "external/nanopb-c": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ed129dfffa8ae01eb013078299707dce6eb6f12",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0j7pda7fvc3cfkj92a6a5gh1jap9paa8qc9a4swbbaxjzby74r42",
+    "tree": "af8f6a07ae5d5f42243e5a9821fd88d12906e936",
+    "url": "https://android.googlesource.com/platform/external/nanopb-c"
+  },
+  "external/naver-fonts": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a6edaf0428af95aaea3ea5ea712060e3cb2f6d0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0di075grackq1205qja8j8bfywwypyqc81sk905yf0c34ry5rv86",
+    "tree": "4190d2d4418689e137cee39b4fcf811ba409a1a3",
+    "url": "https://android.googlesource.com/platform/external/naver-fonts"
+  },
+  "external/neon_2_sse": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20348f18496a686d6a8de237cdb8d4157aa3141b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0c3qb5b3588xiz1hq808jyh1sir6qpfim8hinj9qvblmcb55bi68",
+    "tree": "1123cf6d846d3f2e5508045943f7e88645fad79b",
+    "url": "https://android.googlesource.com/platform/external/neon_2_sse"
+  },
+  "external/neven": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50a98264b98bd62ac3224d7f68de4e7bd141a0a9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03c7hxy0h5lsv3l11k73n8dkr1nda5f1dz5cjkprv1m3xs7k8hp5",
+    "tree": "f3d6d8aa7cd9c560d8a9d1ebef0047565e232b73",
+    "url": "https://android.googlesource.com/platform/external/neven"
+  },
+  "external/newfs_msdos": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "464929284c562276186bbac035b3397c8c077af9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i0zgbqzdgn7bv4yzn1a0bk9zaykq2zd0ch31420zx58dpmp3fjb",
+    "tree": "eb302387d49252c0566ec0c67293de630faf97a8",
+    "url": "https://android.googlesource.com/platform/external/newfs_msdos"
+  },
+  "external/nfacct": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e9ba79535c3e3259a44a310268d46bd9f87b6ffd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0v7bxw6hcxrgrj7lay64sjr4ybcf1nmsdbf5pzcz3wy5d83cal53",
+    "tree": "104c818c31a9577b2441f7a190fd949880aebb3d",
+    "url": "https://android.googlesource.com/platform/external/nfacct"
+  },
+  "external/nist-pkits": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8906155386e6827a0f0707e905d8f4ce759ff88",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vj52aaks7gn78904qr5h4xhrhcpxlal0lsv2zg9c16gf1sb8dc7",
+    "tree": "371c55699313b1edf29efb0f53c750f04fc022ee",
+    "url": "https://android.googlesource.com/platform/external/nist-pkits"
+  },
+  "external/nist-sip": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b97b10da8fff8a2af2a28a8493638977fd7ccec7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1d7n12gpk7ln4hv74lijw9klxi8mi8bckwxl859751wwdp77860r",
+    "tree": "fb9cb53547506257ab5cf5027a896574c8ea49d6",
+    "url": "https://android.googlesource.com/platform/external/nist-sip"
+  },
+  "external/nos/host/generic": {
+    "groups": [
+      "pixel"
+    ],
+    "rev": "36377cea8e317a16a488082360d684d07a7d5204",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0fa0qfxfymb8lafhizd9wl4cj820lk7ycz8w0psq4x94z03njh4z",
+    "tree": "5580531d461e36047e4655531aaa241b3515f170",
+    "url": "https://android.googlesource.com/platform/external/nos/host/generic"
+  },
+  "external/noto-fonts": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fec2380d41df0f9997f38bf2f5b633a5e52ac8fa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "030y9yskj8xid5g3hv90g7y48r0wj0sarhjdn8wgi7cpvaiscg7n",
+    "tree": "72ad0edd8328100e2814390ebd0b01c5e5e76846",
+    "url": "https://android.googlesource.com/platform/external/noto-fonts"
+  },
+  "external/ntfs-3g": {
+    "groups": [],
+    "rev": "1baaa4bf5a7c98ffe7ddadf9ff467815b787a33f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "16b8ajvc2b5p9lw147594s4qdf163x4gx9mqdh4x3wqmjj8hi9mm",
+    "tree": "16670419f074923509c10f3b008f21e64f892595",
+    "url": "https://github.com/LineageOS/android_external_ntfs-3g"
+  },
+  "external/oauth": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e10c640c3f1df1b856882ec739a3e5857a8c5ec1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1n511p39ffl6yr6wwj1zy0qxmmyvdbydy1q2kfgpacdk4pzbbc07",
+    "tree": "f0e411c6d18d77c327031ff9e5d406231ddd4203",
+    "url": "https://android.googlesource.com/platform/external/oauth"
+  },
+  "external/objenesis": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7624d91cfbd2b13ca10b8432b867b9e6295dfd47",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0fwmixzqvycc7v6cqj71f56140bpnx2g7p1hgl7pv6bmb97i57sy",
+    "tree": "6154fa784c957714e1c9d88238054b22a6488519",
+    "url": "https://android.googlesource.com/platform/external/objenesis"
+  },
+  "external/oj-libjdwp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d605d85e824f00ff4b91e2857c321cc1391fa53",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vf8x5qsajsc8sklmhzi8rx1nnrcfyvkkz4fnp8v4p5fh4yi5fn2",
+    "tree": "87ddbb09d7e1a3efb234579e7205e501044cd972",
+    "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
+  },
+  "external/okhttp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bab99db23421829830b1a5cff4153beeaf1f6c22",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "16n865zmjwjj8bbp4n7kg6ibiwl36g2d997qyamf0iqr98khclw8",
+    "tree": "f4dd39df620dcc3f33cc1968fcd922f455c7180d",
+    "url": "https://github.com/LineageOS/android_external_okhttp"
+  },
+  "external/one-true-awk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c0d6a227846d70b9280f8d3b33c29a1a90dabad",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "136jk749jrpqgpxlv1x2h9bqk0a8qadc8cds62w6r1h00mi1dzwh",
+    "tree": "f6307e79932c3a0088655ad69bf40daf26910e04",
+    "url": "https://android.googlesource.com/platform/external/one-true-awk"
+  },
+  "external/opencensus-java": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "73535a38b8a0da9d74ee4810a4676bb579f9a16d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0mxas67ywp91h7isswcyaczzv0h1rdccn9d3w8jf215lm1c1najl",
+    "tree": "4a8ed8adacae521aa3c80938288b1b3926409907",
+    "url": "https://android.googlesource.com/platform/external/opencensus-java"
+  },
+  "external/openssh": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a2824afa6b93c043aa239a77d2cf4f646531b93",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1by72x5qs3w3baryjkb5ijqaw0f42vhhf6zcv5rn4d6pavw9rfqw",
+    "tree": "0d6e1d78b12772282baf0c2397ad5a4a0aa0dcde",
+    "url": "https://github.com/LineageOS/android_external_openssh"
+  },
+  "external/owasp/sanitizer": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "187aaa25699df6a113076faec6249905b3ace9bc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xh9r1nzp4hcj94fva563iyxwlhki405yv77q5kbr9r3w7f3s6vl",
+    "tree": "9276b43d852b5e65095ddf71a28bcdf51f7728c6",
+    "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
+  },
+  "external/p7zip": {
+    "groups": [],
+    "rev": "6f674e41e9e243e24e8e334f0db15a325a03b35a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0a4y8cj71gx0kfb2wk49d1f13kaybsjp2apz740kic0vd7qrvgl3",
+    "tree": "241c0453c5514d69abec83750c215d8fe3bbd9e6",
+    "url": "https://github.com/LineageOS/android_external_p7zip"
+  },
+  "external/parameter-framework": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f69cad475b33abfb15d14d0e7a5ce331a18eb2d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0472571rg0pz6vbm6sx02182zzm064phjjjg2fn08x15k7xqa8vi",
+    "tree": "3f4adef7bceceddd7d7ccdcce6f8b25e903172f8",
+    "url": "https://android.googlesource.com/platform/external/parameter-framework"
+  },
+  "external/pcre": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5e7650fe7ef3cd3e5608c72913cc856da6c6d6c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gxmfrbww0r3kwa4yhvhh2ycya12q9fk2lp2jfi31m7yvnjhnvl1",
+    "tree": "e73719ac6eb3178b7cde375373cbf600f2c20aea",
+    "url": "https://android.googlesource.com/platform/external/pcre"
+  },
+  "external/pdfium": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1da5c3596042af585734840e91b13b950e419b2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1l1f9a88v18cc1jwxvaabhphcvmz7p34cn79l7ln3lkdlxyn8vbp",
+    "tree": "b08b5d43821500b102c35bb8ee671ac6001e2f5c",
+    "url": "https://android.googlesource.com/platform/external/pdfium"
+  },
+  "external/perf_data_converter": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe6b66434657c85c70376075e413f09715afcbb3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1zdqnp7198i4dwzvjq7ncgk7szgpccqwzy3jz133sn4rychid3l7",
+    "tree": "6a238b1f31ce3516ac8687710dbda39711e7111e",
+    "url": "https://android.googlesource.com/platform/external/perf_data_converter"
+  },
+  "external/perfetto": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9d3d267b1ab7e80d58ebf5578c3e94dc4724ae67",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xcj4hbnbzdiyyks1ml4fgp8d0i09m6m4zqfbfkyaw2233nn6zs3",
+    "tree": "6620825e0cbbb22e90e86786a8244b894bca9e81",
+    "url": "https://android.googlesource.com/platform/external/perfetto"
+  },
+  "external/piex": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87212fefad6456e8fba3f626ad99b8bad323fe5b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1n2irv73sbz1fl7zl895lddnwwc454mabp2fs4n866fqbhpvfys1",
+    "tree": "69d70cd6ca10fd75bc1beb7f2e27db81c08a4938",
+    "url": "https://android.googlesource.com/platform/external/piex"
+  },
+  "external/pigz": {
+    "groups": [],
+    "rev": "b825616338a219976c6e7d8a31b474242bb6cf1d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "09lb0msnm52rgycgqlnwc94qvczlvx80f2xvkk7gh2jw2apjnw0q",
+    "tree": "e31e8c12ab93ce539873c6fbeeb5fa6a5c92209f",
+    "url": "https://github.com/LineageOS/android_external_pigz"
+  },
+  "external/ply": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ba22dcdb3f4c4d14685cda1adb8f3a450f4cd26",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07s6wb7s5cxnlhr5ij5m0xh6v78677sw97sv4a2y9jh84ibm32d5",
+    "tree": "e6afa9ffb4ce3225cf6d0478c7876c26292e5375",
+    "url": "https://android.googlesource.com/platform/external/ply"
+  },
+  "external/ppp": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "932c8eaf053135fc7a43851039710e51743a961f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07ygl5iimrc59155zq5g2vz3j5rb01v28s4ag21nijd33yn85qzg",
+    "tree": "5073d2e02f20c674bde17f71bb4077956d5f97df",
+    "url": "https://github.com/LineageOS/android_external_ppp"
+  },
+  "external/proguard": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "054d3bd8d1db965f3ea1899499a9cdd86223cfaa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0finj53hjz22vplhxvwwvzpjb0vik1vdc0w0gzrlwhl314brk95d",
+    "tree": "6fe7bd12f6ddde06f9d196d4b71cdb7e9e303a1f",
+    "url": "https://android.googlesource.com/platform/external/proguard"
+  },
+  "external/protobuf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3df5d1ed068c2cd1517a5448f5b3b79bb7aa560f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rc2kqc0306zgnli6b8i8pif0zgy2c6g4h2gqrhgpaijlln2k1zs",
+    "tree": "319a18bcee1689daad880e62848e306a0051eb34",
+    "url": "https://android.googlesource.com/platform/external/protobuf"
+  },
+  "external/protobuf-javalite": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42c011b4e57b0ca651251ad7061e5cc100684ad4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i152bk89d1ylcc60c7am92rass35jd4gbpg4wf24yy4mfi0f1ix",
+    "tree": "5b59afb69d7e9cbc5dd34fa8dcf98276bcc9ca92",
+    "url": "https://android.googlesource.com/platform/external/protobuf-javalite"
+  },
+  "external/puffin": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c1be17ed305694dc8c53c5ef0ea742e17bac7ca",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0k8v73f7yj8ad6cq11k7l1vqk7xdk1lncbl2rq694zfpjbi3xkpq",
+    "tree": "40285823a35f14791bfe177f751433b7d6f1961e",
+    "url": "https://android.googlesource.com/platform/external/puffin"
+  },
+  "external/pulseaudio": {
+    "groups": [],
+    "rev": "c680b1eec38d618062c0e903cbeacda37297a0b2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "08cd6k4n71vrnq9pnwwphg9wf3qayndh8kshg6h34v2mkc42m9nr",
+    "url": "https://github.com/Anbox-halium/android_external_pulseaudio"
+  },
+  "external/python/apitools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20e415753012140e28744152daf63317eb746c7e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "04l2zl3cl5pf70v0c66v4dj4rn61zagpvj4cs15g212yd8ffbrii",
+    "tree": "eb72bb18f1e5fa3213160dc0c947f5875d18f5dc",
+    "url": "https://android.googlesource.com/platform/external/python/apitools"
+  },
+  "external/python/cpython2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ea270ec00c3284aa6380c19e39dc78cac096854",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15hgr5qjwil28i04jp7ybfqyx1ilyhcw9srw7wfa2mc8dwy6lybl",
+    "tree": "36d2f9f04ddb1cbdbb5f04e71d34c3d14b3598ee",
+    "url": "https://android.googlesource.com/platform/external/python/cpython2"
+  },
+  "external/python/cpython3": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "82907ba75987e0a3de96e9f1116355fe9003e6d8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0dm4fk4b1saidg4sb8a9q8xv0qpaq2kck4m161fbwblwn9ak7mf5",
+    "tree": "92c86761a978ab9662836dcc339b414228795218",
+    "url": "https://android.googlesource.com/platform/external/python/cpython3"
+  },
+  "external/python/dateutil": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21fa1c2d8e87f4f8f047e4a58bdc3ff445fbca27",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "02yj3m87c7h24r5n2kjj44zy3mzxviikj6zxmj15synnij6yh81l",
+    "tree": "2073a39eb16886e63387b73f4095eb364df07402",
+    "url": "https://android.googlesource.com/platform/external/python/dateutil"
+  },
+  "external/python/funcsigs": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df9ce6cf711a9bc7df9120abf45656486f47e4ba",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0r41sjzzd4avwf44wwwc1r678q286sjhdi1sywiibyi5i487rfmv",
+    "tree": "fd6ba7e8c25d9ca69a62b6ea2a973dbc0992bab1",
+    "url": "https://android.googlesource.com/platform/external/python/funcsigs"
+  },
+  "external/python/futures": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "cf37c37c33c8feaf87b6a46501078bab11bb1185",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0wcvnm1g97gw4vrxaf4jbmbpp7m2kvpxcgl66a3ii5fsm70a919x",
+    "tree": "23012154c0fc5e77140af3cafd4dd423ed62c4e4",
+    "url": "https://android.googlesource.com/platform/external/python/futures"
+  },
+  "external/python/google-api-python-client": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "ccd04b277f917bf97d5cd7e787fa438561072f33",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0adlb40ffq189g90a1ylmx695i8nhx28lz183prc1hpkhgc5ikh1",
+    "tree": "80d1fffb4a67be0a02547f1466a2bb698876b010",
+    "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
+  },
+  "external/python/httplib2": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "805cc5c05b03be9f498141daf4ad55ee980baee3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07ir9c4fd9lp8qx6zdmiglkbv3h7cbjwpx1p64h8db5nmb853fq9",
+    "tree": "8d036b85bcd46a445ab961acbea273539d570980",
+    "url": "https://android.googlesource.com/platform/external/python/httplib2"
+  },
+  "external/python/mock": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8bb4a31103284453eb9de436bdeb83bcc6da6129",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0w92dgc4mbpjrmwrylxxbyl4lb8s3vlhshcq72njqvspwgi6sb7w",
+    "tree": "c061d953718c1bf111d4cc7cfd9276c1eaffc565",
+    "url": "https://android.googlesource.com/platform/external/python/mock"
+  },
+  "external/python/oauth2client": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "614336bd1209152e21a6c0f987445eacf5874501",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i1w9fkg1rk2m1xslcwdahrk52hfc9i7m3l5z67f4l8gpgf166aq",
+    "tree": "d6f6d35bc4ebafac9afbff1ce1bcd4067f24875b",
+    "url": "https://android.googlesource.com/platform/external/python/oauth2client"
+  },
+  "external/python/pyasn1": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "e6638583fd7bf30f99c58e797c0c1e9dd0472025",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1gqj2gsjsbdl9dkx9425v99sy6c4vcmhn1smyd26qayrhdacqppi",
+    "tree": "d18cc22876b952c6451a8808b3649efa597a3f5a",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1"
+  },
+  "external/python/pyasn1-modules": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "15eaa2c217e04f7d59be82d3790eb611750825af",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1zz0q4rj6rb3lfwjy78afnzf3xb4yffsamqfm95qyk15qzfzzbn2",
+    "tree": "c20f3284dd456cb13b8ea5842d8d4c54668187d8",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
+  },
+  "external/python/rsa": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f1b01db81d432aaa5bc282e5987dc0752bd9b6e5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1v484mb5p7h0ndl097ckh7l8321n9qc05s1a5hpc9qijr74h74qk",
+    "tree": "3eb572c3ebc62886710867852e6df4e336e9bab7",
+    "url": "https://android.googlesource.com/platform/external/python/rsa"
+  },
+  "external/python/setuptools": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "dd4555b34a35f2d17b083ff8ba952cd610e10b11",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0307dfbr8bs94074cbflr0i8nq7nsag3db0bgv62m1nm0f85gz2v",
+    "tree": "921925f8846b448aa04abd890c99aa146cf1b213",
+    "url": "https://android.googlesource.com/platform/external/python/setuptools"
+  },
+  "external/python/six": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "8247afc315ac6fe17054b841ad4da670cd86dce4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0c9laakciia7cdd1z4w2ml59wss8axh88xh7lfa48w8qlzf6hra2",
+    "tree": "cd138d698e587959d76cf10a02a632535ce359a6",
+    "url": "https://android.googlesource.com/platform/external/python/six"
+  },
+  "external/python/uritemplates": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "df9d93bf020494e564d1545ccdee53d37709e3b6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1cr281r7cmyyc9rv2vyzpsa3lxrygfwwwl0xmj4fxmsnjs5jpba6",
+    "tree": "4b7488e57b673278be19f6329998303066b0d375",
+    "url": "https://android.googlesource.com/platform/external/python/uritemplates"
+  },
+  "external/rapidjson": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c27e5a000b088ffc25617edff5c7e6c51369c73",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/external/rapidjson"
+  },
+  "external/rappor": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e9a2153c0e926ee4c7b24ae3647a8c9c671872c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07xr4254n0782dmp69gw7d5hvlqhzkswq48akkyllyk65z32321m",
+    "tree": "5b9ab3f02d73297c500224125f9cc44ffa60eec3",
+    "url": "https://android.googlesource.com/platform/external/rappor"
+  },
+  "external/replicaisland": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "58c7525ddcce2b559dd515e446b96fd17b405d2f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1kjb8n3f8hyxz6r19krknwpy1jads5f2bwv1ygy5cyllbwc13wnc",
+    "tree": "c5cdd47d9a7b4d2c2aa043433ccc3c57b1c16c26",
+    "url": "https://android.googlesource.com/platform/external/replicaisland"
+  },
+  "external/rmi4utils": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f06dc0bca220be959cd9c39925e5dce02e9fd18d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1a8qdawvm25b0sk9k08fdciha58dsgk54dnbmicfv00rxirh6whv",
+    "tree": "0f46155d25cc6e87cebe961c62b4f9eb877a3cd8",
+    "url": "https://android.googlesource.com/platform/external/rmi4utils"
+  },
+  "external/robolectric": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5fc2ea3d17387efbdb19cb50dbdadc65693d4d58",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17h1lyga1i993rqhq5yhbkzr826da0hgkdis82q6s5pwy5hq7qxr",
+    "tree": "e92fc97557a41e588b5cea6e8c4a3552e2835bcf",
+    "url": "https://android.googlesource.com/platform/external/robolectric"
+  },
+  "external/robolectric-shadows": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6828493c746b2f03ac4412ed1c7d8fffcd3819f5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1nz74z8wlyd6hnawla4pili0fndbkp7l93rqlsr6bfnmniskkmpk",
+    "tree": "4ee73280935c77d5b6f6ed740e259c0299e58b72",
+    "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
+  },
+  "external/roboto-fonts": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef57d56adc405314904374d214db2dd33b2fac04",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xz3fsjqf4szch21z0bn8f0i16gamqxn9wirlfrv1ma2a1qrbm66",
+    "tree": "db1db5dbde404b18cb41900bb94e2e600e2368a1",
+    "url": "https://android.googlesource.com/platform/external/roboto-fonts"
+  },
+  "external/rootdev": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f7de445c4f30933f4a3cb5c66098f4054cc7ebd8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1isb5hays0mr9g7zn1pgsc71rp339ica8kyqfcfjfm40643smlv6",
+    "tree": "c885f21bc507fccc4212369d30eee99e9eb66413",
+    "url": "https://android.googlesource.com/platform/external/rootdev"
+  },
+  "external/rsync": {
+    "groups": [],
+    "rev": "48dfa96f43aeb3d1fdc1a910f4dc7fc86b66bc9c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "057m7n6w2160ii1i30k3spajm87pbybi6x6ch7p4qxc7gzr6k4wc",
+    "tree": "ccf69b6f8a784b9b8bee28b61175e05403c20cf9",
+    "url": "https://github.com/LineageOS/android_external_rsync"
+  },
+  "external/scapy": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ba0c091662488554bd3314c69d026e35673138d5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xw5rq99pl9m6fm0qxmdacl2d44lmc0ijmqdyzxjs1q4sqh4cnap",
+    "tree": "61190f5c0312bc87ac325f4b5a9a915a4ddce70e",
+    "url": "https://android.googlesource.com/platform/external/scapy"
+  },
+  "external/scrypt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df85dcfc70423cc23237d3ece514e33349544b26",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0bbkbpx0567x88ypw15z3yr1nyxvmqjqwii491hg9g21694fyjgf",
+    "tree": "6ddd82161b799040c3ff268a6df1b2afe034eb99",
+    "url": "https://android.googlesource.com/platform/external/scrypt"
+  },
+  "external/seccomp-tests": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "679bee6275635b962ebd6cc484ab97291f4b81c0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0cg775kxp9ibnlwh62fb1gxlf58dh82g2n3swdsll7gs9s6d48q3",
+    "tree": "8b3347f02c831a09356edc014abbf34a742a901f",
+    "url": "https://android.googlesource.com/platform/external/seccomp-tests"
+  },
+  "external/selinux": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5137b7db929672532b4cd7810704ec4e2d61df1f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fvlcb85ifr2lr90jb5mwk8gh22njpflc1lapjm5wm8ghq1vx7zj",
+    "tree": "6001c8cef0b48ede5e025a14fdbf320525a95f3f",
+    "url": "https://github.com/LineageOS/android_external_selinux"
+  },
+  "external/setupcompat": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "592ae5c2ec629a612e077911cbb1214f773e2616",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1j4d6zxnsrc2lm0dnzy43y60qy2ihd6kpkrp39gf26a2ihjpaa77",
+    "tree": "8933cb50c96b08d25227fa65d70b55b5e825958e",
+    "url": "https://android.googlesource.com/platform/external/setupcompat"
+  },
+  "external/setupdesign": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15010d32b7037b3334240d2fb38d6d7db46ecfd6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ipx8r1wk2783bs1fqzcag0rbfr5f88wwjv1fdvszv865268srhl",
+    "tree": "bd54c8420d669e3693d4b7cf54f5d757392b71cb",
+    "url": "https://android.googlesource.com/platform/external/setupdesign"
+  },
+  "external/sfntly": {
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "0f3d65ad50447aea0e7adad0fc2e2aeab9499982",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1n9b6hjrgkpjgk563m84lgdalq3b1gh9vdkh2z38s0yfz6yvrlbc",
+    "tree": "1aa83db6bfd3b223f4503c4ee2cbcec39fcfdc46",
+    "url": "https://android.googlesource.com/platform/external/sfntly"
+  },
+  "external/shaderc/spirv-headers": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "967c64d166afc5dacd49d3dc5236fb43f86d8ea9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gakc7gl4g9qkh6b3130x206mi3nkv1ak4brfgq3h931zvc3x5fl",
+    "tree": "ee23328ebf0a66b35bd49913b95cbffeb9c9d535",
+    "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
+  },
+  "external/shflags": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c15d7c0d6ee0461c6fa2b6c8602ec18aeccec7c1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xr0xpyd5n8xrmnj5plv9akcik4df99gm5hi4z87bqmwimahzxv2",
+    "tree": "77d6fe3104735b2ca1f85f973498d35258edb464",
+    "url": "https://android.googlesource.com/platform/external/shflags"
+  },
+  "external/skia": {
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "3e76a81b2bfb520e23d060801f2aa97927e4f162",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "11wg078q39wq2j1jaim46bwf75z5hfl9dv69rfb8xdwr9234n0nm",
+    "tree": "5f86ac097e2846edf0e2430b44270148e8716a39",
+    "url": "https://github.com/LineageOS/android_external_skia"
+  },
+  "external/skqp": {
+    "groups": [
+      "cts"
+    ],
+    "rev": "46c0bb864f2674c17ae01ed5f27a5ba6b526c549",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vqhzg6a9v8byxcaqx8l53q9grr9rwryf145ppa0lqpc032scbib",
+    "tree": "cfcc4a166b3da6b20fb8fcc406731977e9c1ff25",
+    "url": "https://android.googlesource.com/platform/external/skqp"
+  },
+  "external/sl4a": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dac16aacee2bc9f2095b49a54ed8c696a211fbcf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12m1ixd2i2hhy6c3azvqka77lawa8jnr56sj6z8wwyrjjpyrkzi1",
+    "tree": "d8436dd3adfb017f9152b400b74e104f9c594367",
+    "url": "https://android.googlesource.com/platform/external/sl4a"
+  },
+  "external/slf4j": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af2143aa56f2bc0e361bf460d6099bad0eefcff0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1sr2i0isszh7bndb48ak6kl8n11rlhvi28b090nqkz5dvpiy7nln",
+    "tree": "4350563157199e968dcb97546b8a0386ae3cd1d8",
+    "url": "https://android.googlesource.com/platform/external/slf4j"
+  },
+  "external/smali": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19a6e57e9417ebc227785245e101f540ec088492",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "147l1966cpyvpw7cwcrq12la08py8jn8n7bps3nq3i6ilvn7hpgb",
+    "tree": "e6285228b769295b8e1f6ec6e469cd3f74d77b9e",
+    "url": "https://android.googlesource.com/platform/external/smali"
+  },
+  "external/snakeyaml": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7252296ec37482aed0b094f8f4708aa2e2aea839",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lidxs6v60is67089fra7cisyy41f0qv21kh9clwr54p0z60wmfc",
+    "tree": "3f2a91bdf318dba2888692a931f1f3eb34f8cb0c",
+    "url": "https://android.googlesource.com/platform/external/snakeyaml"
+  },
+  "external/sonic": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88bc160a23ab64a98dd408ed697506b231aebc6f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1kg1hnm8zr38j5yy72ncl4qks03flhcr4ryabcwllhli4zdvr3nf",
+    "tree": "a4bfead03da3e6b103c44e93a6d36c2e6ffd9651",
+    "url": "https://android.googlesource.com/platform/external/sonic"
+  },
+  "external/sonivox": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d4b36df364d250df2613b14e5d651ba439adbdf",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1yrnlvhfi31xp586nmqf4g0k58g135aisylv531a89zp1nrvasji",
+    "tree": "95595d4183c67871e4a09bcef6a1815800a45a22",
+    "url": "https://github.com/LineageOS/android_external_sonivox"
+  },
+  "external/speex": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9cafd683db8927afcfde5bff5e162f352f519059",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1gj5sdbqm4n4p8g8ii7q6j6k1nkyabnjs5hggabxy8b6nq3y35jb",
+    "tree": "9a5ba7f97635093d8c8398d73e527ab9a088f463",
+    "url": "https://android.googlesource.com/platform/external/speex"
+  },
+  "external/spirv-llvm": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb09cec8a37cad673d821cdc8daa2a1ec34c260a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "152lqagh6jhdhlshpnvwriwfnj3mzdldg1hn7q7c64s7mpcjh44y",
+    "tree": "eaefd672e595b6612dfda7bda1abe4a176d46212",
+    "url": "https://android.googlesource.com/platform/external/spirv-llvm"
+  },
+  "external/sqlite": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b7ad53cfb08a679968d9a5a978fde765493976b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0sn3f5bpxw1akvq7jb6858ay10nn4i9r7wqbiqf06qcw9lr0yldj",
+    "tree": "128f8026d34c7d8d76eaaec8ec400f8f46dcfaa8",
+    "url": "https://github.com/LineageOS/android_external_sqlite"
+  },
+  "external/squashfs-tools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddca6997ed69f4e5aae55f9127361683edf8c2aa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0r99ypdvmdqnn2i92pxh017ffb1xinqxkbfgy07adhxbri3xnz60",
+    "tree": "111f013fb5b5afbfec783efb87f7dc1fd88141ff",
+    "url": "https://android.googlesource.com/platform/external/squashfs-tools"
+  },
+  "external/stagefright-plugins": {
+    "groups": [],
+    "rev": "1c9e395958225f06a7f47353913ecdcca4aebf83",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0yxk870j15j721dahwk37v5av1wy6hkaxmj7mrjwbq24shf0rhgi",
+    "url": "https://github.com/Anbox-halium/android_external_stagefright-plugins"
+  },
+  "external/strace": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ee282cd148f4ba31252ee719377d3e9beffde61",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1sq35pfglpcjzhbdfmrmqm7maagwg1xdy92p1iw1k0acmp6cmid8",
+    "tree": "01242584b2c178a4029bad3070419885b9a5de35",
+    "url": "https://android.googlesource.com/platform/external/strace"
+  },
+  "external/stressapptest": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efa415778a0f48800e4605c168a57001fbc67746",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "187cqafk2wm2dxx624bncr36qqrdl9zca9rbz2z7fgcfcsllhgna",
+    "tree": "21847297eca51a53a742d90a6c79498b9d36292c",
+    "url": "https://android.googlesource.com/platform/external/stressapptest"
+  },
+  "external/subsampling-scale-image-view": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef967664e1327fe595447c1de863b4692266ec0c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0j5sm5fl33pr4ph059kmpk1dh6h8z8vp612kbm76fidp35krsf3l",
+    "tree": "fea66d74c8b32d168fc354d281a68937c582a928",
+    "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
+  },
+  "external/swiftshader": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d24c4a14335118f2391d6f5ca6b8d60d9b8f9562",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07apwcrvkmkv14dbfjgywvn1w2v30njr5nakaxc6wg2slsa2a2y7",
+    "tree": "9eeda5851e70620197ab8e3110ce44b94f2b5f19",
+    "url": "https://android.googlesource.com/platform/external/swiftshader"
+  },
+  "external/syzkaller": {
+    "groups": [
+      "pdk",
+      "projectarch"
+    ],
+    "rev": "691bff3fe63085065a9161773278d654cf65f9f6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "08a4vywf8vzvslkbvmzkh6x3ggjiwz9zcw3r5cfq78h11n2l1ppf",
+    "tree": "9bd4ab79a9fa780681b021d9aa42d817d8526d78",
+    "url": "https://android.googlesource.com/platform/external/syzkaller"
+  },
+  "external/tagsoup": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "840e2b2caf6f8f66e8ae9e7e35ded732d5c4be11",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f47ha19zgbilc887p8fg3dyqfynzqzyjkqi25054c9zw94mzsa0",
+    "tree": "25a9d9d04c4c4de5d0ca26c77c38d611d0623ba4",
+    "url": "https://android.googlesource.com/platform/external/tagsoup"
+  },
+  "external/tcpdump": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "27fe2b94a8e65b7c2a215f7af40cf5b7f01da9db",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1ig0zh4qrhcbfi9ny547q1pm2pdb7ba2fp65ib9xqids0m8xm73l",
+    "tree": "e0cc5a3dce451d70abbf50b2f59147c7de8677f6",
+    "url": "https://android.googlesource.com/platform/external/tcpdump"
+  },
+  "external/tensorflow": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b532708c2f151e4e74643d1e9f4bda32e9d390f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0kmn96cr5w4003pm86z24509nkfpsdjhw7h7kyqhcricb0vg6ln8",
+    "tree": "96dae704c8baf3d3ebf1686c7adfdcd9d34e42c7",
+    "url": "https://android.googlesource.com/platform/external/tensorflow"
+  },
+  "external/testng": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bec3e4ffb0fcf8b43725ea29db1ad33f9f297681",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zrq9smgs5lsbfdpwjd7agh08bzhhhsnk7x5b93cc19hgv5xkk74",
+    "tree": "dc71046e8e6003a7338233f66a0e74d760af5247",
+    "url": "https://android.googlesource.com/platform/external/testng"
+  },
+  "external/tinyalsa": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4b3a6d4dd962994e595ae6f8fcdcb5d77a3c6b0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1nlvlrc5gp0dsfnv05kwmw7fgw33n5yik20h82hjbsy9if2i8k9f",
+    "tree": "6ab8000ed993fe6c0a408e5354b1b94136df1c18",
+    "url": "https://github.com/LineageOS/android_external_tinyalsa"
+  },
+  "external/tinycompress": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "848ec3ad67cc414294d18776a2b4d644be95fd64",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1hrbas539gy7zww42z7yawp2gasyfkbk5ns69db34pji1x29k7rl",
+    "tree": "a1170716481370369a807ad1a6849effa870d643",
+    "url": "https://github.com/LineageOS/android_external_tinycompress"
+  },
+  "external/tinyxml": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c613f53c8947ac03a169e79f2fecb12736520625",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0g7rj02x85fnm9jj5zxp2q0b67191k1p201ahxbnib4idbp7nd0q",
+    "tree": "284c06163054f0f08570f72184c9a213273f9106",
+    "url": "https://android.googlesource.com/platform/external/tinyxml"
+  },
+  "external/tinyxml2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b204df64fd1f24634bab549b6c535fb4a215a1a4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0bwifhpnpxr4zzqnva574a9kmkzn4qhafgriy94r7kw0d8dgzchq",
+    "tree": "dca69ce04ab6e3aade602c286fbb2b360762daf2",
+    "url": "https://android.googlesource.com/platform/external/tinyxml2"
+  },
+  "external/toolchain-utils": {
+    "groups": [],
+    "rev": "cb301b4af4551646b9eb1e2c9ec164e4f3b87b31",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0fqhvlr87xrjbi554cay837n3mmrlsn6h3xr3rjign4rzjkigjdq",
+    "tree": "220a95d346d58fa5090d8033991bcfef2ad03d99",
+    "url": "https://android.googlesource.com/platform/external/toolchain-utils"
+  },
+  "external/toybox": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7798eee1498aec3cc88f881454485316cb11171",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "06q5cvg1zhd3xdmffkr5v96awjnrhlyp31f5q77qh849szykr9li",
+    "tree": "0421001ccf002dd3e9026468667cd033ae50209b",
+    "url": "https://github.com/LineageOS/android_external_toybox"
+  },
+  "external/tremolo": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cbd3bc4c7b6caf1e05c108ad537b44859ef0c6f8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1r3jkd6yxjq5jm0wb9xh7a9mdsnv4fmh4yhhm8v6nwygwszy8vgr",
+    "tree": "57450390cce9308a455e9d877e979a8ef4783dd8",
+    "url": "https://android.googlesource.com/platform/external/tremolo"
+  },
+  "external/turbine": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a765ce87ebe2fe72c8209871ee96920f19857c52",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rklvgv399vdd9kkzm92gq2k6jr8gzgvlhx4778wrnz805j5kg51",
+    "tree": "b2ee86bc6a2a57af828365a0e34bc1b79f6bf756",
+    "url": "https://android.googlesource.com/platform/external/turbine"
+  },
+  "external/u-boot": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3dbfb1a9888ccaddcc03e3dd2a30ebd9ab2f0bf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13q2l94q2dhkb12ksa03h6fwlgn1r47y2wxvhp2dq6pwid51g5n1",
+    "tree": "0640d4e16c9dc9fa022e1b2b4e97edaa354ce37b",
+    "url": "https://android.googlesource.com/platform/external/u-boot"
+  },
+  "external/ukey2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "751f862a9c34001add26415de9d7aeeb3e3612cf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0npbqb5i0rwwxiiqd7lk1kgfz72f1dbxwwgna2i5nzzdq2s50nkv",
+    "tree": "7e00d65b458ba1d02ad2a4552a241baf89fbb895",
+    "url": "https://android.googlesource.com/platform/external/ukey2"
+  },
+  "external/unicode": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5995bc1e30514b40d98cff7f19878a3a72a1cb59",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1d35rmf6bsiz2rdf2nva6md84n9isnh0rr3k1amzxdri8skac6n6",
+    "tree": "ef27c927e40c71935275aa86183b820aabcc4bb3",
+    "url": "https://android.googlesource.com/platform/external/unicode"
+  },
+  "external/universal-tween-engine": {
+    "groups": [],
+    "rev": "1a4c7263b5070e59c1d7fda1b0a44329cf84e451",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0wr0ywr533jlvvi9qhrjzm5ql24hnm4a322lw2ysglc91gj6z3yh",
+    "tree": "ffee24b87c1bd6e0c20be4d499dcdea63f6917ac",
+    "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
+  },
+  "external/unrar": {
+    "groups": [],
+    "rev": "17c84c8e627f81a36ad555e7a641a3401544fcbc",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "013bcjzsddm4201224nic1j98wnqq6pfs0sc8x3i869xqvhmgqdr",
+    "tree": "fc837881170acbd839b43a846f1393d716e5dea8",
+    "url": "https://github.com/LineageOS/android_external_unrar"
+  },
+  "external/v4l2_codec2": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da5ab425a75f18b67b9b256c20916dcfd38c2cbe",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0a9sdpzz17a152qhdf0afaiiiz2aiwnbrrhbg6izav7n3y2qg2fs",
+    "tree": "f2ee538e31e0e0599cbfd64ea44f4d312712d05b",
+    "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
+  },
+  "external/v8": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a4037fef282a76a7b78a2ddae7689522708bf19",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0m884lcdkfrwk676fql3ijsvzyal881r6r1gmb3lm28xpwqj42ga",
+    "tree": "b19ea3df19e9d94e668f6c5a8df9277a567a1db1",
+    "url": "https://github.com/LineageOS/android_external_v8"
+  },
+  "external/vboot_reference": {
+    "groups": [
+      "pdk-fs",
+      "vboot"
+    ],
+    "rev": "612089bc99f380b5ef9799c0a411ce49c498b208",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vn6b0m05hv3k4am1j3dr8ncdyaaman7klv1nmw02whvss0a77xq",
+    "tree": "7cc1ba2b6d8cca6c412263454090c505b017cdda",
+    "url": "https://android.googlesource.com/platform/external/vboot_reference"
+  },
+  "external/vim": {
+    "groups": [],
+    "rev": "821b7e3b24dccb6366c8d9265ed8e110f481af1a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0471wpjgwcgl6j73wcwzlvq8armhk9681cbl19cbbh1wcjw54ag0",
+    "tree": "b5fc4a8d9e8e27c1f10644a4f13e7f493561b759",
+    "url": "https://github.com/LineageOS/android_external_vim"
+  },
+  "external/virglrenderer": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "526d1c195a2f0355cdb00cc9aa0c2893d10da578",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17j32bcg3xjw7dsggq90z880b7jn5vc5r15rhgfccchmgm3iwk0y",
+    "tree": "588bed2c3af46d9d42cb37331579d6aa5ae7d971",
+    "url": "https://android.googlesource.com/platform/external/virglrenderer"
+  },
+  "external/vixl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ea5d053768f885f93225169c506b0ff5492657e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1z9r9ynzi9q3kar9pkzixvcn2788qkzh3dlwmj0xl5lwsnsgkrz9",
+    "tree": "61a0f77ae882e3747bc92b01cc3f2aa5e193caaa",
+    "url": "https://android.googlesource.com/platform/external/vixl"
+  },
+  "external/vogar": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "324b2fb14d6da41791e3e32c374dfa0a053740f0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "056gr0vb4gblp0lrvy9xmh956p6wkdr92b6mx3zvkw3r7zwb1y2i",
+    "tree": "c91aa4942c58eefbb6bf4d229cbc3c486f3d6dfb",
+    "url": "https://android.googlesource.com/platform/external/vogar"
+  },
+  "external/volley": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "059c7b2e36853eaacf7f4c3b16480059c20adfb8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vxr20w0d60ihx2nmlx9phw0hphp0khg96a2wfc0bqpz1j4ykrm3",
+    "tree": "64996a4d0fe89a8562b0b18c02b0b092c9f86f5b",
+    "url": "https://android.googlesource.com/platform/external/volley"
+  },
+  "external/vulkan-headers": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aaac9580c105aca5b490751931606f79a98ccc5a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0d365czg7nvynxyl21lwjab2rngjwpshz5jbr88cb2qw7g2kblf0",
+    "tree": "c306cce3863e8a300651f5585569455aa1e7603d",
+    "url": "https://android.googlesource.com/platform/external/vulkan-headers"
+  },
+  "external/vulkan-validation-layers": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c69449dad629de55f842eceaf249a21315522689",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "08v5cszjqplqg98pzr94viiycky46pnh1nhw3cwcs7qj4rnhf0n2",
+    "tree": "14d8c016827399c8e4e83829a2a9ff94f972ed11",
+    "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
+  },
+  "external/walt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3fe0857688f58b6282ef6a4abca77c80476f61f6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0q7350gf9hn10iq6iwn58sardsbyx3w91mm243ivc8fnqp0szm2a",
+    "tree": "c30ac4649286db84b343802e00c4100ad1900759",
+    "url": "https://android.googlesource.com/platform/external/walt"
+  },
+  "external/wayland": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1ad0f78fbaa3295c87d6883bf75b0d79592b433",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zgva90lx1q4c9bihjpx56n0gla3drc97rwmv9773nwn6x1zh48y",
+    "tree": "0a2a08307e1abfe274ea41a2d62173fdf0aa6a06",
+    "url": "https://android.googlesource.com/platform/external/wayland"
+  },
+  "external/wayland-protocols": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a23fe5b763c96f4bd947fd6c7fc67c6344aaa758",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1v2a8wmfr19h9ixgx57hiig46ckzs7hz6hfmhajh475zx4qh3sfw",
+    "tree": "ad6fb72ce68c87b5f71c1e59f2c310b1dbf57a9c",
+    "url": "https://android.googlesource.com/platform/external/wayland-protocols"
+  },
+  "external/webp": {
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "cb2b2bedfe6a97b6d8c0b86f14709758642c03bb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0smd64ldnwdd8cp37pmyjsbsbchgscgxn904knrdx5vzg0phryj4",
+    "tree": "e84b47b72232b9e62e2b6691a0cc46a1343eff76",
+    "url": "https://android.googlesource.com/platform/external/webp"
+  },
+  "external/webrtc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b59e78f61e86d6a395ad6979404c30afa6e76020",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ghdlzx10gnb135vd30k4hwpcir4fp6x8p99nm0lzf7r758h5lsc",
+    "tree": "a918dbd5e48b0ba8139c51c8dc68a6367a85559b",
+    "url": "https://android.googlesource.com/platform/external/webrtc"
+  },
+  "external/wpa_supplicant_8": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d114c93c83571a574883798865ed68d4caddfba",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "14g0b5f188hxhwmgyzql0r3fjmnk066bn8a1nhvba0m8sc8dgd6l",
+    "tree": "bc095ec391923d386c848563dc970ed637e2af81",
+    "url": "https://github.com/LineageOS/android_external_wpa_supplicant_8"
+  },
+  "external/wycheproof": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c41994e22144731be0d1c6567e5f9539b0ccbd1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gpw5pv1kxncgwp2skgn3wcgbnxz31avy12iymfl6pcq5p19abdy",
+    "tree": "dcf99d57071c10c6e9c65333a1ce6e94e7270cac",
+    "url": "https://android.googlesource.com/platform/external/wycheproof"
+  },
+  "external/xmp_toolkit": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d891cdca7e3d6d3146673bb69ee2c47509230dc7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "080ksi59z6panck2cwg087815cvgrqqck4rsln5bm14kaifm6dim",
+    "tree": "39e98984145a753cdf6837647a0b034e6cd305e7",
+    "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
+  },
+  "external/xz-embedded": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2ccf38d71ff5499687b0f189afb1ace19730db9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1npk8wg399mvj0pa77y9p7l2nkg68s96bn3ll8gfzh6sqamb41n1",
+    "tree": "3fa43e10a9ad5a73f42822c479b0817b8478f94a",
+    "url": "https://android.googlesource.com/platform/external/xz-embedded"
+  },
+  "external/xz-java": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4317afb87bbc3c184d3c9d1e65cfa0062610340a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1b2b2n9p5f19l599xb6hc2nnrd4iq1qr7s7xq35bsr8phxmcspaq",
+    "tree": "04578cb39226d6eff2235778f275c75269c863b8",
+    "url": "https://android.googlesource.com/platform/external/xz-java"
+  },
+  "external/yapf": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0a6ada5cea52dfac1e89b973290592761f9c2cdc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1yqnb4kr12bchqgybcc04c220rhwampji2yfhc1kfxhwyz0b7ry1",
+    "tree": "438abb73f45286ed215cb666e75ff68b0e105f0d",
+    "url": "https://android.googlesource.com/platform/external/yapf"
+  },
+  "external/zip": {
+    "groups": [],
+    "rev": "c4117e141be848db220f292f08006182427cd93f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "13sp9jqxb6xyqwc5l01ild37457vgn7d8q9vp1ynwhlfvyd4vbc4",
+    "tree": "1c31fd88b3eb0743aa8557523c38137d12ba09d4",
+    "url": "https://github.com/LineageOS/android_external_zip"
+  },
+  "external/zlib": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1bc12763225d696e4e551efecc0a6815791a8c0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zhn49s1rb5plm96rpwcw19jqgdqm70nybirmmishsfkpy0jzxj6",
+    "tree": "8be5b41fbff7ff7a1d1964d92a01532d00c8338f",
+    "url": "https://android.googlesource.com/platform/external/zlib"
+  },
+  "external/zopfli": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f46cfc51b76a5e6df590969367cb465ac058b504",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "08cxmdcm5k32mylf11qgzd7nnaxz98l57xq6s3zh135wrb7rjpbd",
+    "tree": "f31405f0c3ed97405bc7515e0adb9e1c718b6148",
+    "url": "https://android.googlesource.com/platform/external/zopfli"
+  },
+  "external/zxing": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b580d9d5acfb2b82dd868afedc7ada1f97bac6c2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1j3j9rs847z2gjc3l3zgf4ciyzwg68afkjv8b1fajxw8123d83wa",
+    "tree": "76212e7901a47e59cbac4e61149d00616adad86f",
+    "url": "https://android.googlesource.com/platform/external/zxing"
+  },
+  "frameworks/av": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88230949dd55554af36458d27827ed0b35233606",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1vg33h3ivnhngh0xsl55gnfwf9lq2lkd5d6p5hyiz17ixpb5q3hy",
+    "tree": "ffac43bf3c19f10dde5447711432d9dca431d890",
+    "url": "https://github.com/LineageOS/android_frameworks_av"
+  },
+  "frameworks/base": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f3e14c38eb092eb65a91bea2bd8dcb4c5431357e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1y671j0j18y3bd2s5f1cv9bn0pfmaqfd9v64vlvhm50ps9336v2r",
+    "tree": "797aa7c1acec177df57d47d1789218ebb0565dfa",
+    "url": "https://github.com/LineageOS/android_frameworks_base"
+  },
+  "frameworks/compile/libbcc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aefdade1c181d238253bfd20a1d1ef27e94cd950",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0p7255aba7l94p7wpapzyp34zi3gg7wjxbfp827crszh714c8dgh",
+    "tree": "d6c2bf674287955a7f6a9c1c1e3f419e281bc863",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
+  },
+  "frameworks/compile/mclinker": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c59f0ab5103809dd37829d9e47c4a700493048d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "158sf3r777c3ppyw57ws0scbgvjf3xfi01sfshf3vlmrr66csj1r",
+    "tree": "f3afed1b70d82e5e87911e3a0e1cb6a2d87231f5",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
+  },
+  "frameworks/compile/slang": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a11b40fe7b9d03c86045cedce5583d2bc8e72de1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ikay8f92npxzyrqsadgyh7d30xqivhn5p56fr0ms97x791awf92",
+    "tree": "b2b38ba9690a888c48c52f0dae9281f1e528ceef",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
+  },
+  "frameworks/ex": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a5159e2b4e6aebca4978b0d62b660e457113a6b5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qh12n5kfw37h3kagmdxdrzk8xfrkvr0mzsa6kw569c88sbs92jr",
+    "tree": "dda0e977c3cf2954c53989875b26f75029dbfba7",
+    "url": "https://android.googlesource.com/platform/frameworks/ex"
+  },
+  "frameworks/hardware/interfaces": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9428b9c793b3977980e73bb1e27ec474848eec95",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1cb3an8pallcnxzdmj7p975aii3ac3s93yqblj5zkxalk1qb6qnn",
+    "tree": "50d40aad4e845ad865f6d0dccf80ef08db06ce6d",
+    "url": "https://github.com/LineageOS/android_frameworks_hardware_interfaces"
+  },
+  "frameworks/layoutlib": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "306fba0d3b318bcf396673d31eb8c0ef9edea9fa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1p2mccl7vrfxw4848hgkkp529zbswz38rw0nygcw21png5a77bz7",
+    "tree": "4c022be9420b5c76bcd8edbd7242c590e7df4e2a",
+    "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
+  },
+  "frameworks/minikin": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "3cc3d53f502e46a9698d9d4b126587f91faeaf16",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "13rfi5s6lfh4zxp9xwffbksx3zg0g4yw6fzxhkc9lzzf0i11bmwv",
+    "tree": "cbbb15a0f3123435fb11e541cf96d841b336bab9",
+    "url": "https://github.com/LineageOS/android_frameworks_minikin"
+  },
+  "frameworks/ml": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5a862c40b6ffa7a720d817a5ba3a6f02ca87ec0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0bkvxk0v4xm7yck8nig482qzbg23kw9bmdws5nb76d9gqwx9rdsr",
+    "tree": "2f0032da863fb6998253e1421322056be67b9a85",
+    "url": "https://android.googlesource.com/platform/frameworks/ml"
+  },
+  "frameworks/multidex": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bcd6bbe2cc61e831656300c125b7edcbc8ef97f0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "18l9b083jwrf0mxwdrbqrmgc66zc643bpsbcbfrgnvxrkiljw9sl",
+    "tree": "4a55778ad6cd0b4aaad13e376160e8c36b3e544b",
+    "url": "https://android.googlesource.com/platform/frameworks/multidex"
+  },
+  "frameworks/native": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93564456754774f68fdd91f51070aed8d7cb3221",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1rnw0s7cly1q14my9ydvxrnl05dv9iqnacw62w3l9m192yyxkp8l",
+    "tree": "9fcd7ec9061ee37adcc3c4e7ba898576592c13cc",
+    "url": "https://github.com/LineageOS/android_frameworks_native"
+  },
+  "frameworks/opt/bitmap": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8a8f720f036db20ac4b9f92292160c307298934a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0lg0rrvk8k7a3kndhfn30ns7rmllqb2i7y5vc1dznjsizr1rx0wg",
+    "tree": "0c27aadd054aa068f4d015b50387da5c4e220760",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
+  },
+  "frameworks/opt/calendar": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "59c83053425df19ab12668e2b839545a53e326a5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0dz2j4v2p3w2vkqnmrc5ibncbj6zbzzb0g8h57n0nvl1v8sn1kph",
+    "tree": "ae0aa56df500fcb19c63297ad7385dc15093d40c",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
+  },
+  "frameworks/opt/car/services": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9b0ffe124f199e5cc631bb63d9c186337ca49948",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "02ribnz98jx49na0nwrb21h9q7gxk588s7xnr9jkgbkk3n45dbaf",
+    "tree": "587a3b49ca83cd9dc8c9c863b34cfbfeab118769",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
+  },
+  "frameworks/opt/car/setupwizard": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "491ae2746fa6bad8845ef08d0cc0869088aae5e3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1hlng2c2mr1v2i383wf193p3xbpjcl8vz9alq2hmqd1l940jir5y",
+    "tree": "a8df9e8f080110b07aad539bd5ef8de0d4567477",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
+  },
+  "frameworks/opt/chips": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d80c034893859c32e00c97900f724383b18800ba",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "08a2naif35pd29zcqj9nr2c6w8jcka0d358inbsn7mcs0m29j1hw",
+    "tree": "cb632db870e65f7ba4de0c9af3072c54e7526fc3",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
+  },
+  "frameworks/opt/colorpicker": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f81620b2e2b50560456cdaac18f637ed712b35b5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1b0i8jjfr1x9rs4mnlih1bxssc8aq5xifnj72b8r0sm8yx48jaw4",
+    "tree": "7bd1e419d3510c1b5ec9750bebd3cdc1d91faef7",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
+  },
+  "frameworks/opt/gamesdk": {
+    "groups": [],
+    "rev": "348812b092d46379a63d61f0df4e8c3899af5d4f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vac3lcwzifcjw86ibn86a3r26b95wx2q6g1rf1x4zbd4pbghqkb",
+    "tree": "24f341afa3b56079c9cf6e8d1f3828113434ea10",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/gamesdk"
+  },
+  "frameworks/opt/net/ethernet": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "45e2e9a13b8bb6eeb697d77029756259c4f55d7e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "118bn50jjqa36c7x3r08zbb96b6m0zbbizk9l6nfmhjvvn3hl1r9",
+    "tree": "48dbb10f5bcf70273982c07fd8b5d12d97a1dd0c",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
+  },
+  "frameworks/opt/net/ike": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "492d1bf710d0c800cbfa684186268bc32958c90c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0r1h6ryw8rdzj8xmnll7ysv71b53n094aymj12ixqf7zkqp35gd6",
+    "tree": "dcd2a4ebf55e7c6f692cbed60509054eeaa46d98",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ike"
+  },
+  "frameworks/opt/net/ims": {
+    "groups": [
+      "frameworks_ims",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cd6f2df70a4eeca6328e2c0d4f384a8b7ae99db5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1ddr3lngv5qzsjcdrz7c3m9l9kdxygx1h4vpc68i9p90c49d99ws",
+    "tree": "ed7ef0d45f5f5115c5be92256019b79c953e2dd3",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
+  },
+  "frameworks/opt/net/voip": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e11ee38606debef534c3bdea430fd2d774f1890e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0q9j25mf8zg0n3hfmgspgd1yg4pzbb9hp0nc69fmhh10b4c442sb",
+    "tree": "76b87933173d59240d96d51e8c3102e9dbb3ebdf",
+    "url": "https://github.com/LineageOS/android_frameworks_opt_net_voip"
+  },
+  "frameworks/opt/net/wifi": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba2c7adca90f3c4d62b9b94558003551738248d4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ny9nrswhy3qwxcsr2fjyihw06a3dmmg3mcpa2hjk4k6j61m1v0n",
+    "tree": "3f42efd8824b8572460709ebe3287dfc1d419d33",
+    "url": "https://github.com/LineageOS/android_frameworks_opt_net_wifi"
+  },
+  "frameworks/opt/photoviewer": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7ecee8778d0648552bae766a04924f79daf8ffcd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0mp9xwxg12lpcb9v09908fnvjr8sj0ci4b13iq6clxss7fmj9dnh",
+    "tree": "25902fb3e94f6f1f9d16ed7450ceeadfc4d9e705",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
+  },
+  "frameworks/opt/setupwizard": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "db8e89af1d00ac080d28524d74ab31e0b1ae5989",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0iddqja88kmvwl4hmj35y2s2cmdgna3wiyjap8rmig905s3jsicl",
+    "tree": "d4d0f1ccfa3d6b82ef0a0be0a353328a3001714d",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
+  },
+  "frameworks/opt/telephony": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9d25b5fcf67a41b163c0393c307430b979f816f7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0hpn67vnm3p28j9mxn96hcxlcf0dqfmk48p6i8lmj8p3d820ym0f",
+    "tree": "7b9949b08df625bf16903cfd09661b2dbc296b72",
+    "url": "https://github.com/LineageOS/android_frameworks_opt_telephony"
+  },
+  "frameworks/opt/timezonepicker": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d27fc884f33e383a857e550abca3fc97f225725b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0bm0d5rwx7g7hj324snmbjyy9ijhiknda1hmwba0qc0376vvingf",
+    "tree": "7fda9fdd77285580bd22486d63b4eb4e8c734847",
+    "url": "https://github.com/LineageOS/android_frameworks_opt_timezonepicker"
+  },
+  "frameworks/opt/vcard": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bf5dd1fabf5f566dbb4a8e4741746c3d1a21231b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0c8ihknnvpvpy71xgfwvwz3j84xr6apq81g0s5iq34dcbsifyaxs",
+    "tree": "18edb7d6b18282a4874ef5ec2bc32140a72bf618",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
+  },
+  "frameworks/rs": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f68ad311d5c17dd562cff72e2d383974adbdd07c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1dsc0k1lmi13vfdkcdgnsf1zq9cd8fx138r4hh6mrj3hnr0m1i42",
+    "tree": "d4eacb1ab9756b07bbe92ce920902bfbd76f2710",
+    "url": "https://android.googlesource.com/platform/frameworks/rs"
+  },
+  "frameworks/wilhelm": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f85c0497fa264cf005370faf47da050457def18b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xc19fya9spkxs4wwqjyp2rhnc26risk5gk5gm28v8q3iszysc76",
+    "tree": "d073c5f6f285c85dd7100ae92ad035c0d10160c5",
+    "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
+  },
+  "hardware/anbox/interfaces": {
+    "groups": [],
+    "rev": "f2a6c491f9a6fc78e6362045d51e1fc741911385",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0pmwdlsmkcjd83hhpca2pxn4ngsqcsg3cj7xwam7amg4iy28iw90",
+    "url": "https://github.com/Anbox-halium/android_hardware_anbox_interfaces"
+  },
+  "hardware/broadcom/libbt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "27def02df7dfa71fa8ae41e3c644ec9f747da106",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0c07hxl8gj8pw86ln9d2mpjk9l2dg6sx9xmn7qc1rfnqh6sssffs",
+    "tree": "ed4cbb15610ffc3c78efe7cd5ae7b3fa6688ff14",
+    "url": "https://github.com/LineageOS/android_hardware_broadcom_libbt"
+  },
+  "hardware/broadcom/nfc": {
+    "groups": [],
+    "rev": "75b7597077d59d41208e105575883647455af46d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ach50bavq482xhmqpynv3n1dnf9q6d44hwk3as76cnl07fqp22s",
+    "tree": "0e8f9f4106ee1f6d538f024d306bd10baf222015",
+    "url": "https://github.com/LineageOS/android_hardware_broadcom_nfc"
+  },
+  "hardware/broadcom/wlan": {
+    "groups": [
+      "broadcom_wlan",
+      "pdk"
+    ],
+    "rev": "8220b8c2f5bb423caeba3bfc5dd63ade981788f5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1wq24hgxvxdbhydn5iqsq4hmlv70az4k455dvgciz2mr07lfj3pm",
+    "tree": "e83a6bbe988bc6f6d6c0ca1003d760505670084b",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
+  },
+  "hardware/google/apf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2e048ab9b7622f1f0d5280091e9e04a9d86670c4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1dk6a0hsx56vlrxa090fnclv1l895rbpdrdj5jbqgc3l9d8s7ffm",
+    "tree": "950baec1cd1f978011841c7f8e8e2f9286cd0f3a",
+    "url": "https://android.googlesource.com/platform/hardware/google/apf"
+  },
+  "hardware/google/av": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c8e2e226c2bdcf6396b0e5c21a6e92eff2cc1cf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sj8xlibs6gnmhcvd94p7k1np2f017v1ak62ay5bz9cp5lv55ylj",
+    "tree": "1952671fdd679920bbfe4aae131ef98def1ed90b",
+    "url": "https://android.googlesource.com/platform/hardware/google/av"
+  },
+  "hardware/google/easel": {
+    "groups": [
+      "easel",
+      "pdk"
+    ],
+    "rev": "f947a2830666f5bb4ef9cd7e700bbed206aa863e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1gjm9c9bwfcka4pk5b5qkimd34g4hv8c36azqgpr4f3y84pzxgbl",
+    "tree": "f09233dd2dabee59c9c40d580bda1cbe183621cf",
+    "url": "https://android.googlesource.com/platform/hardware/google/easel"
+  },
+  "hardware/google/interfaces": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93f53e6b055269290b095a7f5fc40ca74fcb0b58",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0jigqk8fy457lfaxdpncdvm8rxv7y8ar2byjnmvlfz9nvbp88nzg",
+    "tree": "0990c5bbeda769156216328146eb5413cc7acaa3",
+    "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
+  },
+  "hardware/google/pixel": {
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "9f2cc99c2193ede98d83e50c3d60394ccbc8f596",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1rg08kvhpn2k7jshd5b3lfdarlgmvjy4l87jbrrzv5dbwm1hkvjf",
+    "tree": "5bad823c29258e881625abb4bfe40dc035d842e0",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel"
+  },
+  "hardware/google/pixel-sepolicy": {
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "fa7c0931d8e78a91d2c3f56aee95d23615890cdd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xqwq32ycgrm8yj9a1yazpgdfifbhbzh86wfqn6iza63hdq4mg74",
+    "tree": "0cf5ac5e810bb1c027b826713b632a1b3686744e",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel-sepolicy"
+  },
+  "hardware/intel/audio_media": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "0e60b77af3fa70393ee9fa0e80811d1b39c5f6fc",
+    "revisionExpr": "master",
+    "sha256": "0c6238r05fdwa3cg5v5nwwyvgy98l1v043l6qvqhaj65f246980b",
+    "tree": "c2a684c23ca92b651851fedb2c2b114716f97690",
+    "url": "https://android.googlesource.com/platform/hardware/intel/audio_media"
+  },
+  "hardware/intel/bootstub": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "14399d52442a9f81b91bdfc38b2269496ba60268",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "0w5wckyqbv792f0i8zvhn3dsxv8l19hwg1qg2py14hyy97jjww24",
+    "tree": "99ae9eab0542a97e69984c0d3032185f35962633",
+    "url": "https://github.com/LineageOS/android_hardware_intel_bootstub"
+  },
+  "hardware/intel/common/bd_prov": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "8af329f2d2b54dfcfa84051d3ce1fae95f79011a",
+    "revisionExpr": "master",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/hardware/intel/common/bd_prov"
+  },
+  "hardware/intel/common/libmix": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "c4527142c2f6f605f372a74c8277e6483ba58fd7",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "1mysswn66pifw19skg0frmsi7hbsly8kwx14nqfywyhavgbkw9zz",
+    "tree": "398c3ac451aa599677b383294cf6942172ceb693",
+    "url": "https://github.com/LineageOS/android_hardware_intel_common_libmix"
+  },
+  "hardware/intel/common/libstagefrighthw": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "bfc9bda74643eedd4414e996d2a089a36d9acb24",
+    "revisionExpr": "master",
+    "sha256": "0y53p7ai41n36b9jr13mpdnpcxf74ivhgnbbg03vjhpwhyhaqz02",
+    "tree": "26a4e9cd50d861118d4af3951b5292663fcbe162",
+    "url": "https://android.googlesource.com/platform/hardware/intel/common/libstagefrighthw"
+  },
+  "hardware/intel/common/libva": {
+    "groups": [],
+    "rev": "a3c6d7e76ff09660efe75cf1dd699a6a78c68ded",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0pg6rn5fc4m8kwx9dgc94jfds0lhwqsfx67f0xnqyjqbmgchfcyh",
+    "url": "https://github.com/Anbox-halium/android_hardware_intel_common_libva"
+  },
+  "hardware/intel/common/libwsbm": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "43470eaa35b14e3c723caf5fcdeafc57e3670ffb",
+    "revisionExpr": "master",
+    "sha256": "0yz8jam1j32362259b494hmsgn721rjpnjn8d37srjm0q8fmgyp2",
+    "tree": "4f616396f609f1aea7c12fdb8d6349b5f27cb584",
+    "url": "https://android.googlesource.com/platform/hardware/intel/common/libwsbm"
+  },
+  "hardware/intel/common/omx-components": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "028624572259ede6c5e7aca6ae25c4bd59dcc816",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "1fcdajx2w9zjpvl94a74bkr6n5hgvcc8075f374cq3bx3hahq8s4",
+    "tree": "f4b32664468ae733959e10a32af1f5d2be084788",
+    "url": "https://github.com/LineageOS/android_hardware_intel_common_omx-components"
+  },
+  "hardware/intel/common/utils": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "f7cfb3a4ae624cf62c52d234576c6fc7632820b6",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "0x7a5i5g1caqr1sgbr6klr0hl4qlz9r60mjfpdds075fi9l8smwf",
+    "tree": "7678e8ff7faae53327895df5d5ee07bd42dacb38",
+    "url": "https://github.com/LineageOS/android_hardware_intel_common_utils"
+  },
+  "hardware/intel/common/wrs_omxil_core": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "689411deff0f97b7904e86a371a92dfd2605177c",
+    "revisionExpr": "master",
+    "sha256": "006fgyx5jpg9ybrd3imvfkml6306j8x10cci8a4mqwcd4p89x34v",
+    "tree": "c759b5cca033aea4b22e52a991a42d773aea91bf",
+    "url": "https://android.googlesource.com/platform/hardware/intel/common/wrs_omxil_core"
+  },
+  "hardware/intel/img/hwcomposer": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "b056741f9d968cdb30981c304f885cc0e98c796b",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "18zjfrhsb152ki78jg1c1jamilipahf5q6aw9rxzbfd2m288z2dg",
+    "tree": "783860f3a8bcb4ebe1eb756ee223874406a20673",
+    "url": "https://github.com/LineageOS/android_hardware_intel_img_hwcomposer"
+  },
+  "hardware/intel/img/psb_headers": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "ee44d217ec829fa81f198d36856fdcf5121a9ff8",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "10xs0ygwcgnyhh2kg3iw0jmhhkgwf8bmj8dahrn284sj3wf42gx2",
+    "tree": "3ec70b24abbe66daf1462f58398a535ab06759ba",
+    "url": "https://github.com/LineageOS/android_hardware_intel_img_psb_headers"
+  },
+  "hardware/intel/img/psb_video": {
+    "groups": [
+      "intel",
+      "pdk"
+    ],
+    "rev": "01cc5e130c2a0f0ef559b7e49840ee1d2cdea1f3",
+    "revisionExpr": "lineage-17.1",
+    "sha256": "1q77wr12cik1v3598a9hxhgiprq0mycy1i5dvs79hgmkr69pnjhi",
+    "tree": "1d86fd368d675ac4b19103d9ed71d4ca7a3fd808",
+    "url": "https://github.com/LineageOS/android_hardware_intel_img_psb_video"
+  },
+  "hardware/intel/sensors": {
+    "groups": [
+      "intel_sensors",
+      "pdk"
+    ],
+    "rev": "68dc9e70b79dacddc4e0bf00af0de7f764b04eed",
+    "revisionExpr": "master",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/hardware/intel/sensors"
+  },
+  "hardware/interfaces": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02951860e9c95f19384fa07522925537d8c17a18",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1hkjfv8myqv1pcj3j496xzfyi1abrfn4d51svxacfpvwl4jwnhws",
+    "tree": "7ff2002ebdc10bc91b5eff59e80fc494f994f4f5",
+    "url": "https://github.com/LineageOS/android_hardware_interfaces"
+  },
+  "hardware/invensense": {
+    "groups": [
+      "invensense",
+      "pdk"
+    ],
+    "rev": "8bb56c732472d6bce9921feea9c433b6592b0356",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0vvz90g55cbg7k616j3d95c0va6v5g4i8p3cp0mzvp8lc7w08gvd",
+    "tree": "bd0725018d01a52d7b6cc2b5dbfb44e1e4e98320",
+    "url": "https://android.googlesource.com/platform/hardware/invensense"
+  },
+  "hardware/knowles/athletico/sound_trigger_hal": {
+    "groups": [
+      "coral"
+    ],
+    "rev": "7f994b20519094470dcc11bf79c3263f4cdd80d7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1iyl588fndacscrac1pskq4kvn8drgianl35za79snwlsjnghj98",
+    "tree": "73fc3a1eaccd06a32af8df617bd55c8efbc87279",
+    "url": "https://github.com/LineageOS/android_hardware_knowles_athletico_sound_trigger_hal"
+  },
+  "hardware/libhardware": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8caddb38009ef6f4fd650795637891698e34bb3d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1ahpic67pk38sw7rq2p1j0p33cjdvygqnahd06l1w28xn0sizz9k",
+    "tree": "7b5edfeb320350f979a5ed29aa4eb1cc0780d5d1",
+    "url": "https://github.com/LineageOS/android_hardware_libhardware"
+  },
+  "hardware/libhardware_legacy": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f06b37284c0e408ccbcffb5671a07d22abef945",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "03xvi7a61h2pihmhi2y218lyidb5iz5hxg9yx7705h5h1lbqjbvw",
+    "tree": "72aa61cefa415a575e59ba9ff958b351a58443ed",
+    "url": "https://github.com/LineageOS/android_hardware_libhardware_legacy"
+  },
+  "hardware/lineage/interfaces": {
+    "groups": [],
+    "rev": "a4d493f658012f0ed13dcb0c44b500a0c12c00fe",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "192p0ayp0banc15pfa976nlwrimljnqhl041nnkh8cj314kamzwl",
+    "tree": "e5dbb2b8f3c833798f532173babb3a8a6e484f14",
+    "url": "https://github.com/LineageOS/android_hardware_lineage_interfaces"
+  },
+  "hardware/lineage/livedisplay": {
+    "groups": [],
+    "rev": "db60203475cdc4debabe68ebc3ccffd60f55d175",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0r19gaxbv7wi6rxf852wp312gv33xkw0lb7j29b4s45pqknn9lck",
+    "tree": "694fa79a2f22df0c121ea35b4f39d794c361741b",
+    "url": "https://github.com/LineageOS/android_hardware_lineage_livedisplay"
+  },
+  "hardware/nxp/nfc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40b21563e8e881edf8f6ae2dc43c8a0362de347c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "15kk5m6l6zfv5qb7wnwshm2w8gv8iyzdrc4mczi4pg5sc2rlk2b3",
+    "tree": "263ef205969f9423942def9b274b8f13b8329a25",
+    "url": "https://github.com/LineageOS/android_hardware_nxp_nfc"
+  },
+  "hardware/nxp/secure_element": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6040f9fdbc872007e2ffee629e783dc1ebe17196",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0klpmyx1h4yvf9v8w0dn13mvmb64yip01wlgdy903rhmrw35x0yl",
+    "tree": "eadd9b76937a9d44c9c4ee462d2d81e1e63a5a04",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
+  },
+  "hardware/qcom-caf/apq8084/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "7feb4b0794bd9d628ec3dadbe1baa5d96c39ceff",
+    "revisionExpr": "lineage-17.1-caf-apq8084",
+    "sha256": "0a21v3l7r2zfbkvly4lgzn45i73cp795klyakv5583pagrk1a3k6",
+    "tree": "dd1a8c8c8307b79f06e45fc05b478efdd2e339ec",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/apq8084/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "26a54aa24bda9626ff5b21d6023f0032296b34d5",
+    "revisionExpr": "lineage-17.1-caf-apq8084",
+    "sha256": "1c4nqidz8gvkar1v8fw8y9akm0rbll4011ngi3cp573clf5qypjs",
+    "tree": "08a265c5959ac531ff91536f396f7074eca9a0ec",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/apq8084/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "09bc40392ee7b78f385093765146758c7472b546",
+    "revisionExpr": "lineage-17.1-caf-apq8084",
+    "sha256": "1cr51g0haflfz0njrj4izby63s8rw55x9ca3h3ls2v8cigbmc3df",
+    "tree": "31a35ff5a1498abaf3e6343ba9d11f5ef4956022",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/bt": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "d5d367952633e7c698c6049346c538b42037f544",
+    "revisionExpr": "lineage-17.1-caf",
+    "sha256": "0521vi9d86jahrrk3wsfynmj39674yzayfrx7vqb6l09190gp6c1",
+    "tree": "dacccd8ec398d60743ec799646b225ddff15b926",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_bt"
+  },
+  "hardware/qcom-caf/common": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/Android.mk",
+        "src": "os_pickup_aosp.mk"
+      },
+      {
+        "dest": "hardware/qcom/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/apq8084/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8916/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8952/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8960/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8974/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8994/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8996/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8996/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8998/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/msm8998/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8250/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8250/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "vendor/nxp/opensource/pn5xx/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "vendor/nxp/opensource/pn5xx/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "vendor/nxp/opensource/sn100x/Android.bp",
+        "src": "os_pickup.bp"
+      },
+      {
+        "dest": "vendor/nxp/opensource/sn100x/Android.mk",
+        "src": "os_pickup.mk"
+      }
+    ],
+    "rev": "3b586a8bd168427250000ab7fbc37478c5f80f0f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "06j1skgwgfia4cxr5711vlamzvnvxfwhr7m22avlz0ynrkj82f45",
+    "tree": "72c9a7cda3a3b651ed3b265734defe9dba8d4301",
+    "url": "https://github.com/LineageOS/android_hardware_qcom-caf_common"
+  },
+  "hardware/qcom-caf/msm8916/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "a729b638be235e98416c067c4fdb626e2a3f27fc",
+    "revisionExpr": "lineage-17.1-caf-msm8916",
+    "sha256": "1mmzzbfyj3df5xvsbzwyf81axqwz7aaja8bgsvgiaqrglxh0klfv",
+    "tree": "3cb41a80a113b99dd807b4414f4b4dafd8d55d02",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8916/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "2facb060edd926529c0da4a6c653ca48d1904fca",
+    "revisionExpr": "lineage-17.1-caf-msm8916",
+    "sha256": "1rvjndjk2bqnhi075m3ifx92ckbahdf96xl72h5xiklsimxn5y0y",
+    "tree": "261a50486cc4fdd0147f0d61da52ec97b4a2c2b2",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8916/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "f9cd945b048490a02cb2755d5056265299bfec82",
+    "revisionExpr": "lineage-17.1-caf-msm8916",
+    "sha256": "1n8vhx6p5sjyg759gndfrcpz9srwphgpzalajgl1sc2mkydp73ph",
+    "tree": "53b8cf4136b0b5fdd939ed58ffafd4e94fc243e2",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8952/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "bc2d95118e5b4b5851b7d785e64b26c95bc4e091",
+    "revisionExpr": "lineage-17.1-caf-msm8952",
+    "sha256": "1akdpm20ybnacv8vjrlzqzadglrpwh39amkjg7ipbyj0gb9fdiqh",
+    "tree": "e91377580c097f8bc699c7503e0a1decae7cc9bd",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8952/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "6f49df17752e2b647b52f66c422431406798598c",
+    "revisionExpr": "lineage-17.1-caf-msm8952",
+    "sha256": "1vin63a4gawz5sam0jf776la74pga7zs42a39zn8xxm46nwgw5wk",
+    "tree": "90e142d28f76b72046b1a047348f745a473326eb",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8952/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "b4e7973d4ccde2d1a7d2652ad468b6adcb4c0280",
+    "revisionExpr": "lineage-17.1-caf-msm8952",
+    "sha256": "0aijskj5dvq98xda5j9qi3zm8v7718qhdgjap219gy8r0cq2canw",
+    "tree": "649cb7ade0833fcbc3bbf0888d8f3c1112cc511f",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8960/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "54b66b520bb5ae495cbecfde35ffb1ca0ca0ad5d",
+    "revisionExpr": "lineage-17.1-caf-msm8960",
+    "sha256": "12n4anzxsy3qdyvrb7afxci6b4xnvhz17xwpxl3kf864gfcbgwbw",
+    "tree": "d8f313eaf827476d71a7fc30e9943ed2da6afc38",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8960/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "41b61234996c1fa5ff22cdc39a8615d32fec8f5e",
+    "revisionExpr": "lineage-17.1-caf-msm8960",
+    "sha256": "03k3yy0kg330kbzw9lywxz9ynj2h1g2c7wla2c6bc749vzb0gpg1",
+    "tree": "f1c00241979212af5b3c92a3a1d7dd4a7ec7225e",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8960/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "bf8cb0a28885875c62471d94035e71f9fab535d6",
+    "revisionExpr": "lineage-17.1-caf-msm8960",
+    "sha256": "19brfj2clj1hblchi9ijfgci8hkfhjbwpr78fdgdxqy96v1plwlf",
+    "tree": "eba3b9dded49cee7144251c18ed4e90dac4561a7",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8974/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "8a808922fda3ace039adc84c01864ad71daa15b7",
+    "revisionExpr": "lineage-17.1-caf-msm8974",
+    "sha256": "0arifgm3mk1ik7xnqd51mpsi8nmd3rqf25cifpq4f2a63qbvj8n2",
+    "tree": "0ad70b9d2749aa3de6d09fe4da9549fdf008ffb8",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8974/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "d5ea072799a7162a1d977fcf5b155d21b1f6f19f",
+    "revisionExpr": "lineage-17.1-caf-msm8974",
+    "sha256": "0wzjppkjp7m5zy74y4piv5xrani5r8gq0v026zb7jbp230l71l2g",
+    "tree": "4cb3f6083bfde7b29cabc759ea84a087ac4fc82d",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8974/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "0ac6d80ebbc99c24f92893656a0c93dc4def8d57",
+    "revisionExpr": "lineage-17.1-caf-msm8974",
+    "sha256": "1i70b7d0lxlkdx849qb61ghbk01akb3k86r77342qkdh0rl4hkrf",
+    "tree": "df3e1338830e65a7f3760ea576ce62301bc49ce8",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8994/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "7f4cac748b6f62897294cdaece9d1aec27e1e927",
+    "revisionExpr": "lineage-17.1-caf-msm8994",
+    "sha256": "1011zz0zsspzbnxzbssm2bazjzdp8nc016zswx65nc79y8b6iazi",
+    "tree": "16a35277e03778dcbbc5124187da9a53dd3b1f43",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8994/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "91b8d2d1ea18f47a455a8c386ee2511b123f7e22",
+    "revisionExpr": "lineage-17.1-caf-msm8994",
+    "sha256": "06xysf57j33dx1fa753z8vkvbd2wc5mm6px956s2zgkar8r65c7a",
+    "tree": "719d9aaa9bc95b90c775873e268b2da41518c649",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8994/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "99965b3db3a7795360f12a9889ac0d9c3b38bc6e",
+    "revisionExpr": "lineage-17.1-caf-msm8994",
+    "sha256": "1l4fysylmx5sjxcp878sgy1l80442l5mp5n374ji3vbyc9j65byq",
+    "tree": "80c67035beb778ab3ee51a45f3eeb111286603d6",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8996/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "102e042c83163f65033a8d45fa43fe617a218165",
+    "revisionExpr": "lineage-17.1-caf-msm8996",
+    "sha256": "1zsm99qmxwci84lw3982f60lvfbba60vxzlw33h3q6gqq7cy71c5",
+    "tree": "c9bec47b5d26064308da319456582e2dca0ba39e",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8996/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "744e84a5bf472afc46b14ad38c3925ba73b2136a",
+    "revisionExpr": "lineage-17.1-caf-msm8996",
+    "sha256": "1ambldf19n44xlk89y1ij2pxfwyghgkpgz83gys27rx1712819zb",
+    "tree": "ce5b17ccee76630511bfb0377cf45bdd4e4129ee",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8996/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "b07da441193a7a0564bef7a781cf2cf65bfef5d0",
+    "revisionExpr": "lineage-17.1-caf-msm8996",
+    "sha256": "08x962vg7d4qdxjf9n4wh2k4yv0f499sa2brdanv14l4r5im5x98",
+    "tree": "b8f44668d76fba71999655cda8c7241b103670e9",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/msm8998/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "9e2e494b3484b178f8ed9c1f3b0a4175f9073326",
+    "revisionExpr": "lineage-17.1-caf-msm8998",
+    "sha256": "0kcmjmkc3r1mbg55zgvfklmyh2jkdsggqimjxxp3wjcf9q7s308p",
+    "tree": "f430ccd6d7332c16c6d94e5c48f0324d3f35fd0b",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/msm8998/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "02224d9874819957f57839a518cc7547c1d760c4",
+    "revisionExpr": "lineage-17.1-caf-msm8998",
+    "sha256": "1fj8917ffsnb0da36akrw3spw6v8nqrg7fxbb26qrsw1syxkf5yr",
+    "tree": "c20f26e3991136f82d99e86a6d1d1a1a0bf88cde",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/msm8998/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "7d9631d63f3ae8765eb861e174226141219c9d92",
+    "revisionExpr": "lineage-17.1-caf-msm8998",
+    "sha256": "0w2m76ws6ldxjyzg0qc0zzh7hsdbi3q7pngsmbkf9hk1m59yd0c3",
+    "tree": "fa2cf001c7619c399af57adb62332150fd0785ab",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/sdm845/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "b415d7030e2e9d284f0abd778edc0fd0f2cdbe66",
+    "revisionExpr": "lineage-17.1-caf-sdm845",
+    "sha256": "07rkclkn9lmvj5j8453ni138yzj26r95n86y1v1c54lg4yhrl650",
+    "tree": "a4538a405136c64720965b55d41c2f60fafdf828",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/sdm845/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "95a2d7c71d274cab0929c85b699de156c2ca482e",
+    "revisionExpr": "lineage-17.1-caf-sdm845",
+    "sha256": "0mn8sl8v0kr89d70cvs33ybzp9z10d6pznspppbglcy2f42ngvr1",
+    "tree": "16eea8f28ba7323afff6f5963aeb511d2fefa285",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/sdm845/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "9a250e0a2e0770bc3bce57580185f7c8a4bda5d5",
+    "revisionExpr": "lineage-17.1-caf-sdm845",
+    "sha256": "1il3qxpkwlhik134m4nqb3kgqbhrb89793kfyap0crkklkmm883q",
+    "tree": "2f92f1d960d910e2a0e2757f48510d42d26b412c",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/sm8150/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "6a9c3b0638e86e996f5ff730ba84fa9cbf2e02e4",
+    "revisionExpr": "lineage-17.1-caf-sm8150",
+    "sha256": "06a5smh1c07s1g67rkhq436nk6sw42fwvp0frl3pwqkc9xp13dia",
+    "tree": "b5911f11562089e92c4b13c18db2c9440cecaa6d",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/sm8150/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "c78f45e5833b93427733eae159cb34ebc60590c0",
+    "revisionExpr": "lineage-17.1-caf-sm8150",
+    "sha256": "0k5nzqm9kfzy4kbv1yk1g66d8nhmjzvcfgifm26hc9j3ky44mpvm",
+    "tree": "e68d4c6b84f85e44c75fda4df6f8669ba63c4c85",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/sm8150/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "43135520b41d6bb644232577f3bd107141f21d1d",
+    "revisionExpr": "lineage-17.1-caf-sm8150",
+    "sha256": "0kzm08fmpfw4f7m4yrp58khiwqfggmnwp0zghs6mkcxpg978kr1m",
+    "tree": "c9868a052973c1bf37b6e6b1235aef203284377e",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/sm8250/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "02a7ad67e3610443856d7127c5fa42084c27c1bf",
+    "revisionExpr": "lineage-17.1-caf-sm8250",
+    "sha256": "1rxm1h893s2fapjdkr1mrwgn1mpd5rxh964r35j49hj2lbylkz18",
+    "tree": "40c3d923e963ccb8ca4a7098c09e0022ddba59dc",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/sm8250/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "4ab176b0e2689fea67130b72edb2f07809cc6e3b",
+    "revisionExpr": "lineage-17.1-caf-sm8250",
+    "sha256": "1f90snq6pg45qh3wzqa3ms8nkq98d03djjmfa1sqvmwj3vlrc7fn",
+    "tree": "e22a6aab9ef9af3a81a69b7fa3920baeecc34aa4",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/sm8250/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "bf0d869e626401af3cb1acd01c1ef207e7c84720",
+    "revisionExpr": "lineage-17.1-caf-sm8250",
+    "sha256": "1vafr682bzxbsd8khbzzfk3hzn915c1w4x95fdpg3jp157q60pgz",
+    "tree": "1a89fb9a2792b39a8fddb2a1dc104d3cc24e8e55",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/thermal": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "8c677b6ee5179da8aa6ac1f00f37198e0df947d7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "070v1sr1ha55nfk4yq9qvqxkm889j0v6y9b5g965459k8396vssi",
+    "tree": "cd4144d75a0d638d00622d1432b2bb5e2484e43d",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_thermal"
+  },
+  "hardware/qcom-caf/vr": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "a2c6ad6f6443dee7ec4b48f788a2c8f7ee351aa2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "12kj00fl65kmars6gs9ssbxm3qckw6jlzmy8h6xhdqpwmzxd006s",
+    "tree": "296fc1750b91b38c2fe224b8df5f53da31da73fd",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_vr"
+  },
+  "hardware/qcom-caf/wlan": {
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "c497d3e4b5c50e97312c1cdde2912f934161ac82",
+    "revisionExpr": "lineage-17.1-caf",
+    "sha256": "1k2m1v4j8xaj6caw894qvimfa3d8y2gf0y22dm519rvsqia4is6b",
+    "tree": "00c9ae84e227a41bead5cd2d01f8617749d0c8dc",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_wlan"
+  },
+  "hardware/qcom/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "722c28c2312bf9803ebd5828d0571157f47055f3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "12yqk8qpn83lqgq8ds9zp1vv4cc0q1yqvqval9zfzn6dll74s4az",
+    "tree": "be3429351f41861e0370d7d3c5cd4c7347ad461e",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom/bootctrl": {
+    "groups": [
+      "pdk-qcom"
+    ],
+    "rev": "69f2d8d08699fdec49605c6b95fc06163952b6fa",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "10x6lv8a9h14rq5rnsdvp8k448m099pbapcl8jwllii09yv3i6j1",
+    "tree": "96cca2d3a244892f9167aa4396069ea6fa2d3431",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_bootctrl"
+  },
+  "hardware/qcom/bt": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "5246e961eb70bb7782a1ca35b17627dab740829a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "10p3qya4r7cwvxanar76wpf9r9gd6l5m7s352n6302s664swa1rg",
+    "tree": "6dca92133069b2629d3192dcb08d469d9975cfbc",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_bt"
+  },
+  "hardware/qcom/camera": {
+    "groups": [
+      "pdk-qcom",
+      "qcom_camera"
+    ],
+    "rev": "98f6f466be271773e6a685a2d647f1d61b39b442",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0pgvbgcjsh62rzy5apl9956llgxfs4p006qrlvm8jrr4vmrm59fk",
+    "tree": "f02ad7f60049b6898f49e2ee155490ae01c89bfd",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/camera"
+  },
+  "hardware/qcom/data/ipacfg-mgr": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "252e29d524e97c89470ea4d291c8b6fc81a5287b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0iy2dmas1xk7h550isd3yi09hqprakyvjldri0ib8dfwglca3r08",
+    "tree": "d74bc0760492f218bfbe234aa127fe84fee968ad",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_data_ipacfg-mgr"
+  },
+  "hardware/qcom/display": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "efd182313a158b4f820a60099d1af6111a7cbb43",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fnk8xkvwzq305i1px3zq8j3fhrf1gn38l5pvgq3vddypp0ryycl",
+    "tree": "847756a1b75dd0faddff7d67f9da9e172044e3ae",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom/gps": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_gps"
+    ],
+    "rev": "67a2a14cf94f41a11d73cd76aac01fb02f4b6399",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0vcdjsifwnvs4b58y747pdj5ma043m5ldi75nznh3d5iv3d88jrx",
+    "tree": "241b7f72af6908cde2c84f0fa382af0411fd3435",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_gps"
+  },
+  "hardware/qcom/keymaster": {
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_keymaster"
+    ],
+    "rev": "cfa17ea7b26995d3c7719b1c1476ea1d56306186",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "00mdkc05xkhpv17nmanik82d60l4afq54y7vqy63r5m9ra1bqrnm",
+    "tree": "2da45ea47ab550ebeb3c90763070b79a1a18c4cd",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_keymaster"
+  },
+  "hardware/qcom/media": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "e43e96170d86e5f48f1d735fb5fca8cb2fe348b3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0rz0s8qpffi6kinyfwb1zp78prfkbizmpzgpk5wk7g07frr8jzdn",
+    "tree": "105040a976e930b440305453b6970951a3bbd545",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom/neuralnetworks/hvxservice": {
+    "groups": [
+      "wahoo"
+    ],
+    "rev": "809c3fc3b126b9d9f26776cb1d96ea1cc13cb159",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ribxl585vbb38nbcz5f7nfybxd99nqhg71rj2cns3bwza4xwdwp",
+    "tree": "a8a20e131ed63e9a7b81b3e1e695d5726d5c2b06",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/neuralnetworks/hvxservice"
+  },
+  "hardware/qcom/sdm845/bt": {
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "9c7e48a130f85be20c91a6e5f217aa87debea9cc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i1g7d1vgpyzlvnvyp0xlsgn8zapmgb95q4s56abild97q3a2ssr",
+    "tree": "f696a0dc2115747413b9be648bd67d9123b1d2d1",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
+  },
+  "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845",
+      "vendor"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "d5e63821e8d19d37c3b464cb3bf0bc43230b04c6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07q52b6v6rj0i3dhwyh6924760mal3h73b4vdwkdg0fwn275mjhg",
+    "tree": "28046dd631ccf121fc06482e067ba49dc44207b1",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sdm845/display": {
+    "groups": [
+      "qcom_sdm845"
+    ],
+    "rev": "bf445fa9369441c8711d0b5968ec20d4c70ad583",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1kgnjyijw8rgnx2p21fwm7s0pxbvdchivfsm553frqg5j1g902ss",
+    "tree": "32c30b85a1b566da669fb49f8374830a7c98a5ca",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sdm845_display"
+  },
+  "hardware/qcom/sdm845/gps": {
+    "groups": [
+      "qcom_sdm845"
+    ],
+    "rev": "967cd023ff701d429335532fcdea0570c9ffed2c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1sw8v0zjvqb6rqj23ybv1gk4s9aj0rfyninz1hwh4jkz96pnvk42",
+    "tree": "20cbbd780a25d0ebf2d04639516ccf7ee060789e",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
+  },
+  "hardware/qcom/sdm845/media": {
+    "groups": [
+      "qcom_sdm845"
+    ],
+    "rev": "7d563004312803d3db03f54da18fd615906af59d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hjnhp07k5jpwl6jjxgwvw9ri13aw7n9afdpz2d7rgw1cic5b14z",
+    "tree": "c5dc9195f7479351ef97a702ba8403c37df5d406",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/media"
+  },
+  "hardware/qcom/sdm845/thermal": {
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "5b01565bdbe32c3b825e5f3c4695fa20abf49770",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qp1xci4wgql888q80wllngrhh4vjrbwjpcrp1cpihhwrg2kidh7",
+    "tree": "8a55290974b826dd1ef81a0bda55a8a23976c0b2",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
+  },
+  "hardware/qcom/sdm845/vr": {
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "83f09450f15f2e7ed91c8c9e49303bbe7879fd4b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "09p26d9nw5r1zsawz8v869an1bi7ckifa0j5yjmdrqbp1m32vxky",
+    "tree": "d3310d428d7a4cef640acff4ac7d072a2502678d",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
+  },
+  "hardware/qcom/sm8150/data/ipacfg-mgr": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "e4bd86087abf4a2ff7ff676bff3bce96d12d663c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "153xx05zx8v0fkrx3y8fdv3jvvdk9ja9yxjxj2vqadgpb4rp2c3f",
+    "tree": "2d096d01b0401c5e152ecaca6287db15ea4d208d",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_data_ipacfg-mgr"
+  },
+  "hardware/qcom/sm8150/display": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "f57d218c678e352f982c01a693f13dd03f06e6a9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "11qajgyg819ilny4vj865pkcy3p2rj2aw9816224ij7g5sbn6hr1",
+    "tree": "298aed6adf4285fee247ffb53a6bed31e041dea6",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_display"
+  },
+  "hardware/qcom/sm8150/gps": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "a5a5255280e13796c9c67615b23678288ea14b61",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0nk5ig2lcwxb8v4ljci9qlqpr9hsradwv1xg349xw2z6wl9j3kfp",
+    "tree": "975b2376accc3dc079dd700eac1f0169cfe126b8",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
+  },
+  "hardware/qcom/sm8150/media": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "703a92541014b1de3d4e723ca57fd52fb0f45ac7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "13psblgl1p9y8ivavzbcmspay51l43ap2knkskmpqkh96kxxq00q",
+    "tree": "997b8a60522fd90c1b5143ac16b35be9fa373789",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_media"
+  },
+  "hardware/qcom/sm8150/thermal": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "c5f25d8ff52b0adfa44e2558b5c48c183a46d05f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "09bsqv84dgphg13bbw5cfd9gya3m0zh4vl7qmhz8xp5bbpzy86r4",
+    "tree": "e10fe91fc9e0f6b6fb46e2f49087d211e03feccc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
+  },
+  "hardware/qcom/sm8150/vr": {
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "064c02ed2ff0a3ad4795d1573312b0408b6f2f97",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0z34g6ccy9v5268623vvwzda53x44034rk1sxn812y1slxvbfyw2",
+    "tree": "bd990c82016d1884ef5740aec79471241270feef",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
+  },
+  "hardware/qcom/wlan": {
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "309d55b6e2b6b3ffc3159a6e89e136afb6a4c660",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1iknr98gs2p9fshiw3fhbxgyz2x0i5gsrw9c50sldfarc430gc3s",
+    "tree": "f9bbdd6f7f3a09ed538f737060d8b94a528c8dd6",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/wlan"
+  },
+  "hardware/ril": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7ab9c910b11fd826493cf6d24d3a956f5a65a88",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0s3nm9m4i9gj1qal5gc0jy1ly89g2qq3hpi5sgc2yq2z07mmc430",
+    "tree": "6b843df6c470a39ce6cb2d58559079ec4e6ee195",
+    "url": "https://github.com/LineageOS/android_hardware_ril"
+  },
+  "hardware/st/nfc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e4c1e0d559a9c5aa2b59f56f57eb652a1f4e30b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1j4p8hahm8fqyps2in0sj27g2ayrh38zxn4rbvn0arv15xpxksqf",
+    "tree": "33e2d3bd2dbb4988bf2d731f1d3bd7015971653f",
+    "url": "https://android.googlesource.com/platform/hardware/st/nfc"
+  },
+  "hardware/st/secure_element": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee0eb91803acdedd975457f6faa93bfceb95b0e9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0c2lm8wha4r71k6zprc04k2bzkf4cyq2qrcq9bgqsmgp04d80cwq",
+    "tree": "0aab5e44d778683ee67c6892a95032d4dd21c2c7",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
+  },
+  "hardware/ti/am57x": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eec59e3fcab0f10623b61b34454f1752f6630129",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rgg5830ka3fxd30ikvxlgrmw72r8dqqd9syzvjk9mclm5lww85j",
+    "tree": "6a55c98cad11a39418aab4ae5a6ddb4c71186d6d",
+    "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
+  },
+  "kernel/build": {
+    "groups": [],
+    "rev": "62e1b25dba50ceba3b689fd8396f1ffdc9e672bb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0w4c3ma8kafxls4av61xjg23r89ygf51g25x8qfmnpdic6n64wy7",
+    "tree": "449c38b6595ef84be9d061b63ab59d0e34313a85",
+    "url": "https://android.googlesource.com/kernel/build"
+  },
+  "kernel/configs": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "bdaeb67a24f06cdca9e51198ed6b8c8ccca6ed96",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0z5dgchzdas496qw2b7h9ynfl5b8dm22xmmgjjd9jszqay9a12j3",
+    "tree": "99fb0dae21c5619a6ae8206204de366f89e97300",
+    "url": "https://android.googlesource.com/kernel/configs"
+  },
+  "kernel/tests": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "5d650bf8a898e2c11e7c0e1cf71fdae29ba5c5aa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1rmxz3fvrbqbsn552m54kxj0561sk4iy6sl7qx2c9gp123gqkgbd",
+    "tree": "02655f29619ed06cf48fa53aaecf032fb3fed0da",
+    "url": "https://android.googlesource.com/kernel/tests"
+  },
+  "libcore": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ddd1b7903dc7c24cee4eaba3ed9f93bafda677c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0536m8pq0lgas3p620bxvllhv4qgg3b18d38yxy3bb1jc8hk2q3n",
+    "tree": "5a557cf89ec050f93471943a6fbbccf146fd5a6b",
+    "url": "https://github.com/LineageOS/android_libcore"
+  },
+  "libnativehelper": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f2dc6730ff4bc66358631df76b49f14b4d7cfab",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0h8vbpc9lzwx82knblrjrjfnhnrass77ymsr326xj4mfbb8yskvy",
+    "tree": "9345e8f3e6e5eef59d8ec9ccc29cafda6a8c5a4d",
+    "url": "https://android.googlesource.com/platform/libnativehelper"
+  },
+  "lineage-sdk": {
+    "groups": [],
+    "rev": "24c35a815788cdea1d6a96819662bdf50053045b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0wlld6ws9dfz6ivfxqdzg28ypmndnd2k8q9qd6q8phv1lxx1w51v",
+    "tree": "57ae568b85d1558986367a350a6ce9bbe7734338",
+    "url": "https://github.com/LineageOS/android_lineage-sdk"
+  },
+  "lineage/ansible": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "0196ba78e2f17b0b74fe34a890a8b49107aafe85",
+    "revisionExpr": "master",
+    "sha256": "0zzii9j2n310l6jjjaaybdyzbs7j0qag53bkcn8qyy1z3vrixnch",
+    "tree": "ca9ba0a4c7d4e498e15271824a9894b919e99f1a",
+    "url": "https://github.com/LineageOS/ansible"
+  },
+  "lineage/charter": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "fd7fedcc554966221ff290f05e910a59ecd2c2ae",
+    "revisionExpr": "master",
+    "sha256": "0w2fdbw538fjbvlcs4qpbnyfxmakcbcqacb43zxpf1jl3nsg34vh",
+    "tree": "52ea89c2a8b10a63e4d29c06c0670ffe1efd1728",
+    "url": "https://github.com/LineageOS/charter"
+  },
+  "lineage/contributors-cloud-generator": {
+    "groups": [
+      "tools"
+    ],
+    "rev": "15fcfef6cbeb7327643eb1ee7d6f95dbaf3a9cdf",
+    "revisionExpr": "master",
+    "sha256": "18qc4xh6f3834nlqmizx22srz6ixhf24i6r017f2hqc362xbn298",
+    "tree": "eb6e5c0eae575305d666985c73ec34f5f51b829b",
+    "url": "https://github.com/LineageOS/contributors-cloud-generator"
+  },
+  "lineage/crowdin": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "2713c01c2326880f05e52d9f2ac7067a422e85ac",
+    "revisionExpr": "master",
+    "sha256": "0jis89ilrlvmnia56mil9kgdc7vjkbzr54sppcs0fgd9l77i4y7p",
+    "tree": "5f891dbfc2b3ea68af4d28beadb616a298842488",
+    "url": "https://github.com/LineageOS/cm_crowdin"
+  },
+  "lineage/cve": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "add764f52e21699dd07c574d637b8cda54a460d5",
+    "revisionExpr": "master",
+    "sha256": "1hkzpv0qqwimdfh8y7qrw7bmymmam021y3hzrq4nldvw5hixyhv7",
+    "tree": "d17657e2996ffef1042b496baefa99de5fc966b2",
+    "url": "https://github.com/LineageOS/cve_tracker"
+  },
+  "lineage/hudson": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "998fdb3d0fc4d8d1d53b44eb5617c5c2982a73b9",
+    "revisionExpr": "master",
+    "sha256": "0ydllhzg0qbmbnw208wk4318fy8swjj6j2wvai788has1d17pv23",
+    "tree": "65aa433d2c5da2c03385dbe3a1673f5c901e5626",
+    "url": "https://github.com/LineageOS/hudson"
+  },
+  "lineage/mirror": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "e5e1eb209af84ae8a541feecc509af454b316a8e",
+    "revisionExpr": "master",
+    "sha256": "19pvlf7g4h26wdmi25sz8n9gzswqprlywqprs7q23pqbm2b2gh3j",
+    "tree": "face59f09c19fee400d9dfdd1074c577a0b2bd04",
+    "url": "https://github.com/LineageOS/mirror"
+  },
+  "lineage/scripts": {
+    "groups": [
+      "tools"
+    ],
+    "rev": "c0c555710da5b1375136f83764dfeed8d40cbc0c",
+    "revisionExpr": "master",
+    "sha256": "0q8vx3jg97aqa59jbsrn7bqi8ni3227ld4lk0mgxgrsn0vjz21gw",
+    "tree": "81fa50c7db951da73ae7f4f9ebbcbcac5a1bbc7f",
+    "url": "https://github.com/LineageOS/scripts"
+  },
+  "lineage/slackbot": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "ec8ea4d5505905da2151c2dd4608c41b510dbc07",
+    "revisionExpr": "master",
+    "sha256": "02w945xskyka7ghpx15a344bigw0wj88qxpk91f0rrk7aw3myb7j",
+    "tree": "8e8d4332392b41d3ca602eb3a7ab21b0f9324175",
+    "url": "https://github.com/LineageOS/slackbot"
+  },
+  "lineage/website": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "f13225524dc5c2064a5067b845632703f2cc34ad",
+    "revisionExpr": "master",
+    "sha256": "0gxzn3vx756d8npdx2ias2x66r879fk6inv49q82fnjsmiygf78k",
+    "tree": "3a633262605c4d26a73b5199a85927d42616ea75",
+    "url": "https://github.com/LineageOS/www"
+  },
+  "lineage/wiki": {
+    "groups": [
+      "infra"
+    ],
+    "rev": "2c7a49ae5cf0e012dc358b89abe6d5ab04051094",
+    "revisionExpr": "master",
+    "sha256": "1v9l29rx2c3mm0jrv0g4287cvj210ggrsj7z4ngdkcn1d5h4baff",
+    "tree": "c346c2528da65561e4e2b5ef044c92fa50d89afa",
+    "url": "https://github.com/LineageOS/lineage_wiki"
+  },
+  "packages/apps/AudioFX": {
+    "groups": [],
+    "rev": "625e4cd9dcf36831e1ce7c1db90f965b715f2343",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1x0fysg82c42wh3kb22lrwshj6j7712lgqxsp68d5hlacwda8wlk",
+    "tree": "cd37e13b502d2acd6604f127332bc01ada4f5118",
+    "url": "https://github.com/LineageOS/android_packages_apps_AudioFX"
+  },
+  "packages/apps/Backgrounds": {
+    "groups": [],
+    "rev": "e1e2981daf99021ac716be432522c1f425367c37",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ch55dpbswnhqc0imdyqf2l561z2m7xqpxfsm1fsbz5pln8yk9p4",
+    "tree": "8cc0be6ba5605bcc7abab98451fb5db6d6a6875f",
+    "url": "https://github.com/LineageOS/android_packages_apps_Backgrounds"
+  },
+  "packages/apps/BasicSmsReceiver": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "fb4e66890e5d3aae37a584285e26856529762c22",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fac6kiyzx3ii7ndrji654db566qsigrgvd1bi144jnbn0v3cdsk",
+    "tree": "0822e6b99f34d879064a22f02bf473a9d413f447",
+    "url": "https://github.com/LineageOS/android_packages_apps_BasicSmsReceiver"
+  },
+  "packages/apps/Bluetooth": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e63ec889d36cb302391f66394c61f326fe5c1403",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ld5gaggf2ippcd87kis6vam9ax8l90ln9f40bzd8ag6a7i9d9b9",
+    "tree": "f0a7fd8c0c17b46afa3d177a58a94b49684edf1b",
+    "url": "https://github.com/LineageOS/android_packages_apps_Bluetooth"
+  },
+  "packages/apps/Camera2": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0a7390f051cc999a2c96d018b10118deee8d2855",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0s11nmsnbpmrrazi6bv3q9398brvfa5fy69yc8wfvipdj2y7vs6l",
+    "tree": "5512c56b11a25c8e72cfe95b83f9a1b2c40a60b8",
+    "url": "https://github.com/LineageOS/android_packages_apps_Camera2"
+  },
+  "packages/apps/Car/Cluster": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5aad6a7358da1241e9889d585293717ef8c3323f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0245jp4slrm9rpsqkjy2xyhqb8vg47l8crw6xi0rr3h5k6x86q0i",
+    "tree": "101b209004c47193dc7e8ccb5a9bd20dcc1f60ab",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
+  },
+  "packages/apps/Car/CompanionDeviceSupport": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "77c306a690a4f6653264853b3f192b163dc02a86",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0m18n1kj2482hw22mg69hsm5zxrjyx3pp383s422byi79kxi9jps",
+    "tree": "00e4e6cd235b603bdef5aaf9d9f4db1a02ac6cc6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/CompanionDeviceSupport"
+  },
+  "packages/apps/Car/Dialer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bc76de6828d1d4d8091556dc31a8def072d0d559",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12fbd831g7x2gf22lmh16zm7yjm6ifmmncqdxlpz1k707iz8n09r",
+    "tree": "324888b5bf40a3e6c321e6773417529a1d7a54a6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
+  },
+  "packages/apps/Car/Hvac": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c1b5cedef08353c5b035341673602b913cebae96",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0f14197cin4v8431par1apm3hp174l6h6nv42jxchxxn2wj5cnjb",
+    "tree": "70d77d82cccebf5574e6839538fe84277de353da",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
+  },
+  "packages/apps/Car/LatinIME": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "774ea4457726307c6605e594e4b3741c29455916",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13ywkkpd35k4x871ng4l13y4d41qk5m2r2ll835nzx9d2iayr8mj",
+    "tree": "083eb074d487e23c247da13aed57abeb4d4f8cb9",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
+  },
+  "packages/apps/Car/Launcher": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "248c5517c2bb82b4c82b7de690779499a6a072e3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0yf8qkr4xwpyvq8466blgqscx8s8r721vlc8j1xvpk24j5sdjxa2",
+    "tree": "8de4d9163366e3190eeaa5b0c3852f981e23dc02",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
+  },
+  "packages/apps/Car/LensPicker": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "47d480c2e0c557dd3fb2bfe49f421d23bbadae68",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hpfr8m5mmrh4hy20n3f06mcmjvk9an02q2jdk8msjwjnx5f5gjs",
+    "tree": "c843daeb6b8b6ee0c19a5b04d54bd7f676ed24a7",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LensPicker"
+  },
+  "packages/apps/Car/LinkViewer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "82c8431a10a119349c7a9b7896a5e0104db80200",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1pkvykdp91kl63ddjpybmxi3wjfbn7jjr1lhng657ma5aq310g93",
+    "tree": "dcfbc0ee49a50e10a71068cf18d6c92db85123c4",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
+  },
+  "packages/apps/Car/LocalMediaPlayer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "11c2fcbe572207cb06a88b4e8bd151fbed8ba34a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1j0gd87ssnjmxwgv7mfz9i0pc2wgg2yayqbym89dbsr05zv252ck",
+    "tree": "b05890a71bd178f3595b5a4e1e6e8d147fe82b16",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
+  },
+  "packages/apps/Car/Media": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6675ebba7b12837a2f11b08f842c8df6f65aa0e7",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1228j9yyzv5jkm61sjhgd3nkd0h2lb140x42260qdyi7qfh8j4rs",
+    "tree": "4f110b9f6b192ba774d90d0a39e26f3876021014",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
+  },
+  "packages/apps/Car/Messenger": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1ba30827921458a6a48c59095f91b4552718799c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1b9cmxs1gvcf0acr8ipl3492jcf7i5jv278shp8vaw0mmqcnyhj0",
+    "tree": "31d9f3769f860e6066f09379047675002e7162da",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
+  },
+  "packages/apps/Car/Notification": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "137dec060f503c7802e776afa58565fc17cc8ca3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1yx32la46n1ma3937yd7mdi90r93jpjqss9j1vjxa363nvqwdg3b",
+    "tree": "2571b5dd89ef5e6a90a169c40e6a0df8b5f64076",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
+  },
+  "packages/apps/Car/Overview": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4054b7b8d67b44bb38151274db19c7f4678ecf35",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Overview"
+  },
+  "packages/apps/Car/Radio": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "02065afcf35f307821e4a4b52f066ee5b6ececa2",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03zmr45n24xac4gp4mcadiika6jkqbp4yzqwi6ccmai6xrhabpih",
+    "tree": "56dda76f98aa5e4c7367e56a516bf2b37935b51f",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
+  },
+  "packages/apps/Car/Settings": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "04f93ad079449a0657c8a408a173b7ce216438d9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "09vrxlkq68rx4dwfvmq2c0s946ygckma46yzjh291w1s6m7jp6i9",
+    "tree": "800968e98ee947a16457b8898e74e50d8ee6894e",
+    "url": "https://github.com/LineageOS/android_packages_apps_Car_Settings"
+  },
+  "packages/apps/Car/Stream": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c5e804762d7822d4668a3e00feae6848a40a5abc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Stream"
+  },
+  "packages/apps/Car/SystemUpdater": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6906efca4349c62b7cd3dd3e71c10f906280593e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0dbm08s6myz32mm175b0fwq7vaviz1npwlnxf1z4wpc1ljlp2di1",
+    "tree": "2b191ac4db1951864f4aa18343a9d58c5e8eb0fc",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
+  },
+  "packages/apps/Car/externallibs": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c9259bd597da3adf1830b941fe192c6d97007d79",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/externallibs"
+  },
+  "packages/apps/Car/libs": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "620b81ce9d352e484400a0d085ea1da16bd2adeb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1an8d2apa5vb06si1p655xpd7nyqs4c4p600q0fjs4bn7vrc5jm1",
+    "tree": "87e2e44e8cd68d8379025270766ce3cdf69b18dc",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
+  },
+  "packages/apps/Car/tests": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "45cad161318e4360ecdf59ce66fea5ea71f9d9af",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0iil93zlbxg9c5jdkss80gh3ckdckzkrnmhxvrbj4j966277b2ah",
+    "tree": "18dfa28936acde79019be9360c8d0f6c007226ce",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
+  },
+  "packages/apps/CarrierConfig": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0f4ac846afdb30e5a1579c5a1559008eeaaae233",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0qv2baxlfkca0ms7lrl289jmqnwmjai9chv0v4b3nb639vslnw2j",
+    "tree": "e2cbbbaf11526e4236588214924b487574455491",
+    "url": "https://github.com/LineageOS/android_packages_apps_CarrierConfig"
+  },
+  "packages/apps/CellBroadcastReceiver": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "438b7c3c47c822d5980769ed49191d0d3210132f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0mf50pg3mp6gjr225q5jv2cha2a1zkljm7634d5pgmrws61h5k2z",
+    "tree": "3b3f87fb162339418ae677e3412aba9d981cd44c",
+    "url": "https://github.com/LineageOS/android_packages_apps_CellBroadcastReceiver"
+  },
+  "packages/apps/CertInstaller": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "af3289a60f056af8ac92e0f53e9e5765e5209059",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "04j7bw2q20mx1sqc4g7sszcp8vlg5sddlwjqphjnsgkf1yshha0j",
+    "tree": "f10703dc3aa8a2fe8bb9ecd5126d759580251ff8",
+    "url": "https://github.com/LineageOS/android_packages_apps_CertInstaller"
+  },
+  "packages/apps/Contacts": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ff4043a4fe0ef41e1adab2f2fb83267c80788247",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "08vsyk0qn3k47zh1ba5bwx5zhcpb2zam31gcjcvsqnj1vxwydx4b",
+    "tree": "b9ecce230190ce840ffe0596b1b29c1370a7c1e5",
+    "url": "https://github.com/LineageOS/android_packages_apps_Contacts"
+  },
+  "packages/apps/DeskClock": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6fad2c5e4803fb2791d349d7dddb5f8d3d972525",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1vh4s6j7hpa4vlbb3zh2xsb21sd68b4w3cl4ipc0nhwkdvrdhgn2",
+    "tree": "2b26e7caadc3bd85e2b7eaddf0e7f824c44e1b43",
+    "url": "https://github.com/LineageOS/android_packages_apps_DeskClock"
+  },
+  "packages/apps/Dialer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7980702a56fc3ca62464bdab56d244dacf042859",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0lvhl3x684yy0c8yr5zb62qlr5y4v0848rk5ggsf0czxbm7gqix5",
+    "tree": "c28ac52c0f82ead562d690e099b5aa0dde843d3c",
+    "url": "https://github.com/LineageOS/android_packages_apps_Dialer"
+  },
+  "packages/apps/DocumentsUI": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1146fad43f111432d731ba4057319ee2b5e95ef2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "02nvj9rd0287jcmjrkkql33gp22s2rdgi624vnv5mzb4vh46qhy4",
+    "tree": "be3d321715e02c550f3acffcf2739764c2f5b96f",
+    "url": "https://github.com/LineageOS/android_packages_apps_DocumentsUI"
+  },
+  "packages/apps/Eleven": {
+    "groups": [],
+    "rev": "2c472457ca724c7959c099cdee24c873603104fe",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mxhryxnxf6848jvf3cz122a9drqi5svzfsvnc7i1v2f69q2ym6x",
+    "tree": "fbf3d7d592f5d358f6d980b345c5b597232b918b",
+    "url": "https://github.com/LineageOS/android_packages_apps_Eleven"
+  },
+  "packages/apps/Email": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a145cb634e705747451b48a5221e16a0654b04c1",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "15hazmc5bnck2c616zx7ilvybr8bfx5n20ysawqrqmjm8pp3r4il",
+    "tree": "9366bc9febcec460e5df42d45dd1b17b92c48c1c",
+    "url": "https://github.com/LineageOS/android_packages_apps_Email"
+  },
+  "packages/apps/EmergencyInfo": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "06696c74c6c9c203eb76c1564b46a355fde965d3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1ixd1xx8my13ljhqmxfixrs3d6j1jjram45q4h3f3bmmwa29kr75",
+    "tree": "afc2d12373c1f2991d41f871385b415d07306089",
+    "url": "https://github.com/LineageOS/android_packages_apps_EmergencyInfo"
+  },
+  "packages/apps/Etar": {
+    "groups": [],
+    "rev": "33ed35a4b8cc1f39f6affef9063ebc38e773d81e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "11pclr9ygckx54bibhz0584gv3nkvw18ggk4va3yw2w41cai2rk2",
+    "tree": "14dc973b5772c9473d6ff8a4206771af2a806f68",
+    "url": "https://github.com/LineageOS/android_packages_apps_Etar"
+  },
+  "packages/apps/ExactCalculator": {
+    "groups": [],
+    "rev": "d49e5bdfb879c7a28b1ec66033895992227edb6e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1dpzz35bg4njqb90axsza6jmw0fxqbizmn60jplrj7f161zf7j05",
+    "tree": "5cccbb9befdfc0fc456f08283fca03a2426a34bb",
+    "url": "https://github.com/LineageOS/android_packages_apps_ExactCalculator"
+  },
+  "packages/apps/Exchange": {
+    "groups": [],
+    "rev": "24b9788760871d28d4d3a967e32213e8ccac275f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0whhvlsna6dc252ldgvqzswlmbyp7n1xd3cilnakpr563gm6mwry",
+    "tree": "361934e1608ac98a45f0159b229fd89ad53db549",
+    "url": "https://github.com/LineageOS/android_packages_apps_Exchange"
+  },
+  "packages/apps/FMRadio": {
+    "groups": [],
+    "rev": "083683d3fe78f262b63883cb57e3b5f46b79b9af",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1b2p728g22y913rads8nhp81wn7cjn1ig40k9lfbyh1pk9ggizh4",
+    "tree": "8706385bdef4873e9af7cc41a6188f16ebea6153",
+    "url": "https://github.com/LineageOS/android_packages_apps_FMRadio"
+  },
+  "packages/apps/FlipFlap": {
+    "groups": [],
+    "rev": "1aee4521193c1888c9ada9e74968f2fc1b279b5c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1a4p9xcqnxd5gvf5xaw6s3s955gc625wjlgr15wrjkqddl4yvl1p",
+    "tree": "837905b4c094b03fee38a9de6041b7ba46080873",
+    "url": "https://github.com/LineageOS/android_packages_apps_FlipFlap"
+  },
+  "packages/apps/Gallery2": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "844426cfc9c717c1a0a219e92db4ca5d3f009020",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "18frxrs9wgpl15lqfm8gk7bkb3bj2299zk19ng9gcnxfgsr9jgs1",
+    "tree": "0802cbe3902f3d449df6cef4b73e26cf942884f0",
+    "url": "https://github.com/LineageOS/android_packages_apps_Gallery2"
+  },
+  "packages/apps/HTMLViewer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "15fa6be73a5ac5c04181d9ffe1f09ea0f4b88761",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "10hv683l177sl08vy0ns0cm6f07qnx841gb5dfihf4ivfyfv7h9b",
+    "tree": "e1ae0ba04793051caceb1532d465f498cb37f314",
+    "url": "https://github.com/LineageOS/android_packages_apps_HTMLViewer"
+  },
+  "packages/apps/Jelly": {
+    "groups": [],
+    "rev": "04221f3205a020bb78298efdd100d28e7ad4ad60",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1hq5ibc12xc6n9nvpip0rqngi839c8h7dz6ssqam12jp3ss4gkhm",
+    "tree": "9827aa99ac46c47a0b5b5e27eaa4e6a8c4d03e46",
+    "url": "https://github.com/LineageOS/android_packages_apps_Jelly"
+  },
+  "packages/apps/KeyChain": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f56649eb369ccbdc8f228b5104a9b5b36ff2eb01",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1zjsnjh1myflxijyx589lbb6q0yrjfgdhdnxzasyn2fc3gpj8zyv",
+    "tree": "f712ea589740455d5de61786ad48a11251160dfb",
+    "url": "https://github.com/LineageOS/android_packages_apps_KeyChain"
+  },
+  "packages/apps/LineageCustomizer": {
+    "groups": [],
+    "rev": "902123e64d4f365749d692baa23909f216cebc82",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0pkpir6231il6xyy60dyab66p1586dy8xj44bdln9f48bynk2jwz",
+    "tree": "cdb519ae6b6e13074fee73b748614f46941e7ad9",
+    "url": "https://github.com/LineageOS/android_packages_apps_LineageCustomizer"
+  },
+  "packages/apps/LineageParts": {
+    "groups": [],
+    "rev": "4ff47ab7616aa4ea65bcad310f55c837a84f9bdf",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "012jqm44575zr0dgricr8ymgihn2bck6nshfsh734hacvv3vhb5r",
+    "tree": "0903126c5e83c7b042693b5b89365c4656ea9bd7",
+    "url": "https://github.com/LineageOS/android_packages_apps_LineageParts"
+  },
+  "packages/apps/ManagedProvisioning": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "75376deba16e928f8fd01c8fc12e6eadcc72fb15",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "02r9h29dalx7w4n46j5m49ingrz5p66drhjjqqlg1vkkfvxvhvlf",
+    "tree": "fb4cc5b58a8fcea29c42b0765a9b50a33ba4e101",
+    "url": "https://github.com/LineageOS/android_packages_apps_ManagedProvisioning"
+  },
+  "packages/apps/Messaging": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "793c5a31eeecb78b7ddcdb4b46803ca6e83199af",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0d3y1rw3l3vcw9zas24q2jn3ag7gslfgbayaq25z1fddfy4h5lp6",
+    "tree": "d4c4c8804020b88c294200cabf59ec6f75d5b7f6",
+    "url": "https://github.com/LineageOS/android_packages_apps_Messaging"
+  },
+  "packages/apps/Nfc": {
+    "groups": [
+      "apps_nfc",
+      "pdk-fs"
+    ],
+    "rev": "ca38bfc5d6a179ad025b45e81973445d95701c4b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0wlj8c2r6xvrykky7qmdqh0mn492ly1h0h5892mw5famj2lm1vpx",
+    "tree": "f27d258d078cb8ac5e27e843d1962382938db476",
+    "url": "https://github.com/LineageOS/android_packages_apps_Nfc"
+  },
+  "packages/apps/OneTimeInitializer": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6d39c3b3b17282183227d6b511d2d2522aef644a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17rqisrcp9x4fc3kky2whs6vjbjd91d39zasv24nbx2df8kqwrcy",
+    "tree": "e17094b6fda7f5aefb3a2b1446f90d0983226b04",
+    "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
+  },
+  "packages/apps/PermissionController": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2a42d842f7dd9c5ed7d1f8da6864efc0b775996c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0n5wqxdsywr1mcc0q2ixkb5gd23sfj5pafxq7fky3m8hg1wynmnj",
+    "tree": "fd0905c927637e2a9260a639ce0e0657b39f97ea",
+    "url": "https://github.com/LineageOS/android_packages_apps_PackageInstaller"
+  },
+  "packages/apps/PhoneCommon": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0924dd97862a4020108dd2413867bf6ae5529d85",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fwvffjkfpkmydzmsx4zgy4g5v9r83mg6lfm14lgpiginbsslx0y",
+    "tree": "ab325faba6143f565d4bc3e453ca667c2526424a",
+    "url": "https://github.com/LineageOS/android_packages_apps_PhoneCommon"
+  },
+  "packages/apps/Profiles": {
+    "groups": [],
+    "rev": "cae3c7a98d121c477ac7ca757fdbcb500a091e58",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "193cnrg37y48b1yfw86rcwq447swbqs43whlc2kimjfqrlq500s0",
+    "tree": "0738851334572371c23ec44aea30829509558dea",
+    "url": "https://github.com/LineageOS/android_packages_apps_Profiles"
+  },
+  "packages/apps/Provision": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b34dc8492a2a9109bc47b1708f124eb314a383ea",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1k8i6pxfqymjqvj0mxna4riw6xgb7an1dbr3b1hvvh2mpi31031p",
+    "tree": "6cdafaa3a88020d3ff57f55bd6823d31feef0bee",
+    "url": "https://android.googlesource.com/platform/packages/apps/Provision"
+  },
+  "packages/apps/Recorder": {
+    "groups": [],
+    "rev": "ecbce95b2b6868d028f2741ade9251a73b733d6a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0wb7493sn1bbvalw1kigz0pby5m6rs6gbflgr4wg4yk3rgnkhqnx",
+    "tree": "9a5dc431f5cad6f5a4d54849a4b815d0ef488314",
+    "url": "https://github.com/LineageOS/android_packages_apps_Recorder"
+  },
+  "packages/apps/SafetyRegulatoryInfo": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "683eadc7b0ac8d9c479a9df50e93fefdf0234183",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mghi328hpaxi3568iqiaxr1ac5f37bf8b20kk9hdkd78zqfyl18",
+    "tree": "c1a7031dcb8c631df4abba91e1535d225b290157",
+    "url": "https://github.com/LineageOS/android_packages_apps_SafetyRegulatoryInfo"
+  },
+  "packages/apps/SampleLocationAttribution": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ab62902f27f034063e5570494554b4e2ccb06cc4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "17jknvz8p09y76crxahxzigavh0rb7140i0xy0m63a65aa47qf8i",
+    "tree": "823d636adfc3fe09adb0e3e9d0b961136c0ddbbb",
+    "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
+  },
+  "packages/apps/SecureElement": {
+    "groups": [
+      "apps_se",
+      "pdk-fs"
+    ],
+    "rev": "35a969d61cf59ff30d5a0879eacc301e2ffca35b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "10mix8wc6aj40nsl83mm4phcbab40mzi2hlhsajv4q53cingcaff",
+    "tree": "b5f1104729419d0841e74f56c04f42cea8fd67b6",
+    "url": "https://github.com/LineageOS/android_packages_apps_SecureElement"
+  },
+  "packages/apps/Seedvault": {
+    "groups": [],
+    "rev": "ee10de44614e8cfe299b75ccd50fdd18b9faaa7d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "059674xv1fmnsnxd5qay28pb1n6jzl6g17ykhcw7b93rpydq3r4g",
+    "tree": "e7a2f2c08fbf059d5b124479c9dac328c5909335",
+    "url": "https://github.com/LineageOS/android_packages_apps_Seedvault"
+  },
+  "packages/apps/Settings": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a45a83d446fb91d0b8a545fd1644f78cdd87f3f9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0h06inf4nl8r5vhvjljypnysqzk3mywjymcwzys2a0yd8jr9g5b2",
+    "tree": "b63ba1185b55c308f299f9bfd33789b1efd9e339",
+    "url": "https://github.com/LineageOS/android_packages_apps_Settings"
+  },
+  "packages/apps/SettingsIntelligence": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d260274e0bc1ca7e97a23c292a240a1cb2e426cc",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1k50n92v2mvcxsrfw32lz4wr5prlirni70qwnbilh06d3v2wih6a",
+    "tree": "9f6ac8bbec23a29283745fc90f7e1d68ed70f3e7",
+    "url": "https://github.com/LineageOS/android_packages_apps_SettingsIntelligence"
+  },
+  "packages/apps/SetupWizard": {
+    "groups": [],
+    "rev": "6e41cef44d72d93d6906feaf7556c92667d9bc11",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0h11zc04p95ql08f1g8vb4azs076fyxhw78gd0i3bsfd9fry0y41",
+    "tree": "44c64f7ef4111792263ce49ad6b12de9c0080225",
+    "url": "https://github.com/LineageOS/android_packages_apps_SetupWizard"
+  },
+  "packages/apps/Snap": {
+    "groups": [],
+    "rev": "7a4fcfa16dc66a21524e90b383e6a2b09eb684b0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0mml1n34rm6hjsr3m40mg7gzrh8mxvnxd46z9v8474w7g9hpqnzk",
+    "tree": "866737cafd85892c8c18c9f98f2e7336e270c99d",
+    "url": "https://github.com/LineageOS/android_packages_apps_Snap"
+  },
+  "packages/apps/Stk": {
+    "groups": [
+      "apps_stk",
+      "pdk-fs"
+    ],
+    "rev": "7fc8734ea0ef4aee6a70126bd9363a77355a9d4d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ip62av2ygcz29hjw36vy2s66ahhngl85scysxv58rbcw79lzahp",
+    "tree": "ab4ad730cdd0c4f7827ff05f0213c91a1361a6a1",
+    "url": "https://github.com/LineageOS/android_packages_apps_Stk"
+  },
+  "packages/apps/StorageManager": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "15c9644e2f8e2a5eb60dde896868b2e86244ef11",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ff3q9zkxhiqcb09psw9sdgijlymwxbv7y0sfp822kg5vqw9l6bb",
+    "tree": "b531bd93636117cd59faeeafb9988d64c71bdd1e",
+    "url": "https://github.com/LineageOS/android_packages_apps_StorageManager"
+  },
+  "packages/apps/TV": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6ef1da30031e5c757aa1d75bfc11aa7197f7daf",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1bkdpx9jgxnc8b3rpvyb72q7mi7i5fzp43m0jlkm6x260djn6wjq",
+    "tree": "f4ba89447e2d7ac3355508e583a5cf0574c29af5",
+    "url": "https://android.googlesource.com/platform/packages/apps/TV"
+  },
+  "packages/apps/Tag": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1b66b0b9c67fdca93178b6c967ef6252ce1b4b7d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mv7azii5bysz2l159wskgcvjc764vkacwvcld1m5qj0xdv78ym8",
+    "tree": "435fe0e81b098e83a171393ecbfdc9c4d4f34a1c",
+    "url": "https://github.com/LineageOS/android_packages_apps_Tag"
+  },
+  "packages/apps/Terminal": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5e45ffac6c4e215ebe97b44c619f401f02e3e0bd",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0jm8cn72nsivcac4agdn6smwnzyvx9nqysr3ac877hn8v3swbgmr",
+    "tree": "1649d3f8e286c4044a932c7dbe0765546fd7b989",
+    "url": "https://github.com/LineageOS/android_packages_apps_Terminal"
+  },
+  "packages/apps/Test/connectivity": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52acaf7795aecd89d30d4047400c450b257890a4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1hl87g67qhrkksvymmzl2hzxvbm2v696fbb81q6cz5yr50fwvxcx",
+    "tree": "2ca63a07662d88913d3b4a3f940b52005119c289",
+    "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
+  },
+  "packages/apps/ThemePicker": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "84baab3894f3af75bb648d1a0dcc0cab50cbec6b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "02d5dl57rifkx7qqn04nmf9yp7jvffayg8s02isqh28fd6xprj1w",
+    "tree": "f5413024dad888ee7f7ebc96e8659c4b4e52b535",
+    "url": "https://github.com/LineageOS/android_packages_apps_ThemePicker"
+  },
+  "packages/apps/Traceur": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2928915b3d316a430c51d1064319d71c4adda373",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1wbf0r1bs581mbipwx0v2zrv5kkkfaq0a7bgq71wbcyg6f7njgzw",
+    "tree": "927b273636ff628c46837cf9304c8662edd390d1",
+    "url": "https://github.com/LineageOS/android_packages_apps_Traceur"
+  },
+  "packages/apps/Trebuchet": {
+    "groups": [],
+    "rev": "126f83cdc2bddb87915959d191d8fa42609e7448",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1ni7nnxbzdwvyza8qkk19159qyj3qhfp4nadpj02bc56x0b6gx0l",
+    "tree": "c6933b9f6cd2bf89993c2f6fb32a6908005b8172",
+    "url": "https://github.com/LineageOS/android_packages_apps_Trebuchet"
+  },
+  "packages/apps/TvSettings": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "09b2493517410f1cb282aa917ac587040796a515",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0z1a64mvjklgyz1yam7iavgdhhwarg6wwgpy31vq422cjji5iaya",
+    "tree": "5894710fcef1c03306bb8d4c6633d4cd395b633d",
+    "url": "https://github.com/LineageOS/android_packages_apps_TvSettings"
+  },
+  "packages/apps/UnifiedEmail": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6f125a2fcfc3ebdedd3ceda51dafa7c5f6890996",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1620yjmay5rws2qjwhq8nxj0dm2j5bgyhy6lb4qjhwd39ksx25v2",
+    "tree": "1764ac169005898149e7453f6cf9952b1d9ff898",
+    "url": "https://github.com/LineageOS/android_packages_apps_UnifiedEmail"
+  },
+  "packages/apps/UniversalMediaPlayer": {
+    "groups": [],
+    "rev": "96816109bd8188419cd761164547f3def77110e4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1h168q7jzkd4nazziw0cf73gg38xz0y4l0zd6r27f2lhhrh1c5i0",
+    "tree": "2af00eae278d40bf5828ef933852357515acce6a",
+    "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
+  },
+  "packages/apps/Updater": {
+    "groups": [],
+    "rev": "90e4ccbd61684415391357952db1ea323b21f373",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0g3kkvs6m1h61y383n0wg550pqrfxc1kkzrrpczjh5n5sp5zjzds",
+    "tree": "1ec6bf1d322ac6eea28aa0c5b7ebb63bfdec0044",
+    "url": "https://github.com/LineageOS/android_packages_apps_Updater"
+  },
+  "packages/apps/WallpaperPicker2": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "511e26f47f858ff872b6f7ce46da98accb60bd3e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "05nb6psdgj6i3b13xi5yinpik12klf8d2gr90sms38jqk02vgynk",
+    "tree": "4d60239ea88872b1e9accee0b4b75e5458f649da",
+    "url": "https://github.com/LineageOS/android_packages_apps_WallpaperPicker2"
+  },
+  "packages/inputmethods/LatinIME": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "fc3899dc037304e7f0a02d2d30f87d5afc20d415",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fp45y7g3wy7l4fwdz996dma9vhbzl49b8hplppn1fdyhliqb9z9",
+    "tree": "072e1753326e055dc7562b3f84574765702f2b73",
+    "url": "https://github.com/LineageOS/android_packages_inputmethods_LatinIME"
+  },
+  "packages/inputmethods/LeanbackIME": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c15e8e709714310c8a31d83522b66493b10e22c9",
+    "revisionExpr": "c15e8e709714310c8a31d83522b66493b10e22c9",
+    "sha256": "06421pcbli0423p0dpxrj6jl2rdq81krwqhhzfiv5ay0ir2agcmn",
+    "tree": "04e0b939ed5cc092e03c10f5df8f4729f9b123d5",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
+  },
+  "packages/modules/CaptivePortalLogin": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ec980ebe280b6c48c20a2b516668da9ce699a0f7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1rv19va1rkricxc907i8aagbj6xqdijl73jcqsrs06grwcdz8m6k",
+    "tree": "d73f3f773f97ce98be6384272929d56a39ace1ee",
+    "url": "https://github.com/LineageOS/android_packages_modules_CaptivePortalLogin"
+  },
+  "packages/modules/ExtServices": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b8a07556e6b40e8b6d0f0fbf13931d46f6659879",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0jn8fmhfczpisjl0x6lmy0wb0k31agii9rb9zi9w6bcajsbgksvf",
+    "tree": "dbcf04e91e57d337ae8f8824cda415d79dbe1615",
+    "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
+  },
+  "packages/modules/ModuleMetadata": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f4366b892d5bd07c2ece3c12d2db08d56b299e73",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1s32i5na9am44w2p1rw87p442z9hp878njwq2g8lg4dr5y8amk9l",
+    "tree": "31410771c98825bc1577deab0e160b868ac078ad",
+    "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
+  },
+  "packages/modules/NetworkPermissionConfig": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "79a8ec1efca76eef240afc467c95fa6fe9988cf5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1bv1aazhs8azi21x5ryh0qmlckrcg5gj40xlqs1l5rlr2avrk7mz",
+    "tree": "210cbcea5069b4144cc4208d97efb719f20936ad",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
+  },
+  "packages/modules/NetworkStack": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c3a05cde7be73c3c0ad8508c3362ed3f76f01f27",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mzilknwwdc84856zrfgzrlc0xcg20661ddr1qf4pli2kx1cv5ma",
+    "tree": "bb684c29f560c94d452971a08e59d5126ba5ed5f",
+    "url": "https://github.com/LineageOS/android_packages_modules_NetworkStack"
+  },
+  "packages/modules/TestModule": {
+    "groups": [],
+    "rev": "4389f99b396cafece17f54d82552f40a10e31f12",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
+  },
+  "packages/overlays/Lineage": {
+    "groups": [],
+    "rev": "35fb8bae39e632c947e2fa65e2c9eca20ded5cd0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1j8za4a2bpbnaw94mbdzx9awxf63wzsw83j92vlqnhp14dngp9f1",
+    "tree": "503c3ac5ab8b1f609cbbba25fe6a8d575718ade3",
+    "url": "https://github.com/LineageOS/android_packages_overlays_Lineage"
+  },
+  "packages/providers/BlockedNumberProvider": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0869591488bdfafcb772a74b12bb894ee012ebc0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1rq26zjc4z71j0xmpvc4pck9lx3w9y0n24pahpk5pcljgswr29vq",
+    "tree": "28492caca648362ee99473245362c869176f6143",
+    "url": "https://github.com/LineageOS/android_packages_providers_BlockedNumberProvider"
+  },
+  "packages/providers/BookmarkProvider": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "984c5c1c840f6a4f61f42a2da93280a7f0351673",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0g00m7i1qmzir4lx8j69n8ini11x87zm2x13wrm2mk17cp6s1md6",
+    "tree": "e18cfcadc96963f3e4ccef8344e00df40425c80a",
+    "url": "https://github.com/LineageOS/android_packages_providers_BookmarkProvider"
+  },
+  "packages/providers/CalendarProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "095332e5463b306ea6446cf7cb00fe0e901d6301",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1mrfpgaz8h8pa30c5g9bvs1h8vihdwykp1lb7dxfzy7hs45qpi02",
+    "tree": "2e5b36c9c1b3509507eebd742a1778c56088ae67",
+    "url": "https://github.com/LineageOS/android_packages_providers_CalendarProvider"
+  },
+  "packages/providers/CallLogProvider": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2b8b96af587e805cf76648ce3fb3fd9d391aafb3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1966j7ksxsz6z8jfr7cjs486r0ch9cbdkj961fqgx73vp2zfv09m",
+    "tree": "6b5d175103290144b12327291eb866743926377b",
+    "url": "https://github.com/LineageOS/android_packages_providers_CallLogProvider"
+  },
+  "packages/providers/ContactsProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "829c32c8905f15a9068e7c906b647aa38a71f063",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1y5d464vn86gzw9sgalkj7047c0fxnisaswf3f7synwy66s7irk9",
+    "tree": "efa79de86de22dd4370204260843c7873c9356c8",
+    "url": "https://github.com/LineageOS/android_packages_providers_ContactsProvider"
+  },
+  "packages/providers/DownloadProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b23b87c6553cdc13d2278412ad7abad0f62ce364",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "09ab3652brjz45lgywjrjdgmf71pi8pnp16bn4vmidy4v0wjwjnf",
+    "tree": "8f9a94ae289feffbe09332c1fb4c852bfca44b85",
+    "url": "https://github.com/LineageOS/android_packages_providers_DownloadProvider"
+  },
+  "packages/providers/MediaProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "219e448fc973fcef36a841adc352c7d756caf2a9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "09svsy2fllfnyxi4fc939g4irm3bfqi69k3q4m2gf9ajwr3v4kqg",
+    "tree": "befbe076da046c6402be1bf9994d93636aba197d",
+    "url": "https://github.com/LineageOS/android_packages_providers_MediaProvider"
+  },
+  "packages/providers/PartnerBookmarksProvider": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9c3b541b4357011de2047a2e24f92a63c6d8d8a0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1f6ca0dwjfxhvri0pax64jfkbx633kp73fr1qfz619bg47d2mx37",
+    "tree": "59b09c3ec7a34a33a547d64d7d3efe0ef041150d",
+    "url": "https://github.com/LineageOS/android_packages_providers_PartnerBookmarksProvider"
+  },
+  "packages/providers/TelephonyProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "dc5bb0601f864b8bd9ed9f0a4a8cd9aa9322698f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0y8b5hp6d8wr7y4v90s5vdvm5dzydp8ql52fm7sfz3ygjijylh36",
+    "tree": "42e06aad850362c6e8069a684fe8d6d84595c99f",
+    "url": "https://github.com/LineageOS/android_packages_providers_TelephonyProvider"
+  },
+  "packages/providers/TvProvider": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e2ab9cbda2375779514cfafc93c9da5297ce1ee3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1716a96z44nnn3bfdyhlkq4x95hq45xaaf91vx0iaazcl1jayazy",
+    "tree": "f0a47073fe291baa953d02d6d5474fd68fd3c667",
+    "url": "https://github.com/LineageOS/android_packages_providers_TvProvider"
+  },
+  "packages/providers/UserDictionaryProvider": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b37ebe3ed771712f87f40759ad37885c5667a3c9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1d2rr2q2jmnmn2v3zxh8gn0hisxpivj118gjnshxgyq6kbd1qhij",
+    "tree": "b688f965c1bad5728fb50fd3fe933420690db9e8",
+    "url": "https://github.com/LineageOS/android_packages_providers_UserDictionaryProvider"
+  },
+  "packages/resources/devicesettings": {
+    "groups": [],
+    "rev": "c08e328d1220f4a39a116dd4d3890389848c3378",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0iw9hqi4vnnri7cj7zns3w18ia45yccld97gmz93a1qhqbia7dd6",
+    "tree": "92eaacb40ad682f38ed5a05e8e9b556542f96241",
+    "url": "https://github.com/LineageOS/android_packages_resources_devicesettings"
+  },
+  "packages/screensavers/Basic": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "97677a42e0aa48839c84639c7c25be70399412e7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1iq0w4n78hccssx62zmwbj2gbaarx0fs8zz497p0z79j1rbn9hh6",
+    "tree": "a98029d82a716b0243ed56a73d55b2b8ddc935b1",
+    "url": "https://github.com/LineageOS/android_packages_screensavers_Basic"
+  },
+  "packages/screensavers/PhotoTable": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b87fd511fde7b0e6eda90610335daead33517f10",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "01wbbw8qw41xndn2v7jnpdki10vsa3mxi3j3wmwnraxa5drrzlsi",
+    "tree": "1ac671e1598845d971a86a2bfc0382d58d87d0c1",
+    "url": "https://github.com/LineageOS/android_packages_screensavers_PhotoTable"
+  },
+  "packages/services/AlternativeNetworkAccess": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ad6aa36d9b29c736b1cc941d25d321411a955fef",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i3r2y0pqwjbhc9panrvq1gwgby5wdncvn3z2pdbkl63yj5fbh3n",
+    "tree": "89e3066b7495661d9575d121620148397a64ec53",
+    "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
+  },
+  "packages/services/BuiltInPrintService": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9ead2d8ea26b35d843a2ca3aa46b10074d37efac",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0s6b2pzk11y55k6mqdcc52kwrc0xmgms8crvmiqgy25znixarsds",
+    "tree": "f2f26f94a4890b066dd5a6b132fd061b2e488a68",
+    "url": "https://github.com/LineageOS/android_packages_services_BuiltInPrintService"
+  },
+  "packages/services/Car": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "946cafeafe66fab744128501447990c929b4498a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15y94k67lvh4mnnkgg2syibmb7z5cy45k8jmjw9z7lznm5nz3zlk",
+    "tree": "b1150cdd786be7d955fc16cfa524142465b21ea5",
+    "url": "https://android.googlesource.com/platform/packages/services/Car"
+  },
+  "packages/services/Mms": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9bf512cbeaf7e8c5176f57982b62b3d99884971c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1jmzba17g95zi6w3j95hy4v4w3jj3f234mvnr3knnqpvplbds555",
+    "tree": "43c2367cca53d26c72a8d192f4402f50f09a2d51",
+    "url": "https://github.com/LineageOS/android_packages_services_Mms"
+  },
+  "packages/services/Telecomm": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c7d27cc47de2b9aae94be944b010cdfe61d6751e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1qrb8r89vrikiprcpga747r6szg8x6gki20s0xlzg1ap2knigpl7",
+    "tree": "19477f9fe0797e77c5c7d7b9737e448243299c04",
+    "url": "https://github.com/LineageOS/android_packages_services_Telecomm"
+  },
+  "packages/services/Telephony": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "600bee05dd3607976a39886c3c2bfae1075d4b8c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0j2jsi0a207jvx19gqgwgrljzqypfa9njr9sjvni3glxpqwlwav9",
+    "tree": "98696613ff1472242a770a0084c2de6043f651ce",
+    "url": "https://github.com/LineageOS/android_packages_services_Telephony"
+  },
+  "packages/wallpapers/LivePicker": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5b6b44cd8771ca43b760b3b811e0d84d3462a17b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0cg3fcb565ad7mvic74yjk60ca6gcs39qapmgj1kj3ljdmvhg33q",
+    "tree": "969c190ac5a244634060697738a173eee6b7d168",
+    "url": "https://github.com/LineageOS/android_packages_wallpapers_LivePicker"
+  },
+  "pdk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0bcb6f9e5204d84e82a21512b80c16f6db6062fe",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1yz19kg2rjyf9jdh74i85sifqdcsmd4955vfyf7dcglp14vd3sd2",
+    "tree": "9f303ba3566f38aff9c9bb881bc6cc3e997212aa",
+    "url": "https://android.googlesource.com/platform/pdk"
+  },
+  "platform_testing": {
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "137136fc33b86dfa3b27760c44caba983972df06",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ljk45bl6a89rv541alffmgdn3hgc93bch42jw4jjwirxf0bvqg6",
+    "tree": "8e08b5bbcf33367b155847d051ff1d2bd93adbae",
+    "url": "https://github.com/LineageOS/android_platform_testing"
+  },
+  "prebuilts/abi-dumps/ndk": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "960ab5167b654de90f9bbd49d252d60b94dc29b5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qjls8qy6i07dnhdslvha7pa8kd4jx726qyl9155hwwj8d6aq7ya",
+    "tree": "0f44ccd8830d1bc2767fbac9790e83d2d21212c8",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
+  },
+  "prebuilts/abi-dumps/vndk": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "22388ae3935284038c2cb4bcd54068eea809838d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0y2497bzjrziic4qlxhj0wqsw2znksx7lxb1sghi8afj530ma53y",
+    "tree": "76921fb16a816c11cd6742a79e2901194c697efd",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
+  },
+  "prebuilts/android-emulator": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "15773d7371840b048b5f9a588b0eeb49713b6fc5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15ggh0n4dab4gsp7s9vg8jfyzinscqq40275z0lry73741bf09ps",
+    "tree": "c8279024ea87ba9892bcfb59c659160ea81dca43",
+    "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
+  },
+  "prebuilts/asuite": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52e796f0422e7ba76787c1116276d65258a5e991",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gvcj0c5d0r9gz6mjjfrai90qx5d868kxwjlvmpps4qs8q9ijyzv",
+    "tree": "0b3026687f1f64f436f6b81ac24e802666c65d73",
+    "url": "https://android.googlesource.com/platform/prebuilts/asuite"
+  },
+  "prebuilts/build-tools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f068d8b9fdf454907a523381fa6f8c197455022a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1g5krg2378snrf0j88k3cgldv0cjpqjvn0dlhjwlil83nny8wlma",
+    "tree": "1ee08ff760391015a420e0a65345311abccfd626",
+    "url": "https://github.com/LineageOS/android_prebuilts_build-tools"
+  },
+  "prebuilts/bundletool": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "285b4b95f48722df17a4695a9d76455a02c13d79",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1b4r7nf671sbwgirpb8yb7rq8mwgyfz4ibi5a743a3djkqwnpkjy",
+    "tree": "025d527d6c119533ca33c406eb9a01ba3698df31",
+    "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
+  },
+  "prebuilts/checkcolor": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b290049fc76bc232c3831311e9896da86e9d033",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1lb21zxcix3rmcd4l1n0kar85dh14qyz2gbdsv1ih3qsjr2520hd",
+    "tree": "33312bb6edc73900094bbe79edf4718110fdac6c",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
+  },
+  "prebuilts/checkstyle": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "323250e420236d0d71cb92614005ed6bd7262b9b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12fhm4rmyniwlwbv1amr09x8qxphl3pjh9lnngk0k87nsw5sg05g",
+    "tree": "8c17aa8ab579dece5af191e005d3c41980a546c2",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
+  },
+  "prebuilts/clang-tools": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46aada4d88600dc239f39474059e3643366e0e46",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0zy66s6612lf2v8lnnwbi671z1k0qgf3fc1f6n8106cl95ad9pbn",
+    "tree": "0fa4684d49397a9b49950e2201b5f5f8f3aa4420",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
+  },
+  "prebuilts/clang/host/darwin-x86": {
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "e4072d353239ae561ee7c709c1c475a4db47c928",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "04b9w7i7falaw342qdpd7xydy7zcgjz8ba3cw274849b27n4q098",
+    "tree": "e1138bd7485a231254415c032206e459b3456e85",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
+  },
+  "prebuilts/clang/host/linux-x86": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f79817509c4193070c9a0016a0fd0c4bd4cb0b8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03xcs9838znm348bzx8cimmzhrljkmn15i6j3bipwbvbqrd2jn58",
+    "tree": "4ef70d87cce782d27f8a10489d04dcf86cb9d082",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
+  },
+  "prebuilts/devtools": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d921e7491348941a77973bdd5921f43de60d99dc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0r51j9bg6fh2pql2aan6n14qpnbpxnqm0m1c0sr0arzlbkvhxwpd",
+    "tree": "866a2cb9523d8af9821af4e3fff805a440206fdd",
+    "url": "https://android.googlesource.com/platform/prebuilts/devtools"
+  },
+  "prebuilts/fuchsia_sdk": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "009c9f80360375a62643e17d4da632218202f313",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "001drwhz1sl26p86f4k81g4lv56n4crv4mna8i1dg7dar3cbihzw",
+    "tree": "2cd00eae57b9b04c05600b1c61d33e25ed34b029",
+    "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
+  },
+  "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "44dae3c9d557c5efd0367a9d2269379e27ca0b97",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1q4m1lqdrnblx2mhzv4gh5n6vm6k3x4bwds6yswf7fwfwbn64fdh",
+    "tree": "cb73e042b89216f8a79c67c392c4187fd0b6e132",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_darwin-x86_aarch64_aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "81cf67316a4fa5be5cd07bedf02a2d428b0f468e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1a993s1qzzxyk4kp865lhyniynfsx8dmwl5qw7v4mh9z3wm9x8s1",
+    "tree": "bcd6dadf7f542b26e217d36410fcd9b82d9bb29e",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_darwin-x86_arm_arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "3ad6ae68d0194513f7205b2fdae6dd260fcb49dd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
+    "tree": "77441d174377cfb9d7ed360ff8677ee85a717c3a",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
+  },
+  "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "groups": [
+      "darwin",
+      "pdk",
+      "x86"
+    ],
+    "rev": "ccc3c7815af43120058a5523324b75b6c12c7434",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xrh974n99w5327vxqq2ia1hb3kafgp1vcq4j2i3qb3r6w5j3gw3",
+    "tree": "53481a2e2d2214941fc8669796ed2ad721805048",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "a61b4b9ea2a5098dbf113999526978aec683753b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0li7glqw04p247a7814qpqp75bzhr2ddb75rbkwbw1gsihxd61wh",
+    "tree": "fee0bb0888cf6062dee7bdab0d6ebc5a12541e80",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "0e7d16580dd5fb78734174d56887f1e681d0ee4a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "15h3pnmqn71sz5bm7wp1dq0s25xq5n97b28jwc85h9h59nswqbhk",
+    "tree": "e6bb2f4e1df1059ce0c02c675af7e7e2bcbe91c3",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "2d7de97d274478f35a313dd07e0fee22b4d9adfb",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1bb05172754nj1z0vwwf4r1n0q9j6aah4nda2mryvhjadgih2vbl",
+    "tree": "6e33958c70ab9cdc8dfe47067a9b5dbfbd4b047d",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b003055db2c1012f203fa5184348916f190dd308",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1jx7760r08jp3c07c9d8095g1ncvd6arhlf3yl220j4nhw9j4pll",
+    "tree": "3be6b8f522ab3ca42f2b0b771b8df1d285a50d88",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
+  },
+  "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "groups": [
+      "linux",
+      "pdk",
+      "x86"
+    ],
+    "rev": "698ad2d5f745975e177095be96e1075c649f610e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "01nqqn3pd9zx0jdjf15kcqdg833kmv1pw2jg004dxzkx5fml4vfk",
+    "tree": "f7709cac0bbe4b3862ff59a6f51110a41ad48cf5",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gdb/darwin-x86": {
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "3c750d34fcbaa3f85a844e14a82c9a28681246f4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1955726phafj6xq2dj5nm8qw6sxrjgjifgvyfiwf1798ng66bjim",
+    "tree": "aa0317b5e4cecb458628be3a20f8699bf5fd2342",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
+  },
+  "prebuilts/gdb/linux-x86": {
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "920807b11c694fc8fe1cdfc1cfec40989fd7a255",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vnad9il3ymrmcpg631cv9hk1n5h31ss1danxzl8pa50g33wsf2r",
+    "tree": "09920eceee3a2615654645833754f54ffd17b580",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
+  },
+  "prebuilts/go/darwin-x86": {
+    "groups": [
+      "darwin",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "ce77f6573a6c9ef0f350915597c3eccffbcbffc3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "123wf7has5082h6fij5f0l6f5si62cmdxilhnnkhk76ay3avwpw5",
+    "tree": "282047766891be9175ee2508e126aabc681af89c",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
+  },
+  "prebuilts/go/linux-x86": {
+    "groups": [
+      "linux",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "75adb1a9a5f590ad48a97b3124f978e97d08ff48",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12fdj6ilzyandqld13x3ka58dxa36rv5awnli04hpc2ci3ma4mvz",
+    "tree": "fc4aae62222feb015c306e08c0b4920efd832b81",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
+  },
+  "prebuilts/gradle-plugin": {
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cd9bca07c632decfbde0ecb5e1b71358f11a6940",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1l9i5p9kswnrq9ay9v5h8cslfkv80bhfk3bzf7czh5f3qj09sbwf",
+    "tree": "7061d91d9e7bb304b45d9b9286491a4710628fcd",
+    "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
+  },
+  "prebuilts/jdk/jdk8": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb35c314fa828734e9ab076c8d987d98752ab6bc",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
+    "tree": "01bd432e31d7cf56674aa9b4f2b00ed315386305",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
+  },
+  "prebuilts/jdk/jdk9": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c52d2545bed049bb2286fecf804cdcb45039a308",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1mq2jsnwgflaary68r3z1cyfb8fa3pwahv4bpagwkjaa8cv8y3bc",
+    "tree": "e6f2eb3a71adf37bfb0e272764ea99de556cc0ee",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
+  },
+  "prebuilts/ktlint": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb6a66d87c24f3d1af84f55468a0f0a676959749",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1cy4jnvh816xy3x9903shnci6japg833dyv43h71j6r19xqwsa01",
+    "tree": "3031abba104d5e5d2abef673cbe513770d2001c3",
+    "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
+  },
+  "prebuilts/manifest-merger": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac9a9c5e3ba437ab4d758bd29ddfeb796d048980",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0y1k1243z6j324jdban21wv2waz843ld9w7v74j9lfz5860kc4qk",
+    "tree": "8f392eef90653382678dd3bee9091e87c2318c94",
+    "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
+  },
+  "prebuilts/maven_repo/android": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7369c4f4bd2f217d0cb62af21a7b9c73a358fbee",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
+    "tree": "0832b1592aa8200e0d8b30639bfea5813030a20d",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
+  },
+  "prebuilts/maven_repo/bumptech": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ce053ff65ee7c107657af4ccf362e1c4d699c09d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1vdpn3nmbm6b59pk90qnsz720gxdwqrkr2hc4lpdbql4bx2z2gjf",
+    "tree": "56adc7fae8abc205282479ea2b0848ce2b559a01",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
+  },
+  "prebuilts/misc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88f8fce44b9bd966328b86f149c315c7b0844580",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1wng3kcswxcx9j711d4pdzzqj44pwh50ag04b4jvm9fsjay9kjqk",
+    "tree": "4477ca497e619f5c766d6c9a0b933cb91789d24c",
+    "url": "https://android.googlesource.com/platform/prebuilts/misc"
+  },
+  "prebuilts/ndk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "55414c4741dd97aae516390bf4ef11d58cd9f74b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1zpk357i8w40wzff026npb1651q7hl17rv498c6mw5ys350hrwg0",
+    "tree": "6930e020aa37a27db587d3673fa14caab32c2b23",
+    "url": "https://android.googlesource.com/platform/prebuilts/ndk"
+  },
+  "prebuilts/python/darwin-x86/2.7.5": {
+    "groups": [
+      "darwin",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c85b61528efc5833d86c71b64b731274f47443fd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
+    "tree": "c0ce8f39fe73178fd646b5c15f4f349f94ec7d96",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
+  },
+  "prebuilts/python/linux-x86/2.7.5": {
+    "groups": [
+      "linux",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "3c581c1aeaa3246dc910d6b6027d141808fe5938",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
+    "tree": "9fa1607f1d27e9cc931723d14fb9d7b29719e4d5",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
+  },
+  "prebuilts/qemu-kernel": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c79bd52e4c04fbe1aa842d6edc3c15bf0f2757f9",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qrj1fjvjkpli9jqrz1zd4q7zcwzxcl06yh1idwy23zkmlk9mb9d",
+    "tree": "d6bc7521869bfa593d2357cdfa4fa5bab361032b",
+    "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
+  },
+  "prebuilts/r8": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ef1b5ec49cdcea431b8cfffaabeea83a75027b7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "05dad0pvlzx1172l9ha498gbwpgds3nxdzx22xz71c97ibrw7lvl",
+    "tree": "10872604eebef344a516b376022a9206bdccef13",
+    "url": "https://github.com/LineageOS/android_prebuilts_r8"
+  },
+  "prebuilts/sdk": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1966c0b8ba7be3495ad4aec657868ba775b6f32",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "10phzas2487jdc0ipmg376xxbihdv7azyvx55rfdb6n0qslxnyxx",
+    "tree": "c07ba8e35743de5c81304d0703a6477e0e886d5a",
+    "url": "https://android.googlesource.com/platform/prebuilts/sdk"
+  },
+  "prebuilts/tools": {
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "42dea9fe53741758170559dcecec51568ef32d05",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1g88mficcm65hrcrs2cav6kwhxqjkydnlfn8vnahyws4i40vsr9f",
+    "tree": "62e7084f6af257ad6b4445afdb63bd8781f2b473",
+    "url": "https://android.googlesource.com/platform/prebuilts/tools"
+  },
+  "prebuilts/tools-lineage": {
+    "groups": [],
+    "rev": "b0e4e6aaaf8a3e42743b2b5667cdb55e04fa1e89",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0cbd27yjdz09awr0lwmxqkk3bmiijgw2kcjwxj72kqjkl6mbda29",
+    "tree": "9ecd3a12059fb140c9f81baf4e4d08ce67a1eac1",
+    "url": "https://github.com/LineageOS/android_prebuilts_tools-lineage"
+  },
+  "prebuilts/vndk/v27": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "37d3d5c2af0973077d2f44d0887847e410318271",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0jjw5a37kaamrvsllp722kmgj9qhka0v2blxyvwaaiclc3kdmd5x",
+    "tree": "34910f2f4131bbac9293f5730ddff6e44b568d36",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v27"
+  },
+  "prebuilts/vndk/v28": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ef50656885803b712d5abd78715bd3deadd23bd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1iyqb3wpd9wn8q0bbm4n9kqjq2zvl2a9b6p4gc5c9kzs8f2hg5kq",
+    "tree": "9fbd434c0d92f89a507115b5b3423f6c889b53ad",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
+  },
+  "sdk": {
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "linkfiles": [
+      {
+        "dest": "frameworks/support/README.md",
+        "src": "current/androidx-README.md"
+      }
+    ],
+    "rev": "3c26236800bace1ea6d54fe0cd9ff5c3d5023503",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0i0wsdrszjfm6n14hdlkl6dclsx72ppyd1kmj5bw56c683ff8ida",
+    "tree": "27fcc13cfa1c51779019fca53b64af3d62140d1f",
+    "url": "https://android.googlesource.com/platform/sdk"
+  },
+  "system/apex": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ce94bf567402c2065fd973a56a664d3faa17e7d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "19j5pdl757jic2kd31wlifg7p19zbxf84mg14pv3r89a2si52z54",
+    "tree": "f76e5a071e6e1e91bdfdc5b35406c70070d364ed",
+    "url": "https://android.googlesource.com/platform/system/apex"
+  },
+  "system/ashmemd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3953d6c8c14f16d6af7d23bfe2155fb845703e97",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "06yj5xd0niyw7nz0ddwl2xmi3z13mdhjjmjsk87j58q6a8vzvawv",
+    "tree": "77826f26294270bd508b0519b8348674bd6958a5",
+    "url": "https://android.googlesource.com/platform/system/ashmemd"
+  },
+  "system/bpf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6491032cb4f95e5b74b00f21336585199d9bf2b6",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1z2mxw4fh3qvy9nvy58cwj262861ph4ipj2l7pq0flcvzx1mp2xs",
+    "tree": "f9feebb20f9f8539fe5c7fac85aaff06113de2fb",
+    "url": "https://github.com/LineageOS/android_system_bpf"
+  },
+  "system/bpfprogs": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6cb42eab80c602995728194f8e7e6cedd3ec2c8b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "162frx2jnm1g007q5kr7b2sgidki27v96pv8pb342pxwmzv2iv63",
+    "tree": "0f833b19f50b2b7d8c4b633ae3e613fe8a06037c",
+    "url": "https://android.googlesource.com/platform/system/bpfprogs"
+  },
+  "system/bt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "79823d36dbe1269bf234b26167cb84d1db1922c3",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07yk9ggsyrslsvvv3cvd3pvnb9jxzm3hprgwy94yvjifs1lnfcbr",
+    "tree": "fc64d8c0018783322aa2de65cad60f207ab61f9f",
+    "url": "https://github.com/LineageOS/android_system_bt"
+  },
+  "system/ca-certificates": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f3d9e4ee7886a11137b745adb32da14fb46799d3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "14pw13fsijnkzkd4yflx07jx8zxg4g25h5zl2dlyi30cwyf93vhm",
+    "tree": "d03995ff05f3e8b54fec41aaad5702556dfea977",
+    "url": "https://android.googlesource.com/platform/system/ca-certificates"
+  },
+  "system/chre": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49f7b3a74b4e7e7d0fe09f536614dfec9649d0f0",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "19p7a5qxl2qhkl4bcxcvahyf12igkx5dqjl3gdbh1jxg3spnimy4",
+    "tree": "a7f3a93d544c8380b1a8d7fdc4d5a91c7ef5344f",
+    "url": "https://android.googlesource.com/platform/system/chre"
+  },
+  "system/connectivity/wificond": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b680ee54032549388cf5d7b9a2d076241c2f6f10",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fqdknl133whymr4kqyhrid7czvxqfynkji8ix5wqk2lbc5rbnqq",
+    "tree": "71ad67e52b46e3dd68224715f747f9a5f3ea9644",
+    "url": "https://github.com/LineageOS/android_system_connectivity_wificond"
+  },
+  "system/connectivity/wifilogd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22a4863c1500efb8c5853444230e5372be2ca75d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0pppjc50nq3dlx0fhzfkv0sbhsjhbcabnz4lidzm2g414259cwv8",
+    "tree": "b681a8ae10944e65fc15c63422a08becd43c33cb",
+    "url": "https://android.googlesource.com/platform/system/connectivity/wifilogd"
+  },
+  "system/core": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d4f2d2d80d4efbc8ac2a8a52e914cd1750d979e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "09pcj1sd7bw5zp9vjr42wz5n2krslwwbba8cqpb1jgvmhf8agw2b",
+    "tree": "d2bb21261cb301403ccbdca1b6e60fc3585d3be9",
+    "url": "https://github.com/LineageOS/android_system_core"
+  },
+  "system/extras": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c822595d47ee99a4afc27dd15e84cd92be83a17",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ddgdvabnz9p5qk2wacaian3q52p0jv093yfk6kqaldz8gbmak5k",
+    "tree": "416d1f739c8dff8a064886c7758a01c81e06b09d",
+    "url": "https://github.com/LineageOS/android_system_extras"
+  },
+  "system/gatekeeper": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e9d40690dadd9fa8e3cff0526f2314d918b7677d",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1xnm9vjzhd38gvc0rvpgmlf7v79w3rjr01jj9wvsbavbmbpilf7y",
+    "tree": "f193df9febbc605ef9646a8562f114807a78e468",
+    "url": "https://android.googlesource.com/platform/system/gatekeeper"
+  },
+  "system/gsid": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3bd03a00e4cc8b06083399cd8f46dbe3e3e29b9a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hb83mflygdzhsqzp0a3x8kc50jsk4gqc009yjrh3zcq6489xpd3",
+    "tree": "54b0313105d531de45e5ed94a70317b063097662",
+    "url": "https://android.googlesource.com/platform/system/gsid"
+  },
+  "system/hardware/interfaces": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c145c49cc83bfe37c740bcfd3f82715ee051122",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "19lwjsm1wq6sgxhk8mysg9f8rxi39f9a906bby71dvbgcy4sd2vl",
+    "tree": "540bd6399ba2c83d08abcb1d2bbb743df6ba1b21",
+    "url": "https://github.com/LineageOS/android_system_hardware_interfaces"
+  },
+  "system/hwservicemanager": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41879e6ad08c01fd9bf3aaf8bd1478568019dfe6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xw74bpphijl63ipxy7xi5wj21vz1rkb0wm3nkfqn31h97alwbw3",
+    "tree": "b10e44bb55e43be04d1af35be8807a7dd7b7a621",
+    "url": "https://android.googlesource.com/platform/system/hwservicemanager"
+  },
+  "system/iorap": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64117d10988f3ffa39bdee0a8b238766fe96bf67",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13zq2l3c000fk0617h8a4vqad4xa309c7b32rm8ifyv1dw49r8ni",
+    "tree": "d75077cee933f01c6d29277f2bbfc929adec8051",
+    "url": "https://android.googlesource.com/platform/system/iorap"
+  },
+  "system/keymaster": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9978131365c0456baf9ff742bd52005718e17034",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1xf3zwd7c4kwmp7i5ca3b6iwcmb4r9w5zf78v9i7k3dd6vxzwbsb",
+    "tree": "6b92421bb92d3f3090acf51436f90d56f02f312f",
+    "url": "https://github.com/LineageOS/android_system_keymaster"
+  },
+  "system/libfmq": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5e824b84b0f31b4f5204c9a203250b39c5aaf7a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0l5dwfj7wni0bfbgmbs7byyvds5fbn1bm89biir4k4m33q9mflyl",
+    "tree": "ccd3044ff934ee877bd6299c31c9f33b9f17035c",
+    "url": "https://github.com/LineageOS/android_system_libfmq"
+  },
+  "system/libhidl": {
+    "groups": [],
+    "rev": "6f7041ff93a9185fafd1669796487919232beff9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0dfxq331b5bnpfg89xfslji6rkacm7h5dhk8b7xazwdz66rlm3vn",
+    "url": "https://github.com/Anbox-halium/android_system_libhidl"
+  },
+  "system/libhwbinder": {
+    "groups": [],
+    "rev": "685c8ec2cf8a6db339c51838c9c6668fbc0c65ad",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1qya0yrkx6mqli0aiszf5nn6hg60qigygjr6k0qhgpwl5qbz6943",
+    "url": "https://github.com/Anbox-halium/android_system_libhwbinder"
+  },
+  "system/libsysprop": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e4a41ddc804973654a45c7d7b9985f36b6b6f33",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0yrd5qwis4m3xcjjnhzhad509mh7zky5771ka86rg3wkw93m3q8f",
+    "tree": "2ecdd7896e6af5af24bef36e5a2e31673117cb40",
+    "url": "https://android.googlesource.com/platform/system/libsysprop"
+  },
+  "system/libufdt": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c54fd0834ab980033cedd9441e83674e8a984d5f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0a14iiflg0bvzgp2c30ccgclnraqdpjxhzl29hj28lbh4i3rsg67",
+    "tree": "68074cf7c326e41f2b665ddaeddfebf8992c112c",
+    "url": "https://github.com/LineageOS/android_system_libufdt"
+  },
+  "system/libvintf": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f038598cab242dbfcdc21f8376dcf75a3c5c4fb5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "01yhdzzhznvhn2fcp5vbqyghy12fh1a6ws79c8xnraij0kg7nc3a",
+    "tree": "74feed31f8fb623dcfc2e408374d5dab61144ff8",
+    "url": "https://android.googlesource.com/platform/system/libvintf"
+  },
+  "system/linkerconfig": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab976a72034b8b9bc38a60208711ce5bd3c65296",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1lyiy6bsk317ghzlx1b9qnni281qzi6yi3i2mb734jqa8sgkqcma",
+    "tree": "1f3a6b94744d3f2f6f512ac82a65e62f8b273e5f",
+    "url": "https://android.googlesource.com/platform/system/linkerconfig"
+  },
+  "system/media": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cfd2aea29073df2a9f9fb560bda8497dab6a2137",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1p8hicb5agkncmrc99fi2gzf0qadg3gy9cg4998shzysbw1fkwds",
+    "tree": "f791a17e57c4eaf6298dc8167ba6c0dad2e00c8e",
+    "url": "https://android.googlesource.com/platform/system/media"
+  },
+  "system/netd": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e9ad7e3004e34e30db7dde4f2428ec92f8a7d740",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ydyicmb73c1aysikh7n9a93jzsw3zn38wwpqrvvqa60lkfxfbbj",
+    "tree": "9e5e70b39437f855272203b6e5180c19321f5059",
+    "url": "https://github.com/LineageOS/android_system_netd"
+  },
+  "system/nfc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad6928f2796941013783a9ca29df8ed959d62968",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1b4r0y6jsd9s6laksxcjimp65djc88c7fxdrlh6hvaa5ni7szy21",
+    "tree": "c599a9b4ac32fa5c68183287c474398d68dd20fd",
+    "url": "https://github.com/LineageOS/android_system_nfc"
+  },
+  "system/nvram": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad5d1127a01170bddda5618a190569b4a2eb26c6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15mwcp750ac9mc4m5j3b5nqdfjm6wkkgaapc439yn37lzkiq1si1",
+    "tree": "7ecff3507b406875ee7f6eeb6c7adf75806e71d2",
+    "url": "https://android.googlesource.com/platform/system/nvram"
+  },
+  "system/security": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6df7e4fb7e55c9a627badceebfaa650e7658f9e2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0mdnalh7vxl8h98sg1zfr505xc97m8lzhby7h2695i6l8mkmmxzm",
+    "tree": "6cc4a6a2557fd74100795dde3d8c23a9fad29576",
+    "url": "https://github.com/LineageOS/android_system_security"
+  },
+  "system/sepolicy": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d13a7ed16338bb57e6069a0307d380c706df73b",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0q6mjp5cds8qki6z6crqc9am96fh65mn81khq0qk7xmnapwxmh1y",
+    "tree": "a4ec1e207207f55fc7ceeca54eb5032fda8bb8d4",
+    "url": "https://github.com/LineageOS/android_system_sepolicy"
+  },
+  "system/server_configurable_flags": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "58c3c14f170012f5c98a6bdb5f914aceebc2ef8f",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1np00fg9ycmnp73fc976wvikhxxng0z4agy45rkdwxp46sxzjwxp",
+    "tree": "b6040d3614a1a0de93697b3616da051f6ce7053a",
+    "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
+  },
+  "system/testing/gtest_extras": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31092f8cc6638ab05fa8d63ed032800d94501bd8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "041ywigbkjkdrzi1p4qylgf7glvybmw8iib9m5wvhx23dl4zywdw",
+    "tree": "979158939e93d02e955246282be44c8e8deac1ba",
+    "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
+  },
+  "system/timezone": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1fb669420c71537e48cefe4c13b5817ffb9652d9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1pbwsg5868kflfh1q9gbqvawchn0wi82kacqkchxk4mwm3xd35bk",
+    "tree": "1b83925c6f6f0a171e3005c0f7b482e272d10f12",
+    "url": "https://github.com/LineageOS/android_system_timezone"
+  },
+  "system/tools/aidl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1c27fbb652359e38f38e41ee173366b50e1466c",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0ffj0g6nvcflz0wyh04pmq4cgq2ylgvd3f87hqhq2s5r50nrmvyv",
+    "tree": "d121101c84365ed43e42c3ff5caf223985ffbd93",
+    "url": "https://github.com/LineageOS/android_system_tools_aidl"
+  },
+  "system/tools/dtbtool": {
+    "groups": [],
+    "rev": "a2b9e476be722a49ef7a056a0548072cb6babb75",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0y4pbq1rpd8kw036qb6q07vz8fv2ngpxpdni71pg3iif3b4y7fp5",
+    "tree": "30edd20ab63d043c8c25cd8f454b9b54037bbbc7",
+    "url": "https://github.com/LineageOS/android_system_tools_dtbtool"
+  },
+  "system/tools/hidl": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c96782efb59203b6f4d07b87c8db7716bc60bd7",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1a82g61fzac1rnxpc6qyd7wc4sykaglqd2k9715qbicza83msg81",
+    "tree": "3be4466074e6ad3a1edb6008f2e64fe9fd65ca6b",
+    "url": "https://github.com/LineageOS/android_system_tools_hidl"
+  },
+  "system/tools/sysprop": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ea70df56af92c114fba7c0814b8d57266defc67",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1gbzr40z2093vfmiwazwd5pgy14dc3jz3zjrcndyg2qzqzdf22y7",
+    "tree": "7ae222d0d3c230162804f9c413f846cb62bbe3fe",
+    "url": "https://android.googlesource.com/platform/system/tools/sysprop"
+  },
+  "system/tools/xsdc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ed8bbd753dd5b0b9c01af4264a09d2338ab802b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qxpfsgmj7zqqk6ppnrwwb3r9vvw8inf3b89ybmjcb9zq5chmjf6",
+    "tree": "d38ddfcddf3eb773fc6e848a6cfbdf8ca3e9011c",
+    "url": "https://android.googlesource.com/platform/system/tools/xsdc"
+  },
+  "system/ucontainer": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43d7c3b4ee78228298a5a1883655ed206d0c6130",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15zjs51p5linxnp0gd4zfgbq203jkcy4ld33wwx9pgizmbyyhj5r",
+    "tree": "ac3a498235309462479df2567470916a903193e9",
+    "url": "https://android.googlesource.com/platform/system/ucontainer"
+  },
+  "system/update_engine": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c68499e3ff10f2a31f913e14f66aafb4ed94d42d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1qvq10r4y6x95ychacmc8bfc9x0sa4k1qr7z9nw0zijz9bdq35cc",
+    "tree": "52204473f52b82638700807a5a430515b387a4d1",
+    "url": "https://github.com/LineageOS/android_system_update_engine"
+  },
+  "system/vold": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "209a1118a4fc8a30773bb3bb5c319a5956b0d7f9",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0nzcxiyk1l7gqbckpxnkyg4vln18ldyq7gvwqic21k2pfyy8s7li",
+    "tree": "4dcac3dada1b1e6a9ded2bf9f9d538e57d9992cc",
+    "url": "https://github.com/LineageOS/android_system_vold"
+  },
+  "test/framework": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "abbe02c11a9795cd101a80c47cd534ee9ff3160b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0irlvhh9ysp23mfns7aihqk10aipxx9p54yc63h056gxd5cvgvv7",
+    "tree": "dbdfa1a5e871697ec4088b3d09987953b987a8d8",
+    "url": "https://android.googlesource.com/platform/test/framework"
+  },
+  "test/mlts/benchmark": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21f14cc0f0eb819932cf32f30ccd939ab64e97fa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "042jxvvzbjk5z9pxc24ayz0bcyq39wcwq7f17caald8lv7fziryr",
+    "tree": "d9042bb0bca1c5ceb2306f5266df754bc2f39a03",
+    "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
+  },
+  "test/mlts/models": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4208312c885dabe30223e464113ac65d893ad29c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rrg07fyw2r1z4a871j50fcxqs69f1n05ci2l9ikym716kafvjdx",
+    "tree": "cbbec484d59fe1d3db49663b91f039654eea1155",
+    "url": "https://android.googlesource.com/platform/test/mlts/models"
+  },
+  "test/mts": {
+    "groups": [],
+    "rev": "91075d5f5854dca0a941fbe4fc1758dbcc2b894e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1i2qsh98b0wl8n8j07qq0lb2319fvqpn7k3m9bfgk4v1fkzkc0rn",
+    "tree": "881b6cafc86ef25d27aa1539d89c6f166653fbba",
+    "url": "https://android.googlesource.com/platform/test/mts"
+  },
+  "test/suite_harness": {
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2f70a29ed2ff0f0d35874542c155355861519502",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1gmdpkxxp5asfkxlqsv3p4mfdd9nimvcyjqlkpvnjp7r1dhqlpb7",
+    "tree": "2f9dacbbe71bfbcf9fa27af8ad30f4b06e25636f",
+    "url": "https://android.googlesource.com/platform/test/suite_harness"
+  },
+  "test/vti/dashboard": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "e8a34eb94446d371378806f78a49d41e31a7574c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
+    "tree": "9a6aa23933457f0347256478c4c7f87c8436b866",
+    "url": "https://android.googlesource.com/platform/test/vti/dashboard"
+  },
+  "test/vti/fuzz_test_serving": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "3242619c1f5d15acbf246f814ff69e4ea63d7c0e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
+    "tree": "3bab6d094c78d500d34682e7f4e8aae8ca125301",
+    "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
+  },
+  "test/vti/test_serving": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "6790fd6c5ec57055f529e59c39058e664eed2cdd",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13ba314cqkcn29nchd7lk7bvmczjsqia6qd310pjkgivsx30j6vm",
+    "tree": "3a5b26e145f6189bd77e7bf27090cad9404ff208",
+    "url": "https://android.googlesource.com/platform/test/vti/test_serving"
+  },
+  "test/vts": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "08c67907ded2f213091a6200ca23aa6c372cea6e",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1v7p3vyyya53wlp04bd9isa7vs72scianhikbh6clx1mw91nra7v",
+    "tree": "cc1ddfbca4d8b4383fd9d18d52e10cf2a761e0e8",
+    "url": "https://android.googlesource.com/platform/test/vts"
+  },
+  "test/vts-testcase/fuzz": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "5786e8aedde257fc8f6db90474102aa99ecb294a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0h38v1p6947kl6ffr366f4b4cdzvxpi0lg6y8nz34qm5rsis72cw",
+    "tree": "02955b06ddc151440fd545e6809d96644dd4f6a9",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
+  },
+  "test/vts-testcase/hal": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f0b0ef57ec53351197685414c7108445fa5f73ab",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "16hzxh4f32ng8656zsim3s16vkrxx3f11pzpliv13sn1xfc7xxy1",
+    "tree": "4589e1b86e973f5777f9f75ca66ca4050c87daf3",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
+  },
+  "test/vts-testcase/hal-trace": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "1c36e0c1cc61a713da126cda85c4a2d6ea3b0199",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
+    "tree": "09ab51841180faca371e6527dc7cefaad5748992",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
+  },
+  "test/vts-testcase/kernel": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "cd39b07120c1703446d78609272d280c2bebb6c6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0njkk7fcldgd0lw6n42zy9lq8jar00dfj8ig30r6435n3l7xjlgg",
+    "tree": "2c6ef11ca6d9db941be96f8dd1c6ffecc6503956",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
+  },
+  "test/vts-testcase/nbu": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "eb61b3bf69613b8e265debcf666ea6a530fe51f6",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0kmwxhdmd4jga03j4lj0iidixdnz34sz7zc8a8c5nsyn2k8mqn74",
+    "tree": "d35655099e5c55d37310e55670d14ed614890f72",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
+  },
+  "test/vts-testcase/performance": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0de62a73c48e7fa5832f6d8ef0fd2e3b532ddb3a",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0xgh0js5vr63xpzy794qrdlc6ckgwhn4w0vhhk1gmn5qgmsmja7d",
+    "tree": "b9a5ebc8d014c96ec8c53907a08b83a92f041027",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
+  },
+  "test/vts-testcase/security": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0be509341aea01fe137c953cfafda167df520739",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "14lfcmfkwq26d5kcycgrkmdlf2r9qp26y0hdjbsssk950shpjpgi",
+    "tree": "3249ca9c202a060f17583f2345041b4a7c18250c",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
+  },
+  "test/vts-testcase/vndk": {
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "b4b0481163f53c536d54ae2fd7e683d869a92b83",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rjmk351gmfir28rjgrc29mwr4nvr45bv2qils636b1irr15vz11",
+    "tree": "ef87935750407065628323128870e53fb33c8e2a",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
+  },
+  "toolchain/benchmark": {
+    "groups": [],
+    "rev": "d635fa311d5ad80611e44df409813cf17f8941c4",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12yrxw378akva94sjc2zpi424mjhfk7s654m0g5wdsmsqygp2i4v",
+    "tree": "ed5d55e2691c1288e7ddadacef31e01c6edbd0a4",
+    "url": "https://android.googlesource.com/toolchain/benchmark"
+  },
+  "toolchain/pgo-profiles": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2df9ec3c217b92ba43d45595689a059b0654ae2c",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0ckwvsciak1q04d5z9q1fqhsy2lzqz4wdl9bkh02fphk2zg323jd",
+    "tree": "8834200d40e649d0f32e39b77d95d4d9667c25ff",
+    "url": "https://android.googlesource.com/toolchain/pgo-profiles"
+  },
+  "tools/acloud": {
+    "groups": [
+      "pdk",
+      "projectarch",
+      "tools",
+      "tradefed",
+      "vts"
+    ],
+    "rev": "9468a56b66528d66b573c6aca12dd0a51a108653",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1qfrshinl45ih6zxhc80k4qnfrrngypff05ynlv3w1fwybpkj5rc",
+    "tree": "9eaf02eeeff13c2f203ccfcf9fb3e1b65fe07147",
+    "url": "https://android.googlesource.com/platform/tools/acloud"
+  },
+  "tools/apifinder": {
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "d04f78c8c2748895e7594ec7d67ce81ca3c4f69b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0hcbvs6dns11b83877wy5g3pzyq8f7f71mcas6npi5y8ka503kv9",
+    "tree": "0c0ecdf5b587c2a1c80cfed8d40c5aab3c0d7f46",
+    "url": "https://android.googlesource.com/platform/tools/apifinder"
+  },
+  "tools/apksig": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "740c71ca93c6e2e0412408e82310062950e35a30",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "15yhnbnm76g8z8zfxdfhg21rdicx43hhqfcgxy9kp3spn38z1bv0",
+    "tree": "d97a49c25ba34e97618621fa9f52eeafe5fa4d82",
+    "url": "https://android.googlesource.com/platform/tools/apksig"
+  },
+  "tools/apkzlib": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "75d691212db5007f4f8ee674e58cfa66909206f1",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "12adwr4fnqgi1hbzhiw84qdmv4np4dwlkm6harnj8lsipknsg2sf",
+    "tree": "c7e818e81de15fc5bf5871ff28275cd5fe62bb2a",
+    "url": "https://android.googlesource.com/platform/tools/apkzlib"
+  },
+  "tools/asuite": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4d6beee0c003043a773726e518eb965839dc570",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1wchvfni6mfkx6hhnvzpz9mchdc8g4nb5yyjnx4yvfln1nkckd0j",
+    "tree": "acac3551cf02aebd83e72707c4aef9077ed6e394",
+    "url": "https://android.googlesource.com/platform/tools/asuite"
+  },
+  "tools/currysrc": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "baf9e5635feff1841e8158af8eef562e426cd839",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "1rpl96sixlq212703hn0bpriazsbi7r53smr3bg7m15w3sfg9xhs",
+    "tree": "23bdc04c2bd64aeb89c016042a2b8b6622cc65ff",
+    "url": "https://android.googlesource.com/platform/tools/currysrc"
+  },
+  "tools/dexter": {
+    "groups": [
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "17d93e4d9cb7381351ea2f98ed82061875a5e32b",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0654d77s4jwv8266vp0284zdzdy3ccz95h4irzmi07mpggikh9mp",
+    "tree": "7836323d239634313fb24d1a94263e3f9964f915",
+    "url": "https://android.googlesource.com/platform/tools/dexter"
+  },
+  "tools/external/fat32lib": {
+    "groups": [
+      "tools"
+    ],
+    "rev": "2eade02cd459894bf600dc938228959c78c52cad",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "06zhx540030vyvcmsb9n7lsb2in8qlmfv8nd3yamqwxnyn8rdlfn",
+    "tree": "b3e5cc4b9089e58494f41f9f1ed45230cd9f1d60",
+    "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
+  },
+  "tools/external/gradle": {
+    "groups": [
+      "tools"
+    ],
+    "rev": "1c12ab65922123062cb0c80efda749f4f70e1be3",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "054kzggwzn2xndb8msnbzgrlsv7jz3bakjzhd1nm7jnjcn4gm567",
+    "tree": "e76bfdc5a7612a1f7c21a54e5394c8aa5613185a",
+    "url": "https://android.googlesource.com/platform/tools/external/gradle"
+  },
+  "tools/external_updater": {
+    "groups": [
+      "tools"
+    ],
+    "rev": "6395d3fe715b70896be6a44cdf95694461ccd7d5",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "13zb3nvfxrg6849knvlh9wjk92lhgj1302hghq2di1l3ax6plhhh",
+    "tree": "3d542e4d228c55df36d3fc438aa374b256d5e615",
+    "url": "https://android.googlesource.com/platform/tools/external_updater"
+  },
+  "tools/loganalysis": {
+    "groups": [
+      "nopresubmit",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "a6c75397f93a669f63b318a87428fa2cd71099af",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "11x7m5mrj55f60gw5cnrdvmshr0rqbbyljys4qzmfkll51p4y07w",
+    "tree": "2eaec95c1eeacb580684b882ed0a3dff03949b4c",
+    "url": "https://android.googlesource.com/platform/tools/loganalysis"
+  },
+  "tools/metalava": {
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "9ee5f702a8510ac9756915e560179757a23e4f48",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "03skab3np3xvg3h5y0f15l3p2bc2s044xzbvjcvd3jl9rx96xfwd",
+    "tree": "9f1e23be97dd4add0323ae0e3167cd2f800fc452",
+    "url": "https://android.googlesource.com/platform/tools/metalava"
+  },
+  "tools/ndkports": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a29727799eccb83b8b7e635dfd6b9f02660c498",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+    "url": "https://android.googlesource.com/platform/tools/ndkports"
+  },
+  "tools/repohooks": {
+    "groups": [
+      "adt-infra",
+      "cts",
+      "developers",
+      "motodev",
+      "pdk",
+      "tools",
+      "tradefed"
+    ],
+    "rev": "109ae1a1b8b8b80abdefb95729544d60601160c4",
+    "revisionExpr": "master",
+    "sha256": "0wxh04sv5ldgy9bqpmfzqpr77f06pk0hd38hckxlha96ili9kwna",
+    "tree": "cdac0b841266d119f389a247d83abbb4b2765354",
+    "url": "https://android.googlesource.com/platform/tools/repohooks"
+  },
+  "tools/security": {
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "505f338836d653b06a99f5f586582ec5787838ed",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0a9pnw1qxw1gf54kjmak3pim7y3mq953ngnqkibwg4dzyhymihfy",
+    "tree": "14f5618ff219f9c077ad59268251b1b373095432",
+    "url": "https://android.googlesource.com/platform/tools/security"
+  },
+  "tools/test/connectivity": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "97a8fdec52b54ffeeae7c41e2b31b8c31974bc45",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "09jqx4wf0s7h8m1s1dycf7s47mj2ws2a3cj1rwzhq9ma6lyc1kgz",
+    "tree": "221d5bb3866a4569ef03155e0e25e193906765e4",
+    "url": "https://android.googlesource.com/platform/tools/test/connectivity"
+  },
+  "tools/test/graphicsbenchmark": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8b91c62662896c1c500bed047a417f1866ac3a8",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0b8hdrbq7yap70m4zcx5a29fmhk8r9gd2w6v41q36iyfycmb7ds3",
+    "tree": "83377c639fee93916c31adc3bb7c04fc4991a2f3",
+    "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
+  },
+  "tools/tradefederation/contrib": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "b4ee449701e0a0525e9c3b5247eed191ba2e1b99",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "196a25xgiw7h7ffjyv3if3hpcwwicqf7k8rzbr4a1jj9zw4l3hpl",
+    "tree": "89249ff263b05a02476dea11fb890b16f0fdc3f7",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation/contrib"
+  },
+  "tools/tradefederation/core": {
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "d42844787e489746fb5d1b3b01ea98bf240ab845",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0rz20vq058hj3qjzrbswvb20w966ipwwfi45v4rlg8nbn438xq15",
+    "tree": "f9d4edaccf2032f59d5093552cff23d491f5062f",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation"
+  },
+  "tools/trebuchet": {
+    "groups": [
+      "cts",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "10f2361f0b302f7af4814c790aa0bf9bd866f9aa",
+    "revisionExpr": "refs/tags/android-10.0.0_r41",
+    "sha256": "0qmiq2vixnlv95mgxvkxqnwhnq3rpny8c8gcfr7f65dkldmfv5mn",
+    "tree": "05675bf3facce3b0ae9ecde7f0640db799c1e198",
+    "url": "https://android.googlesource.com/platform/tools/trebuchet"
+  },
+  "vendor/codeaurora/telephony": {
+    "groups": [],
+    "rev": "4562c55936d96f7dc8dfecfd3a05046fe6304b09",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0892i7amphwwc0scqnk5qsz790khyxjdfiw8yk0m846411hwaayw",
+    "tree": "5ffad0682d258703c37770faeea55c913c3dc6be",
+    "url": "https://github.com/LineageOS/android_vendor_codeaurora_telephony"
+  },
+  "vendor/lineage": {
+    "groups": [],
+    "rev": "de660529b22f2179790a03e699725cbffd1178ee",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "069y8lfy9d5npaqsndr38hws36p0fl4imr2r0lbnrnckwhgx4ar2",
+    "tree": "6aeecac7ae2d6b6903daee13e8bb83e0117dee01",
+    "url": "https://github.com/LineageOS/android_vendor_lineage"
+  },
+  "vendor/nxp/opensource/commonsys/external/libnfc-nci": {
+    "groups": [],
+    "rev": "b1cef13a138522751fe2544c30a38f64df4b8c58",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1rf16y25sj8fzpb3kcm94w1mr211lhmhgzrg85hw1ccd20fzs6sf",
+    "tree": "9e54b8a258534d185ff504dff9b10b778d0bc654",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_external_libnfc-nci"
+  },
+  "vendor/nxp/opensource/commonsys/frameworks": {
+    "groups": [],
+    "rev": "6ca7543c0cf9c8a2bdb55df93f93a6fe0f9556f0",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "15y5zjsgcbkkv7qn5l3bnscl32gsx1jw7szyy11dx9z13qrp9sgb",
+    "tree": "10e7cad5ab327eeed3420610348d3874c17f39a4",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_frameworks"
+  },
+  "vendor/nxp/opensource/commonsys/packages/apps/Nfc": {
+    "groups": [],
+    "rev": "1fa0d04904e10c05474bec29366747940f6707c2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0301slbmc185hwga8432q9fzrkbkmjqdgqcvpmbxmfi32ghzzvm0",
+    "tree": "4ee64cee47f0b69952f41296135018bc237dfb98",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_packages_apps_Nfc"
+  },
+  "vendor/nxp/opensource/interfaces/nfc": {
+    "groups": [],
+    "rev": "9657b5746ba8c7f9667de44e83a7066457bb8dcf",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0as6y0wlkplqgancvrhmj95siq6mha2dzc39dq34f1c58wng8xkb",
+    "tree": "5aff492ca2461655f0f5e936ca82a2e70b633c4e",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_interfaces_opensource_nfc"
+  },
+  "vendor/nxp/opensource/pn5xx/halimpl": {
+    "groups": [],
+    "rev": "bea4aa0543fe40e2eda48bb3b26f62d4eb512b6e",
+    "revisionExpr": "lineage-17.1-pn5xx",
+    "sha256": "0g6k737vxnad41nwbmfzz6m2xv5yjcwjcnrisnsr4cqfzzbk7vbr",
+    "tree": "70e98a4bee733b82c34c5268aeded627891a49ed",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_halimpl"
+  },
+  "vendor/nxp/opensource/pn5xx/hidlimpl": {
+    "groups": [],
+    "rev": "3801d672f0f81fd1365ba5f784d98b8144276e30",
+    "revisionExpr": "lineage-17.1-pn5xx",
+    "sha256": "1jr22qbmzamwadirhjzmy0fx1l165gyph5z7ia6xq5n3y1knacyx",
+    "tree": "8167ce6f58dcb2b5e5d7467f5b658f1504e30712",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_hidlimpl"
+  },
+  "vendor/nxp/opensource/sn100x/halimpl": {
+    "groups": [],
+    "rev": "e747bcc85a75a78fb0f20e1fd44cf5913ad83a2f",
+    "revisionExpr": "lineage-17.1-sn100x",
+    "sha256": "19dzngzl9r3rgmw2vf7wh9xksv6vq0ybaaxsgilabp3qny13wfdf",
+    "tree": "2e2b4fe8106170bfa2292a51a31308f2bad30b85",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_halimpl"
+  },
+  "vendor/nxp/opensource/sn100x/hidlimpl": {
+    "groups": [],
+    "rev": "686a88f9de18e608faa49881014d7a2e7d32325a",
+    "revisionExpr": "lineage-17.1-sn100x",
+    "sha256": "02y9bfba4l1mjp50b3kk80qsa22w8a3gqp4y7gkxhv80175rxi0c",
+    "tree": "cdebfe8ce3c24f7397ed6ada880c5abdb2174e14",
+    "url": "https://github.com/LineageOS/android_vendor_nxp_opensource_hidlimpl"
+  },
+  "vendor/qcom/opensource/audio": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "343077c4a5393459bc6b4a5fbccdeb0b33b6e5d4",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1fhc1d3avgnmv485knws0aj95jgkwyynid2x79bl6ks6vvp4irji",
+    "tree": "ae799fcb6055354e6c7d4967ca6b889e71cdc1ed",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_audio"
+  },
+  "vendor/qcom/opensource/commonsys-intf/bluetooth": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "e0c67fe2fe6dccd9d0d1a1a8b3cdd95c23ab58ce",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0w2rr6gx1i63bv19iym7dvs5w1iql8dbdqc0fi16w56lvp4nnz7w",
+    "tree": "6d09c5634d2f94eab496732c713558d6f14baa99",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_bluetooth-commonsys-intf"
+  },
+  "vendor/qcom/opensource/commonsys/bluetooth_ext": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "d72ceb00fb1fa3cea5e9798b7eb772611568662e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0bnhhn3csrp5rh9dyayssljfgsr1ml848m4yz2dpahpc7pf1iqam",
+    "tree": "56c2f2364595500f4caaae5f212cb1753d713edd",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_bluetooth_ext"
+  },
+  "vendor/qcom/opensource/commonsys/packages/apps/Bluetooth": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "97719f4c22c4a7c3bf0025547ef35b8a9e7be9fa",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1hfk0p9yhkjgm1d7s65nym2lmsdpwvaj569y1s8smivw3sb17c5k",
+    "tree": "3eb989db8e4084824f7ebb31bc689e822ef651f1",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_packages_apps_Bluetooth"
+  },
+  "vendor/qcom/opensource/commonsys/system/bt": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "123b7d56572c30ae4653eec3e9e6922c216adca1",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "1wqgg9lixj9imxl3midh3yy501q3m4lfqdwwckd322x5pmg8pfsl",
+    "tree": "1cc92eee7f3e4fcb51b78fb34726beb4739d19d3",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_system_bt"
+  },
+  "vendor/qcom/opensource/cryptfs_hw": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "85dc5fbc0bd55b1af391c51422ac3bfdd6f16b9a",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0mnxjbylxwxkqq31m1z01gsdy25jifsalil6f0n20qsbw934p6pa",
+    "tree": "df940886d9b2440d168a30a49d1bfa07dba59a67",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_cryptfs_hw"
+  },
+  "vendor/qcom/opensource/data-ipa-cfg-mgr": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "7491505079863d40c82bbab02fa913ad7084963f",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0gqi835li392yh54x6sd8kvgy3miyhq2sqmyhf13y9j5apijbanf",
+    "tree": "6c6d652848d2a104be0dc04b3aa5e3417d8b137b",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_data-ipa-cfg-mgr"
+  },
+  "vendor/qcom/opensource/dataservices": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "42931295552b0773cbfe4938d5875223ab4e1b9d",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0l071hxna37660cnb29sx7h6zic5xf3k8whbfsxcayy406vz4p7c",
+    "tree": "0ae9ba39c864d68adde60fd900fee3f6cbf1db23",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_dataservices"
+  },
+  "vendor/qcom/opensource/fm-commonsys": {
+    "groups": [
+      "qcom",
+      "qcom_fm"
+    ],
+    "rev": "e4016959534e2829308948de762bb3bbeb15a673",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "16zr9grys8rdklvldvfz3f1shy9yqnrdmz31k90qxk6lj9207mcb",
+    "tree": "49489f46525a72f8f67dc96bc9c49f4019517e96",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_fm-commonsys"
+  },
+  "vendor/qcom/opensource/interfaces": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "f9246043248d6006af47d3d30558f021bd0ee8a1",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "14411kddflpqibq02lzp18920965vq4vkip6zkgk0w9y6hd5r1i6",
+    "tree": "d5ad24f0501ac01d91af1858bf982df9f8ff5bf9",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_interfaces"
+  },
+  "vendor/qcom/opensource/libfmjni": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "e33227ed63c6b8e7df0b638f556bf14fa99acd83",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0xk9nknn29yy1nrgw8vcy4im7pd2g1jg5d65pk6gcd4zd6ks9ymv",
+    "tree": "49ae9c31f7ef85cb6b3e2a902cb45ca2c93d84c6",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_libfmjni"
+  },
+  "vendor/qcom/opensource/power": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "9685a877d9252842f488528a861e8d39acde8f9e",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "07jimy2p50jf67il0zzp3xid4ybx55igkjb8wp98kclv38sxb2q2",
+    "tree": "682179e65cd2d8d3df1efbc635023a6ba5c45313",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_power"
+  },
+  "vendor/qcom/opensource/thermal-engine": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "84005fbacec7b39da0804ce32b367cee646668db",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "19p0llbljlwhq64i638sd027v81vblz5z5x30wxiik3rzspiay8n",
+    "tree": "6f27b2396a7fac59bc6ffc5721162ffa14b21d43",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_thermal-engine"
+  },
+  "vendor/qcom/opensource/vibrator": {
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "7b166aa9609014f9ec2aab3282616a2a1cc9cdf2",
+    "revisionExpr": "refs/heads/lineage-17.1",
+    "sha256": "0bzbimk2993aw3lrr5m515xhl22s8c804zp79hiws1l7r6wmqyhf",
+    "tree": "71c5e71e9aa6e8fe8dcf0af50c9a434df9b74351",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_vibrator"
+  }
+}

--- a/flavors/waydroid/update.sh
+++ b/flavors/waydroid/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 Daniel Fullmer and robotnix contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# https://github.com/WayDroid/anbox-halium/issues/22
+#curl -o anbox.xml "https://raw.githubusercontent.com/Anbox-halium/anbox-halium/lineage-17.1/anbox.xml"
+
+args=(
+    "https://github.com/LineageOS/android.git"
+    "lineage-17.1" # static branch name
+    --ref-type branch
+    --local-manifest anbox.xml
+)
+
+export TMPDIR=/tmp
+
+../../scripts/mk_repo_file.py "${args[@]}"

--- a/modules/10/default.nix
+++ b/modules/10/default.nix
@@ -14,7 +14,7 @@ mkIf (config.androidVersion == 10) (mkMerge [
 {
   source.dirs."build/make".patches = [
     ./build_make/0001-Readonly-source-fix.patch
-  ] ++ (lib.optional (config.flavor != "lineageos")
+  ] ++ (lib.optional (!(lib.elem config.flavor [ "lineageos" "waydroid" ]))
     (pkgs.substituteAll {
       src = ./build_make/0002-Partition-size-fix.patch;
       inherit (pkgs) coreutils;


### PR DESCRIPTION
Successfully builds, but currently untested in a linux environment.

Built using: `nix-build --arg configuration '{ device="x86_64"; flavor="waydroid; }' -A config.build.waydroid`

Notes:
- `external/mesa3d` relies on the system `/usr/bin/python` and needs `Mako` to be installed.
- Required a manual fix for: https://github.com/WayDroid/anbox-halium/issues/22