### PR TITLE
modules/apps/prebuilt: Allow configuring the module name prefix

### DIFF
--- a/flavors/vanilla/default.nix
+++ b/flavors/vanilla/default.nix
@@ -64,6 +64,7 @@ in mkIf (config.flavor == "vanilla") (mkMerge [
   # devices, all with the name for this device.  This is OK.
   source.dirs."device/google/${config.deviceFamily}".postPatch = ''
     sed -i 's/PRODUCT_MODEL :=.*/PRODUCT_MODEL := ${config.deviceDisplayName}/' aosp_*.mk
+    sed -i 's/PRODUCT_BRAND :=.*/PRODUCT_BRAND := google/' aosp_*.mk
     sed -i 's/PRODUCT_MANUFACTURER :=.*/PRODUCT_MANUFACTURER := Google/' aosp_*.mk
   '';
 })

--- a/modules/apps/prebuilt.nix
+++ b/modules/apps/prebuilt.nix
@@ -12,8 +12,7 @@ let
 
     include $(CLEAR_VARS)
 
-    # Add a prefix to avoid potential conflicts with existing modules
-    LOCAL_MODULE := Robotnix${prebuilt.name}
+    LOCAL_MODULE := ${prebuilt.moduleName}
     LOCAL_MODULE_CLASS := APPS
     LOCAL_SRC_FILES := ${prebuilt.name}.apk
     LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
@@ -78,6 +77,19 @@ in
             default = name;
             description = "Name of application. (No spaces)";
             type = types.str; # TODO: Use strMatching to enforce no spaces?
+          };
+
+          modulePrefix = mkOption {
+            default = "Robotnix";
+            description = "Prefix to prepend to the module name to avoid conflicts. (No spaces)";
+            type = types.str; # TODO: Use strMatching to enforce no spaces?
+          };
+
+          moduleName = mkOption {
+            default = "${config.modulePrefix}${config.name}";
+            description = "Module name in the AOSP build system. (No spaces)";
+            type = types.str;
+            internal = true;
           };
 
           apk = mkOption {
@@ -320,8 +332,8 @@ in
         '';
       });
 
-    system.additionalProductPackages = map (p: "Robotnix${p.name}") (lib.filter (p: p.partition == "system") enabledPrebuilts);
-    product.additionalProductPackages = map (p: "Robotnix${p.name}") (lib.filter (p: p.partition == "product") enabledPrebuilts);
+    system.additionalProductPackages = map (p: p.moduleName) (lib.filter (p: p.partition == "system") enabledPrebuilts);
+    product.additionalProductPackages = map (p: p.moduleName) (lib.filter (p: p.partition == "product") enabledPrebuilts);
 
     # Convenience derivation to get all prebuilt apks -- for use in custom fdroid repo?
     build.prebuiltApks = pkgs.linkFarm "${config.device}-prebuilt-apks"


### PR DESCRIPTION
This allows the user to change or remove the prefix added to the module name, making the resulting image look cleaner. The user is responsible for making sure that the prefix they choose doesn't cause conflicts.

Also stick in another tiny patch to PRODUCT_BRAND to match the official images.