### PR TITLE
Small docs fixes based on a Pixel 4a GrapheneOS install experience

### DIFF
--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -48,7 +48,7 @@ If the Nix sandbox is not enabled, we can instead set `signing.buildTimeKeysStor
 Additionally, the nix builder will also need read access to these keys.
 This can be set using `chgrp -R nixbld ./keys` and `chmod -R g+r ./keys`.
 
-The second option involves creating a "release script" which does the final build steps of signing target files and creating `img`/`ota` files outside of Nix:
+The second option involves building a "release script" with Nix, which depends on and therefore builds the unsigned image inside the Nix build sandbox. The final build steps of signing target files and creating `img`/`ota` files are then done outside the sandbox by running the release script:
 ```console
 $ nix-build --arg configuration ./crosshatch.nix -A releaseScript -o release
 $ ./release ./keys

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -96,6 +96,9 @@ upstream documentation](https://source.android.com/setup/build/running).
     your AVB key.
 
  8. Finally you can disable OEM unlocking and afterwards even the developer options again if you do not actively use them.
+    Note that if you later lose the ability to re-enable OEM unlocking, for example by pushing a bad update that you cannot rollback,
+    and you cannot push another working update because you also lost your signing keys,
+    you might not even be able to recover your device by flashing a stock image, effectively bricking the device.
 
 > If you are unable to enroll a custom AVB key on your device, you could theoretically skip steps 4, 6 and 8. This is highly discouraged as it leaves your device in the [vulnerable UNLOCKED state instead of being LOCKED with a custom root of trust.](https://source.android.com/security/verifiedboot/boot-flow#communicating-verified-boot-state-to-users).
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -55,7 +55,7 @@ upstream documentation](https://source.android.com/setup/build/running).
     Flash your custom AVB signing key using
     ```console
     $ fastboot erase avb_custom_key
-    $ fastboot flash avb_custom_key avb_pkmd.bin
+    $ fastboot flash avb_custom_key ./avb_pkmd.bin
     $ fastboot reboot bootloader
     ```
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -20,15 +20,8 @@ upstream documentation](https://source.android.com/setup/build/running).
  0. Before you can begin you have to boot the stock OS, go to "Settings / About
     phone" and tap the "Build number" field 7 times to enable the "Developer
     options" menu.  Next go to “Settings / System / Advanced / Developer
-    options” and enable “OEM unlocking”.  On my device I had to insert a SIM
-    card and connect to the network for that, so it looks like you have to
-    connect your device with Google [at least
-    once](https://grapheneos.org/install#enabling-oem-unlocking).  This is part
-    of Google's so called Factory Reset Protection (FRP) for anti-theft
-    protection .  However, [this
-    comment](https://www.kuketz-blog.de/grapheneos-das-android-fuer-sicherheits-und-datenschutzfreaks/#comment-52681)
-    on a German IT privacy blog suggests that it is sufficient to allow access
-    to the captive portal such that the phone thinks it is online.
+    options” and enable “OEM unlocking”.  This option is greyed out until you connect your device to Google [at least once](https://grapheneos.org/install#enabling-oem-unlocking).
+    This is part of Google's so called Factory Reset Protection (FRP) for anti-theft protection. You do not need to insert a SIM or log into a Google Account to make the “OEM unlocking” option available, but connecting to the internet is required.
 
  1. First reboot into the bootloader. You can either do that physically by
     turning off your phone and then holding both the POWER and the VOLUME DOWN

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -44,8 +44,7 @@ upstream documentation](https://source.android.com/setup/build/running).
     Select the option to unlock the device and confirm. This step effectively
     performs a factory reset, and will remove all user data from the device.
 
- 4. *(Strongly recommended, but technically optional)*
-    Flash your custom AVB signing key using
+ 4. Flash your custom AVB signing key using
     ```console
     $ fastboot erase avb_custom_key
     $ fastboot flash avb_custom_key ./avb_pkmd.bin
@@ -96,6 +95,9 @@ upstream documentation](https://source.android.com/setup/build/running).
     ID on the last line are the first eight characters of the fingerprint of
     your AVB key.
 
+ 8. Finally you can disable OEM unlocking and afterwards even the developer options again if you do not actively use them.
+
+> If you are unable to enroll a custom AVB key on your device, you could theoretically skip steps 4, 6 and 8. This is highly discouraged as it leaves your device in the [vulnerable UNLOCKED state instead of being LOCKED with a custom root of trust.](https://source.android.com/security/verifiedboot/boot-flow#communicating-verified-boot-state-to-users).
 
 ## Updating by sideloading OTA files
 Preferably, you can update your Vanilla/GrapheneOS flavor device using true "over-the-air" mechanism provided by the `apps.updater` module with a server hosting the OTA files, as shown [here](modules/ota.md).

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -73,15 +73,14 @@ upstream documentation](https://source.android.com/setup/build/running).
     $ fastboot reboot bootloader
     ```
 
- 6. *(Strongly recommended, but technically optional)*
-    At this point you want to relock the bootloader to enable enforcement of
+ 6. At this point you want to relock the bootloader to enable enforcement of
     the verified boot chain.
     ```console
     $ fastboot flashing lock
     ```
     This step has to be confirmed on the device.
 
- 7. After rebooting you will be greeted with an yellow exclamation mark and a
+ 7. After rebooting you will be greeted with a yellow exclamation mark and a
     message like
 
     > Your device is loading a different operating system.


### PR DESCRIPTION
I recently went through the process of building GrapheneOS using Robotnix and installing it on a Pixel 4a and made some improvements to the documentation based on that experience.

I have put my changes into separate commits, because I thought you might want to have some but not all of them.