### PR TITLE
raviole: Update blobs to the new mid-November update

### DIFF
--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -15,12 +15,12 @@ in
   buildDateTime = mkDefault 1635822919;
 
   source.manifest.rev = mkDefault (
-    if (config.deviceFamily == "raviole") then "android-12.0.0_r12"
+    if (config.deviceFamily == "raviole") then "android-12.0.0_r14"
     else if (elem config.deviceFamily [ "redfin" "barbet" ]) then "android-12.0.0_r10"
     else "android-12.0.0_r8"
   );
   apv.buildID = mkDefault (
-    if (config.deviceFamily == "raviole") then "SD1A.210817.036"
+    if (config.deviceFamily == "raviole") then "SD1A.210817.037"
     else if (elem config.deviceFamily [ "redfin" "barbet" ]) then "SP1A.211105.003"
     else "SP1A.211105.002"
   );

--- a/flavors/vanilla/12/repo-android-12.0.0_r14.json
+++ b/flavors/vanilla/12/repo-android-12.0.0_r14.json
@@ -1,0 +1,10887 @@
+{
+  "art": {
+    "dateTime": 1629441584,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e23b87e378f08e7cfa0d48f1bb962dbf0788ba10",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lphdkwnfv86vkvv3xhmaprs76hgm58cmsmj9yapp0561470hlsg",
+    "url": "https://android.googlesource.com/platform/art"
+  },
+  "bionic": {
+    "dateTime": 1628910050,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68d617faaea0742075efe95d95785f50db2a51ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y25max15fzxf1c226hshcb2kjsr24gj37n2m0p7lhjbjgxc33d6",
+    "url": "https://android.googlesource.com/platform/bionic"
+  },
+  "bootable/libbootloader": {
+    "dateTime": 1616547632,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "137603547af6188a262a635d1147134e040d33d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1g10xsdj43z21cw7yl1mg70jdmgf27xqm713al4bvpqy7g3l177j",
+    "url": "https://android.googlesource.com/platform/bootable/libbootloader"
+  },
+  "bootable/recovery": {
+    "dateTime": 1628910051,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d306b59508e345955fd7655dae16063609697a69",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0smawcjxwdh7qib5xnwgbjniw4nvwbcps86hi8nfas2z1vwdrqgq",
+    "url": "https://android.googlesource.com/platform/bootable/recovery"
+  },
+  "build/bazel": {
+    "dateTime": 1620954037,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "WORKSPACE",
+        "src": "bazel.WORKSPACE"
+      },
+      {
+        "dest": "tools/bazel",
+        "src": "bazel.sh"
+      },
+      {
+        "dest": "BUILD",
+        "src": "bazel.BUILD"
+      }
+    ],
+    "rev": "342d9d051b83b8e37589e081bb76fd6bf15412f5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jsyl5fjbqna5vw2w3qqn6p9gr9rln6mkzisd0dqz1i8wh7nw1rf",
+    "url": "https://android.googlesource.com/platform/build/bazel"
+  },
+  "build/blueprint": {
+    "dateTime": 1621904475,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "bf0108e7e40957679c73514ffdf45e695db74f63",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yi42fwvv679pfpr4vxy7vfrqr4la043a7s57rpbw2k5v7h6vm2y",
+    "url": "https://android.googlesource.com/platform/build/blueprint"
+  },
+  "build/make": {
+    "copyfiles": [
+      {
+        "dest": "Makefile",
+        "src": "core/root.mk"
+      }
+    ],
+    "dateTime": 1635410101,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "build/CleanSpec.mk",
+        "src": "CleanSpec.mk"
+      },
+      {
+        "dest": "build/buildspec.mk.default",
+        "src": "buildspec.mk.default"
+      },
+      {
+        "dest": "build/core",
+        "src": "core"
+      },
+      {
+        "dest": "build/envsetup.sh",
+        "src": "envsetup.sh"
+      },
+      {
+        "dest": "build/target",
+        "src": "target"
+      },
+      {
+        "dest": "build/tools",
+        "src": "tools"
+      }
+    ],
+    "rev": "f09316abd6392c5c0e002798ae30015f876b3273",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0541xcsc070vscfqrkqrphky9rjyblgrk6m3dry7dp5k02w6v0b6",
+    "url": "https://android.googlesource.com/platform/build"
+  },
+  "build/pesto": {
+    "dateTime": 1620867661,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17c14f3bf2edd3c30b9a73984d112569421e5476",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0cgw3nmazi87f7qam00szqzy37laz7lv5w9l5zagniv5z0kjl10j",
+    "url": "https://android.googlesource.com/platform/build/pesto"
+  },
+  "build/soong": {
+    "dateTime": 1628730050,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "linkfiles": [
+      {
+        "dest": "Android.bp",
+        "src": "root.bp"
+      },
+      {
+        "dest": "bootstrap.bash",
+        "src": "bootstrap.bash"
+      }
+    ],
+    "rev": "7e00a6bc9290ae5957937dc01a964762bfe07e9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kpy7b4znbga9zylj52hhz6i972n1zf5wcghgapsxzyj8phcyd5h",
+    "url": "https://android.googlesource.com/platform/build/soong"
+  },
+  "compatibility/cdd": {
+    "dateTime": 1618880451,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a5ef0f4888b66af0648a42d534a1beeeb53552d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04l9jdf0i7pf4lq3dxrik4gg3k00v2r3dr9mp6bznf6mm37cvzh9",
+    "url": "https://android.googlesource.com/platform/compatibility/cdd"
+  },
+  "cts": {
+    "dateTime": 1630289514,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "badc0830ad6e57450ba235177d095a13afce4d64",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lzm8kl2vwr72l083qgi88iag1gnmashd62wdbviafiwin7yz1q2",
+    "url": "https://android.googlesource.com/platform/cts"
+  },
+  "dalvik": {
+    "dateTime": 1617930045,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c2fecd5693aa3e6f1b35ff7f1519f71968d7211f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18iw5p98mm7wnfjd0yhnb1fcrnjwrigp1apbz2lyizlm95hkgz2v",
+    "url": "https://android.googlesource.com/platform/dalvik"
+  },
+  "developers/build": {
+    "dateTime": 1613865665,
+    "groups": [
+      "developers",
+      "pdk"
+    ],
+    "rev": "cc0cee520a3b98e8d3f4eb5e19e786e9b89db4e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0pvgglif7iy8n6sx8xkxw7xf6gcv60lgfh4kbd4k1ry75rb1hfy3",
+    "url": "https://android.googlesource.com/platform/developers/build"
+  },
+  "developers/demos": {
+    "dateTime": 1496909782,
+    "groups": [
+      "developers"
+    ],
+    "rev": "29823a01b541985f856026fcd4375d9169e1fcf3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ciqaaj6jkykb6lkksqfka0077fhz1md6qiw5m337llyyiz29ywc",
+    "url": "https://android.googlesource.com/platform/developers/demos"
+  },
+  "developers/samples/android": {
+    "dateTime": 1619838059,
+    "groups": [
+      "developers"
+    ],
+    "rev": "61dbcc902a830ba5ee21374d33eb547a1e63aca3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1npnk3yyvchp4lh38aa7b31kly968h4j9af3x0ad894qigdmbk2g",
+    "url": "https://android.googlesource.com/platform/developers/samples/android"
+  },
+  "development": {
+    "dateTime": 1626397237,
+    "groups": [
+      "developers",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7c3738596abe8ae6a6cbebefd46b1b275984b458",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mvd8nfa2a1adqcgfnqby4b3ilhzqbk1dy30kngkn3i61k92g7x4",
+    "url": "https://android.googlesource.com/platform/development"
+  },
+  "device/amlogic/yukawa": {
+    "dateTime": 1621652452,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "8176d7866998f8368988e83b916ee26eb7585b5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1i3zxm55zy57svhnqp77jprglwqw2r6b7xpxvjmllm3d3jnbzq8h",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa"
+  },
+  "device/amlogic/yukawa-kernel": {
+    "dateTime": 1617152433,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "d14a20cbcbbde7bcd9b1cd520170df6ebbfb9b08",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hfm6i7s4jrhfkxggkdvi58bwkl0gs0zyhn0p2p4gkg4vn1xhzyi",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa-kernel"
+  },
+  "device/common": {
+    "dateTime": 1622682064,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs"
+    ],
+    "rev": "2580fac8c697f731f04256d781898ea31b037cc3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1i1lpm2spdz48cpjwmdc48a4jyd3lnn8s1mzx93rvmcjll6s2q88",
+    "url": "https://android.googlesource.com/device/common"
+  },
+  "device/generic/arm64": {
+    "dateTime": 1588734552,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddcaf20c2cc069e9cf74e4570a51b383703920bd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l66va61ybzf224l9q2gq60i132ikb75k58h1za1faq18m8hwvyx",
+    "url": "https://android.googlesource.com/device/generic/arm64"
+  },
+  "device/generic/armv7-a-neon": {
+    "dateTime": 1615075251,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36665c66117b6da553c58eae7e0d41e039058533",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1986xyq0p2cqf4bgw3xf21qjszbidll8iwz2snzvffapybhr1213",
+    "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
+  },
+  "device/generic/art": {
+    "dateTime": 1613865671,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17b534dbd44057d01b53ac60fa59b57fbf5f2496",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ijzwbsqb7xhzlj1bc84mp6hx782q30cvdsk4z6m36yibwlmkd97",
+    "url": "https://android.googlesource.com/device/generic/art"
+  },
+  "device/generic/car": {
+    "dateTime": 1628125317,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e39c19f4ae17bec1db325649d3d4ae7c74cb1151",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rlgpfbiv77038zlys5rxwpb1hv99gfdw01vkqwpmd9fjdr1xvbv",
+    "url": "https://android.googlesource.com/device/generic/car"
+  },
+  "device/generic/common": {
+    "dateTime": 1621904487,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94c8dc8dab0d655325df083eeeae50db676c07c1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1fvph5bf626bja9c0fq8c849qc7vgj5nnwasyjs5gkbhgzx0s9hc",
+    "url": "https://android.googlesource.com/device/generic/common"
+  },
+  "device/generic/goldfish": {
+    "dateTime": 1628816450,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "446cce10ecb99067c6c1b57ce3eeae5328149c01",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mr6a2ypv6dm22qyr36806bj7i56w6rxa6m6gxlga8dzdlfwz8p9",
+    "url": "https://android.googlesource.com/device/generic/goldfish"
+  },
+  "device/generic/goldfish-opengl": {
+    "dateTime": 1628305262,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d0956638ac1654f7e6013e4b049a61d53b286861",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gfjhdlj5l8d2q0g3p54i8wm15rw28ww9wh8irp8nl7in2k8kqq8",
+    "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
+  },
+  "device/generic/mini-emulator-arm64": {
+    "dateTime": 1600053094,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2decebd68e4f4d01cc9f71d9416acd60081eca72",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
+  },
+  "device/generic/mini-emulator-armv7-a-neon": {
+    "dateTime": 1600052500,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e8b1b6559ec84a69a7504f2b98d87f7eec8df27",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
+  },
+  "device/generic/mini-emulator-x86": {
+    "dateTime": 1600052592,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "613225e7e7f4ee7a7de0b0ef7012b8756697e0cf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
+  },
+  "device/generic/mini-emulator-x86_64": {
+    "dateTime": 1600053156,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d938bc24a6dc175fc94eb905b52228d917cfd09",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
+  },
+  "device/generic/opengl-transport": {
+    "dateTime": 1613440859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c5f73bfb18e12bb94d17556b76e3e601ad97788",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1j6amjg99zbjsdg3xzgls29i0awz5rxdq8wklvkvrymhczk9ibr8",
+    "url": "https://android.googlesource.com/device/generic/opengl-transport"
+  },
+  "device/generic/qemu": {
+    "dateTime": 1600053229,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a020272613486c97cca766c2616ccfc0117da76",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/generic/qemu"
+  },
+  "device/generic/trusty": {
+    "dateTime": 1620781268,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd42784e3445395393d45afcfa7a262963e09edd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hj6w5lsdahw94dh8zgj2a6zs1vidcxdyi0wsxm7zwsvl1pwmrmr",
+    "url": "https://android.googlesource.com/device/generic/trusty"
+  },
+  "device/generic/uml": {
+    "dateTime": 1613865678,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "95150f75fae5a62b01fe5a6260f158c36d32f1f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18ninwq7gwgxxkrf5pgqfd05n8wjfnl9wc2wmwrs9r4kzgawmhgs",
+    "url": "https://android.googlesource.com/device/generic/uml"
+  },
+  "device/generic/vulkan-cereal": {
+    "dateTime": 1621047698,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "953395e875b1f8b36f38d323eca27bcf75666be4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1702hi0dw0rsar4dh0acgy7na6qcw0gv6cryidx1kpql6g8i265k",
+    "url": "https://android.googlesource.com/device/generic/vulkan-cereal"
+  },
+  "device/generic/x86": {
+    "dateTime": 1588734828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8dd0583a9a4d1c5dc7b74325fa879e605f89492",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1msvricg8asj7vhkpfx4vd3jykdg3xqs0yhrvhj7m48lhsandfdz",
+    "url": "https://android.googlesource.com/device/generic/x86"
+  },
+  "device/generic/x86_64": {
+    "dateTime": 1588734345,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e29380021a263d17fca447c03cd1f4b178d8010",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1w7b33sap7ym1y23435n3cjsbvl8ws49m46lk8h1kgy8apg08mkw",
+    "url": "https://android.googlesource.com/device/generic/x86_64"
+  },
+  "device/google/atv": {
+    "dateTime": 1627700460,
+    "groups": [
+      "broadcom_pdk",
+      "device",
+      "generic_fs",
+      "pdk"
+    ],
+    "rev": "7b4c31e7135ce73386656e8119a81eda1dff2fb4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1fivwc6acv199pfci1pvwm2qxhvv228794rh4v9w46skp0yfd6a1",
+    "url": "https://android.googlesource.com/device/google/atv"
+  },
+  "device/google/barbet": {
+    "dateTime": 1629162057,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "8ce0f702593acc1f238632884e4751d1b2422173",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fnvbglyq1nh0pcd71ypxdv7lz7wjr62l1ipcv2j5nkqb460n52q",
+    "url": "https://android.googlesource.com/device/google/barbet"
+  },
+  "device/google/barbet-kernel": {
+    "dateTime": 1628305269,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "f2dfce1c4debd94697e01de2601231e3881d416f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1js00f145l6by8pi38rng834aqzsm6iz3mz0idspfxkiwlhbxa13",
+    "url": "https://android.googlesource.com/device/google/barbet-kernel"
+  },
+  "device/google/barbet-sepolicy": {
+    "dateTime": 1626310869,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "3593d7dc1482e4c097fefdf4d48be55111350c0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lwjsrfcvdzj8lqkjy55y58bqmzirfg25zb19nhrp0bfnph3wlln",
+    "url": "https://android.googlesource.com/device/google/barbet-sepolicy"
+  },
+  "device/google/bonito": {
+    "dateTime": 1628910071,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "d1891f34be28e09dedfb1e9f02c73deb6ea85e2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c6cx4m7ysnb70iy1hfl74hpljpip44hpy74q859sqyfp3hjlffd",
+    "url": "https://android.googlesource.com/device/google/bonito"
+  },
+  "device/google/bonito-kernel": {
+    "dateTime": 1628305271,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "06a643c79d0263131b6770e58eb72a9c2bdede0c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q16rq4wprzgghvn7g0ngm6i50wmgffr0s9b0rkyzf1jfgq1cp5n",
+    "url": "https://android.googlesource.com/device/google/bonito-kernel"
+  },
+  "device/google/bonito-sepolicy": {
+    "dateTime": 1626310871,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "c69f393bf19bf92a36bc31be9826aa73c4c844b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jh4dvi6nckdvvmi02vlk59273nsaywcnkca8l8q7n85g5jkvakl",
+    "url": "https://android.googlesource.com/device/google/bonito-sepolicy"
+  },
+  "device/google/bramble": {
+    "dateTime": 1628305271,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "a86a45764c86fb126af2ab125665ddb6d72db630",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07ha9fsw542jkwjnxr7kjwygsvjr781xy0nn9bcrmwvs901dpmz8",
+    "url": "https://android.googlesource.com/device/google/bramble"
+  },
+  "device/google/bramble-sepolicy": {
+    "dateTime": 1618966878,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "704a822669a56aeae31708c2f44ba47f57fc52ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05f5cn22jkv4vjcdghy8j6g8g33yayrp4qk0bh289xri41l56yy2",
+    "url": "https://android.googlesource.com/device/google/bramble-sepolicy"
+  },
+  "device/google/contexthub": {
+    "dateTime": 1620262878,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "73490fdb02413852d4117b23303042621087c9f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vs3ya2smc8qdhwlwiy4ksy2qfkwd6limy58kvwy12gbgcyqx483",
+    "url": "https://android.googlesource.com/device/google/contexthub"
+  },
+  "device/google/coral": {
+    "dateTime": 1628910074,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "b94768a491208417460b6b12ae598138e7e91b65",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wrc9v7bn91ysdngbqrgljw98fajv510wwf8frl7qg12pcbj6r1q",
+    "url": "https://android.googlesource.com/device/google/coral"
+  },
+  "device/google/coral-kernel": {
+    "dateTime": 1628305274,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "d8131d1343921f91e25b05d8ae8e5152fa8bd3b4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n2fjaamb1vslcm7y65zv78fw5z7xgmz8rqkagc913rf1f4k8g6q",
+    "url": "https://android.googlesource.com/device/google/coral-kernel"
+  },
+  "device/google/coral-sepolicy": {
+    "dateTime": 1626310874,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "41d310dfb377562eb47920fcee1b6b4efee2c5eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02pysgrqcxhqsjgn12l1ckicg3wbm7lyn85asap40v5b5cxj60sb",
+    "url": "https://android.googlesource.com/device/google/coral-sepolicy"
+  },
+  "device/google/crosshatch": {
+    "dateTime": 1628910083,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "03cee3bb5cba8caeee5a08376fb7a345a046b51e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06v96wi73qhihy22jj3x6g1ndsg7qd4mij23a423j4s7yinffn0w",
+    "url": "https://android.googlesource.com/device/google/crosshatch"
+  },
+  "device/google/crosshatch-kernel": {
+    "dateTime": 1628305282,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "6faf15d3cbf1ce09b839b4a1fcfc869fe6fff013",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y2984wgi8277hkalin5spnhkljdx9qx2s6pppxm0aalcxk34shj",
+    "url": "https://android.googlesource.com/device/google/crosshatch-kernel"
+  },
+  "device/google/crosshatch-sepolicy": {
+    "dateTime": 1626310883,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "24766e7d122d2d16f47d4987eb332a9543f86bfd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bhgx2ma193m5gbidyy6zq1q3s695cr72vzw10wci17llg25zdcl",
+    "url": "https://android.googlesource.com/device/google/crosshatch-sepolicy"
+  },
+  "device/google/cuttlefish": {
+    "dateTime": 1628910085,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "fe16ef68474f7cf7d0129875743bb08b7ef68e67",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hq27x2dy6g5cizk2xz6gr97jzr8aqfy2f828l2nf1rn77ci01h8",
+    "url": "https://android.googlesource.com/device/google/cuttlefish"
+  },
+  "device/google/cuttlefish_prebuilts": {
+    "dateTime": 1628557288,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "80a6fc3b4d538b1b60e7a5abafc1528f34538e23",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04593v4y2mb53zz2hrfwk43sayq8myhlm23r2rrjhbyfr2w7mj5n",
+    "url": "https://android.googlesource.com/device/google/cuttlefish_prebuilts"
+  },
+  "device/google/fuchsia": {
+    "dateTime": 1613865700,
+    "groups": [
+      "device"
+    ],
+    "rev": "adc87b6b4f8d987c3dd6840e39194501f0fa7dca",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "131k68cyq4yl559hjy9qxll6smzavph9c2l39q5wwqxlb8w96gzp",
+    "url": "https://android.googlesource.com/device/google/fuchsia"
+  },
+  "device/google/gs-common": {
+    "dateTime": 1621363244,
+    "groups": [
+      "device",
+      "pdk-gs-arm",
+      "slider"
+    ],
+    "rev": "4fd7139c966506ac9907a6d675a5e832210a12fb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/google/gs-common"
+  },
+  "device/google/gs101": {
+    "dateTime": 1635286128,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "6942c87a02ca7b6e6e5bf2f52757263b963a5b8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fkyzkrkvda6c2lg3g4j6xvb6s7a79vvl3f2mfhzsq9kn6dg4yj1",
+    "url": "https://android.googlesource.com/device/google/gs101"
+  },
+  "device/google/gs101-sepolicy": {
+    "dateTime": 1629340744,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "dbbeb6cf6edf6c8318c39c511348ca7985a7f395",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjmsk5ary7k0pkfarg4y4czd24i9idsicfqxj5nr8zmg2a32hkv",
+    "url": "https://android.googlesource.com/device/google/gs101-sepolicy"
+  },
+  "device/google/raviole": {
+    "dateTime": 1635410094,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "b66423ab65881cf84c73af18bd3ed8d5136bda4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0c4b5yqj51b18jnyqxgxiwkcag9glmcrmik4dr1yy2iym5i80rvl",
+    "url": "https://android.googlesource.com/device/google/raviole"
+  },
+  "device/google/raviole-kernel": {
+    "dateTime": 1632794481,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "45e9dbbabb776b51013c7d0992071965dbd06157",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m29clgwb16xvb12ispd89m3fbf4rh4zlrmx78rwzij19bsxx4wv",
+    "url": "https://android.googlesource.com/device/google/raviole-kernel"
+  },
+  "device/google/redbull": {
+    "dateTime": 1628910078,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "9ec736edeb720e3e22138b40eca4b123abfee5bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mi1dyp70r7p7kl2vpfz3r5ys731cwlhf9d7nk4vnvsv54hw5z9p",
+    "url": "https://android.googlesource.com/device/google/redbull"
+  },
+  "device/google/redbull-kernel": {
+    "dateTime": 1628305279,
+    "groups": [
+      "bramble",
+      "device",
+      "redfin"
+    ],
+    "rev": "97230c16b07c3c1c16e68f839e34c5e4d89beb1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1avpf8df32af57a4zjph8jz609sh047rk30f99zsc4qcsqjixzs9",
+    "url": "https://android.googlesource.com/device/google/redbull-kernel"
+  },
+  "device/google/redbull-sepolicy": {
+    "dateTime": 1626310878,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "8463869349be5505424dd5f9f151f43fba98d759",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0apj5wbdlnirnc6fvnm5ibclyzfp0w45abx40q4k27mjbbhd4mn9",
+    "url": "https://android.googlesource.com/device/google/redbull-sepolicy"
+  },
+  "device/google/redfin": {
+    "dateTime": 1628305279,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "e681e0468a04788da489589bfc0aa7b539b774a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05clyfnjv0h91qncb5i23hj3mkgvff2g3qfcxy0hgxa99crnpp08",
+    "url": "https://android.googlesource.com/device/google/redfin"
+  },
+  "device/google/redfin-sepolicy": {
+    "dateTime": 1618966886,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "5e76f11ad4063526f7576dd17998017b1008b97d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18ng4p4hgm1mcr9j7py85420hsdasv34hqbi3whg3kiynsbflj10",
+    "url": "https://android.googlesource.com/device/google/redfin-sepolicy"
+  },
+  "device/google/sunfish": {
+    "dateTime": 1628910082,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "7e084b058fbc8143f594c08f043b0e302d1f8ea3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m739p6ddyhcj2kg7j7ignc6vnqhkhkgh04n03za0aggbs4r4mpp",
+    "url": "https://android.googlesource.com/device/google/sunfish"
+  },
+  "device/google/sunfish-kernel": {
+    "dateTime": 1628305281,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "c80d308d2b3c8db4f65524dc9102f6caa26c4813",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1iqn64p6gb22jywf44amd0vd9wy2sxnw38687hp4vhmbyympj4rc",
+    "url": "https://android.googlesource.com/device/google/sunfish-kernel"
+  },
+  "device/google/sunfish-sepolicy": {
+    "dateTime": 1626397265,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "29061bab63dbfb802bd24b6c5bc3e7f548ae4730",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hfwxn0x7skp9r9pk2czgrank7jzysjaqc7iv62ns7pxjxjpi6ar",
+    "url": "https://android.googlesource.com/device/google/sunfish-sepolicy"
+  },
+  "device/google/trout": {
+    "dateTime": 1627520482,
+    "groups": [
+      "device",
+      "gull",
+      "pdk",
+      "trout"
+    ],
+    "rev": "0d69f7659248bc25fa39077f6f0767defdc124bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09gfag66la5vi3xk0m60c6rifz7ffbpksvh3rqd2lsy5k9czl5ia",
+    "url": "https://android.googlesource.com/device/google/trout"
+  },
+  "device/google/vrservices": {
+    "dateTime": 1613865701,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6d0c09142315f8463dc190fb81fb6268a3372b64",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bqfiyv18g1il413rkmyhz4prkmq85ww4sh2d5i0rzpddc9rldjy",
+    "url": "https://android.googlesource.com/device/google/vrservices"
+  },
+  "device/google_car": {
+    "dateTime": 1628643678,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ce5a4c409366153ec368be27d75ebd6914b4ed2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0f3fdlhf3a00aykpm568hdgwn3jsp4gvizmqw8a8r29mhn04w25v",
+    "url": "https://android.googlesource.com/device/google_car"
+  },
+  "device/linaro/dragonboard": {
+    "dateTime": 1624496486,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "90c6a8e31767f3c5992d56cad072c968c191005d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0pb3mqvj4r549lgvqv53cd8x3qyx0byj9a87v5gl5q99lsrbjar9",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard"
+  },
+  "device/linaro/dragonboard-kernel": {
+    "dateTime": 1613865705,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "4f6a14bf1fc8240ae25a82c91b2cce3a0a432ce3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0prblxspjvp5nsz9ff236ia761539rbnn9wmna8za4k2qg4j26xk",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard-kernel"
+  },
+  "device/linaro/hikey": {
+    "dateTime": 1619139975,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "f9571fef54da3b6f95376549a41e24655489603c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l5bkan588ig1g44bf1c5pwcd27i6wysh3i7sdfvlabkv6h0g86z",
+    "url": "https://android.googlesource.com/device/linaro/hikey"
+  },
+  "device/linaro/hikey-kernel": {
+    "dateTime": 1613865708,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "4e03ce4d862b6baa782bed426c75abd44333ba4e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r994z41qd5fq9vsg0360glrljrivkwa4wsms1amaw503vdxx2nn",
+    "url": "https://android.googlesource.com/device/linaro/hikey-kernel"
+  },
+  "device/linaro/poplar": {
+    "dateTime": 1620262898,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "b21da9c4a584954b8feff432a3028ed9ebd71fbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1j921jkjwi0v7mhf6lybdlv2axyzlrhmyfkpdghmfyny9y1za7bz",
+    "url": "https://android.googlesource.com/device/linaro/poplar"
+  },
+  "device/linaro/poplar-kernel": {
+    "dateTime": 1558122724,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "5ecf1051f8c5e70c9a7987518a5aa4ce46a96197",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0danmswzl4r3skm19gg0868p36fxlhd5vj793v4i5allqkqgnxin",
+    "url": "https://android.googlesource.com/device/linaro/poplar-kernel"
+  },
+  "device/mediatek/wembley-sepolicy": {
+    "dateTime": 1624676490,
+    "groups": [
+      "device"
+    ],
+    "rev": "2e5c7ceb26181a366328a1ef411672689dbf276c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "184isr5327zlh5fjaqzcyanldbjxr7lp934141r80c2pydgfx765",
+    "url": "https://android.googlesource.com/device/mediatek/wembley-sepolicy"
+  },
+  "device/sample": {
+    "dateTime": 1620442913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc5c959a97a2e28135710d72da39d134457242f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14iyki70hlnb95i416izsw29hiyfpj1dnfb2pxnrr82qy3xk6dr7",
+    "url": "https://android.googlesource.com/device/sample"
+  },
+  "device/ti/beagle_x15": {
+    "dateTime": 1617152481,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "94fc84d4704effdd4208421809d198d4429e5eb3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vbknk4k3dx9gbmhnhgvaiinfmhk8s0f3j5hzihbbdljqp0j65mj",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15"
+  },
+  "device/ti/beagle_x15-kernel": {
+    "dateTime": 1554368860,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "60d0bc9df5b6e4c3f7a2991d2a7e6b3d6d27e743",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ahsr4x06x982y975jizgy0k3jix70rd1ypzgg3v3k24wpifrnn3",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
+  },
+  "external/ComputeLibrary": {
+    "dateTime": 1614823322,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "f8a4151f06e0651cfed3b60b9bd7a84092fa948a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k1ian6l5wkr2lgbn061rqggrv2k37z8x56jw2k005ga020qb71k",
+    "url": "https://android.googlesource.com/platform/external/ComputeLibrary"
+  },
+  "external/FP16": {
+    "dateTime": 1613786542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "588bc82c029d9746e17be817eee5473b568cad26",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13lwr9v1rhr35mlvhzvwhwx9zcsry9nmin57w8wy8f3jm3m65lsd",
+    "url": "https://android.googlesource.com/platform/external/FP16"
+  },
+  "external/FXdiv": {
+    "dateTime": 1613865767,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee5c3ba9b77e7c93562c605b33a004c36ca08a1e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1804qzjg3vn7crqfzb8qv4f8sz5gl09b6h1lsgdr2plz2iga6b6m",
+    "url": "https://android.googlesource.com/platform/external/FXdiv"
+  },
+  "external/ImageMagick": {
+    "dateTime": 1619053377,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1ce37432f3c80c1d9db6bd3add366e5b587c857",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06ngnvlj2yd1n5r9d5jg914br23ynp0hjwqlvcp9kyb9wnz8n7ll",
+    "url": "https://android.googlesource.com/platform/external/ImageMagick"
+  },
+  "external/OpenCL-CTS": {
+    "dateTime": 1621991064,
+    "groups": [],
+    "rev": "df01ffb27a2ece65cb34b6c1fe48a0f813635c74",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vs5jdpd0mxglmpcs0yjf778ink7mhkliahd7py6smw8mlram7kx",
+    "url": "https://android.googlesource.com/platform/external/OpenCL-CTS"
+  },
+  "external/OpenCSD": {
+    "dateTime": 1613865858,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3fb7eba3aca65aeb8415350be9b6cd00bdf700b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b3sn1yxyjl7ghzvgq2fk50q1q52s5wbwg7lgdd37kn0dfj8f7pw",
+    "url": "https://android.googlesource.com/platform/external/OpenCSD"
+  },
+  "external/Reactive-Extensions/RxCpp": {
+    "dateTime": 1613613836,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3ffee63fbe6dfab111ea8a89aae8f34e71a723e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ydkh937q0vss0y5zid0zfrhlvk0rib57g2cnylzl2f667svabr0",
+    "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
+  },
+  "external/XNNPACK": {
+    "dateTime": 1616634363,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b6c4071ae55be99a8ebcfb25cd8b827b4e907e6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ps0gzf10n84ppcv23m03knwbllqd6x1skvn69sn6ssfiw12slwh",
+    "url": "https://android.googlesource.com/platform/external/XNNPACK"
+  },
+  "external/aac": {
+    "dateTime": 1620514892,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4f8ea835e55c5c8e78d61487a0e7c844552da4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bg8wabf6snkr7fy3izis441jhqhag1gngi53dlzfk7g7ljiz3if",
+    "url": "https://android.googlesource.com/platform/external/aac"
+  },
+  "external/abseil-cpp": {
+    "dateTime": 1613531643,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87e662e66ad1b0fb655de45a16f2ec99fafb0867",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "090a9pkyc3pxqz1pa42kmgqzqn3cs80f4arabm9sffnkxgds1254",
+    "url": "https://android.googlesource.com/platform/external/abseil-cpp"
+  },
+  "external/adhd": {
+    "dateTime": 1618275704,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d82f41f7a2c3017f4d29298214a0a9625f03e0c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k726ay3gq777jc9g57aqcnfvafh9xxhkfahcgi4mjcys6x60rbd",
+    "url": "https://android.googlesource.com/platform/external/adhd"
+  },
+  "external/android-clat": {
+    "dateTime": 1622682115,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "129187e731721f78e9d325f821cd59c7729b061e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08bddsbl7za78ac6drf63pmpimyqcjkqp3xkjacqqppa16gk15f0",
+    "url": "https://android.googlesource.com/platform/external/android-clat"
+  },
+  "external/android-nn-driver": {
+    "dateTime": 1621558976,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "db4b59ac06d25a5bc660f7d39f959bceedae55bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "060pv319qq0wdmy6xjbllc83mx5xkkz0jaanzbmgwiv2cq2xsc1h",
+    "url": "https://android.googlesource.com/platform/external/android-nn-driver"
+  },
+  "external/androidplot": {
+    "dateTime": 1619233312,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd818adf657d78fb87b514558a5aa185c27c16d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dxx539y2fbys0v3108mvk6ac875rjz6sw552xa2mhdhj5hywx32",
+    "url": "https://android.googlesource.com/platform/external/androidplot"
+  },
+  "external/angle": {
+    "dateTime": 1626915721,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f02750dd555c4be0dac4e4260ea2830bb341d49f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dl3jgr61x82h1a7vdd4a62ax4314fbny3zqas42bbd6j8djkipm",
+    "url": "https://android.googlesource.com/platform/external/angle"
+  },
+  "external/ant-glob": {
+    "dateTime": 1613613700,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40eacaaaf6050b47834e947ea032354712e42443",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kv13x3rrjv04fyipfjgdmvbj9c22wb4ws8xikp2byvqss5qfyfj",
+    "url": "https://android.googlesource.com/platform/external/ant-glob"
+  },
+  "external/antlr": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "45b3fb46b51ae59852a404e6a1531fd1e9e3d605",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09m5na2mm1qbbffzvmyvkvvp48wcfyd2m90asg07adaf94pw7xkb",
+    "url": "https://android.googlesource.com/platform/external/antlr"
+  },
+  "external/apache-commons-bcel": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "74ec88f1b0e24ea126dcca337827c8e566680a85",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wg1k32wz232b3d0iz8n0krpclz21l8jmmpd08ybgx410ga0nlwb",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
+  },
+  "external/apache-commons-compress": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48bf53e837774d2e42004f93d5ada60992e4e0ad",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mrr0ypp23pljll9i0xawar6h4snw52k10xnggmsrj638xi5bmms",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
+  },
+  "external/apache-commons-math": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9f82e2a24ff99c49f71236cf0420078d78bcf72",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17f2wbjgrpyjbcxxmwyfyxfbr7ci4z14ry1vp7dac0hlzn57rpln",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-math"
+  },
+  "external/apache-harmony": {
+    "dateTime": 1622077394,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fbe046c6814cb6e6e7b6a793966e982d0aacd8f9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13j3zz0wjvyyy8i4n56039n96yrla6iqzng13fi02fia2wwv5vjb",
+    "url": "https://android.googlesource.com/platform/external/apache-harmony"
+  },
+  "external/apache-http": {
+    "dateTime": 1622862125,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b6510e3fdd042fb0c12ce071c89284d71d8d708",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "180wkbj8pj021w6wizcjlnjl8giw3bs998jrxxpyrkpnjbf7nw2a",
+    "url": "https://android.googlesource.com/platform/external/apache-http"
+  },
+  "external/apache-xml": {
+    "dateTime": 1614909714,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "065d4364b7061562ecf6d4f7009377f89abc5f99",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07p95202kf49p5wpg5fq9nc99hcjcphac903sbm8wlsvcvppw6hx",
+    "url": "https://android.googlesource.com/platform/external/apache-xml"
+  },
+  "external/arm-neon-tests": {
+    "dateTime": 1613531648,
+    "groups": [
+      "vendor"
+    ],
+    "rev": "2a9267451f3f5bba3870cfd2e57ad0ced52ec486",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05q3rb390d3zdmva3br4r2njy8hwvnn3ny796dbbsy8fwyq6ijzg",
+    "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
+  },
+  "external/arm-optimized-routines": {
+    "dateTime": 1619744511,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ea1ea8c20b81b8a9c81da1efa47bf620d1f7480",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ag1zvd22685wxp2yk82vkwc246y2n1csqqjspx6zsbixgjrap5x",
+    "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
+  },
+  "external/arm-trusted-firmware": {
+    "dateTime": 1613531649,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02cd681e188c9d81b7861b641021357a96cfd658",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rdw9ffppv0lqb2gy6pljp9irrckg389afkb9m90nlx84cw4kg4j",
+    "url": "https://android.googlesource.com/platform/external/arm-trusted-firmware"
+  },
+  "external/armnn": {
+    "dateTime": 1616972498,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "6cb70c28613719df6311c382d4666cfc144565e7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1s30csg50az4hgmc0idc8ifnckw4rrjmhxlc3pl19kqywv1ng9m1",
+    "url": "https://android.googlesource.com/platform/external/armnn"
+  },
+  "external/auto": {
+    "dateTime": 1613865730,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98af6c5f5afb1462fa9e8b79691eb01a3d7fed18",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02zs1cf9553f3wamv53sfxpphh2ss7l6lvww39f970zdpkkr1k85",
+    "url": "https://android.googlesource.com/platform/external/auto"
+  },
+  "external/autotest": {
+    "dateTime": 1613865730,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "616a5d8d3d26c5b427b75d805a141c45d3d3413b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wnd234ci6hwfflsdf248jvmwp8dd08hcka8nll3gh0wqmy9bizf",
+    "url": "https://android.googlesource.com/platform/external/autotest"
+  },
+  "external/avb": {
+    "dateTime": 1625706158,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3823f71308c9135d3f6d11bc9b915828ba52901b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1s35d3zns4w00k7x2x2pvc4b2y4c8kd46rmi7x860kszkl02kvwx",
+    "url": "https://android.googlesource.com/platform/external/avb"
+  },
+  "external/bazelbuild-rules_android": {
+    "dateTime": 1616461306,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f1dbc6739c167c67ad92e5c0f530a00422cc6fe2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mg4iyzaq22b9n07146vmq273vrk2f0hlyj7jm71s6vhmlqzvl3z",
+    "url": "https://android.googlesource.com/platform/external/bazelbuild-rules_android"
+  },
+  "external/bc": {
+    "dateTime": 1620349608,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e273fcfcf2a7bc574ded4f9337201a21b7a3dbba",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ijih5ka54195h55c019z9nq5hmb71f3smgkssnh0rmjry6h5dld",
+    "url": "https://android.googlesource.com/platform/external/bc"
+  },
+  "external/bcc": {
+    "dateTime": 1613865733,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1fd66a042737d422f86cfc2f49b1758f21f3c03f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04kphwmxxnpv72ycsn8skhlc8hkmm01rb8w8x0jl0gcbcw28dbng",
+    "url": "https://android.googlesource.com/platform/external/bcc"
+  },
+  "external/blktrace": {
+    "dateTime": 1613952109,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7f8c75c844358f1fe16cea70ae0060c5d326cd18",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v4znxs40lqzd9k5qw5my887x3ybybdfhhcf7qi3y4v9p8wqk9mw",
+    "url": "https://android.googlesource.com/platform/external/blktrace"
+  },
+  "external/boringssl": {
+    "dateTime": 1619391729,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "889b51ae86a44bda97e85b8c3f08b1d80fc61cb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zdzw01rab9qnsj9vn4ygk0x2i3bm2zjidl7fxwxf8z42h027bpx",
+    "url": "https://android.googlesource.com/platform/external/boringssl"
+  },
+  "external/bouncycastle": {
+    "dateTime": 1620954118,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a017186520f28f172d01dacf1f207f5e021890b4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0x4sy9406gffkglnkyg1pwpi66p1mhkrhh0p1245f2mbap6zbhx4",
+    "url": "https://android.googlesource.com/platform/external/bouncycastle"
+  },
+  "external/brotli": {
+    "dateTime": 1613865735,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e943440baee061f1b6fbf09926b30bd72d286be5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jjahi9515i5fchmym5rc9fk63hh8dmmbacpvf5q8bfb96vc52bg",
+    "url": "https://android.googlesource.com/platform/external/brotli"
+  },
+  "external/bsdiff": {
+    "dateTime": 1618966927,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f52318333b4ab131bd1d9dbff3fd7eb68915082",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bvvbndadhzqsl8avqwzxag02i90zmplbzw5xfiprdrbzr3l07im",
+    "url": "https://android.googlesource.com/platform/external/bsdiff"
+  },
+  "external/bzip2": {
+    "dateTime": 1613865736,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "134c2d71738c8c884a587558c30f924cbd708b3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vc2m1fz3dhypn771zbhfdf1my1lgm1naz08zyfcm62j6p0263sw",
+    "url": "https://android.googlesource.com/platform/external/bzip2"
+  },
+  "external/caliper": {
+    "dateTime": 1614308719,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b373c09ba3170301b371cb34b11a31ca3499b0ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hg2c1b1vqrx3ky9s1s9bdalvpf47sgm2w2m3cwwc66p92x9sk8y",
+    "url": "https://android.googlesource.com/platform/external/caliper"
+  },
+  "external/capstone": {
+    "dateTime": 1613865737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5ee5b0fd4633bb783165a0243df4c8220cf458a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "181svy2yh8400xdjbz09rfmkzbzic8i8zjpj3mmicpq3lrbp37lz",
+    "url": "https://android.googlesource.com/platform/external/capstone"
+  },
+  "external/catch2": {
+    "dateTime": 1613531656,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6a17c3856467dacfd4de895d337e8a37b4ba5c70",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "121f7mvnhl9ss3ckwliiqfdkpi0c1siq7vy2ghd46lk17yc7lc7l",
+    "url": "https://android.googlesource.com/platform/external/catch2"
+  },
+  "external/cblas": {
+    "dateTime": 1613613713,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03841e047b2ddda8b846a4676959104cbb597693",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vs0bvv7jxg9v853ys0262523qw6f83vlyzkq8dfrsvnsycakzzf",
+    "url": "https://android.googlesource.com/platform/external/cblas"
+  },
+  "external/cbor-java": {
+    "dateTime": 1613531656,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "adbcbc81166a3cb8521dacfee4b0b8c631a78771",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18ycp109z76isyfi7pac2nd9idi23wpywkbndp9ki1h69mwr2zmm",
+    "url": "https://android.googlesource.com/platform/external/cbor-java"
+  },
+  "external/chromium-trace": {
+    "dateTime": 1619053327,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14a45bd361887d23ca298809f6ac34f98d418b95",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0alb6ykda1vi6n2g1cw3b3p871c9bpz4xgi163p7kz39hpwv4h5p",
+    "url": "https://android.googlesource.com/platform/external/chromium-trace"
+  },
+  "external/chromium-webview": {
+    "dateTime": 1624071747,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c5d27bbe856f3328d1fc616b439c7d8e9f5894d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p4kh9ph8ijnldlkv9yp61aabwba0q3qipq2i1my6073f9fi0r78",
+    "url": "https://android.googlesource.com/platform/external/chromium-webview"
+  },
+  "external/clang": {
+    "dateTime": 1613865740,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e9b40014a8a1eec94c32b8054f7db52c01d40ddf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06jjzh7xg63a852m61x1dy5mk32g505srm9qax981y1fiqy4pr9b",
+    "url": "https://android.googlesource.com/platform/external/clang"
+  },
+  "external/cldr": {
+    "dateTime": 1619838129,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90373b4caff35f57cb1b94944137a7935517f472",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10956w4glpps3sfa2qf69jn75y64vkbxjc0ra11pfx3is0xvbxmc",
+    "url": "https://android.googlesource.com/platform/external/cldr"
+  },
+  "external/cn-cbor": {
+    "dateTime": 1613613715,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ac4d7629b0c0a1811a62dad39437c446a345674",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gh910wa3zrdk8jaghbbrwhr5cwxj2jiji98b00i79vdndi9fkp4",
+    "url": "https://android.googlesource.com/platform/external/cn-cbor"
+  },
+  "external/compiler-rt": {
+    "dateTime": 1613865741,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d558b8b49ea84c8bd9f910177216fddfab0d0d6c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sxxwngwcb9z6x3f9i7fw8j08h27wvzhdnmwxbrx2kz2zphm4gwn",
+    "url": "https://android.googlesource.com/platform/external/compiler-rt"
+  },
+  "external/connectedappssdk": {
+    "dateTime": 1621472515,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e03ac074bcd91480c922f76ec51b50c9f51d63b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vavn5xrv27dqs41ijz6h5sp54ysb0azwkn4vzpzwwvvbkdxgdfi",
+    "url": "https://android.googlesource.com/platform/external/connectedappssdk"
+  },
+  "external/conscrypt": {
+    "dateTime": 1628910125,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "117a3087c0dadd327788576666c51616a0cf4ce0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0g9kibaj663hwkbsd31vkxhib941gi2vz9pb757wb0afaayrhdv3",
+    "url": "https://android.googlesource.com/platform/external/conscrypt"
+  },
+  "external/cpu_features": {
+    "dateTime": 1614996116,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e036fcf3eff658d8c6560364f2353d5414a28d75",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "078fa0lqhy0v8nhb81yr4r80lr6d24r0xayxwzvyz9f78phvypi5",
+    "url": "https://android.googlesource.com/platform/external/cpu_features"
+  },
+  "external/cpuinfo": {
+    "dateTime": 1613865743,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5042f102fce573344bc93d06fba8fd7d7256dc70",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y7api7gknnfphvwz8fc751yzwj5vzzgm7zqdbrcf0r3m09my4yg",
+    "url": "https://android.googlesource.com/platform/external/cpuinfo"
+  },
+  "external/crcalc": {
+    "dateTime": 1613531661,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "983e68c0f75ef0e9136ce7b27bf8cc129d94494b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nldnvwr197rpzigkxrdb1342vcnwh1mdazr831ynscqga55f7sc",
+    "url": "https://android.googlesource.com/platform/external/crcalc"
+  },
+  "external/cros/system_api": {
+    "dateTime": 1588216001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5b6e23574a47a93761cf16e675ecececc34fc6a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jr6jiz7qjgwfm8p15lq6qh18iy25qbyr1accj1mxy2xcp3lcvnl",
+    "url": "https://android.googlesource.com/platform/external/cros/system_api"
+  },
+  "external/crosvm": {
+    "dateTime": 1620349620,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d375c411ff17eb7f9343bf09a81d1b2e43b4f83e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ly6s74ajgf936hz3wb81cqla6a46dmxn0jk9137nqkxqyvanrfx",
+    "url": "https://android.googlesource.com/platform/external/crosvm"
+  },
+  "external/curl": {
+    "dateTime": 1613865745,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e550dba9f46bf8dcb20b838af2de872704fed910",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wfyfdkw212wlqdmxwwm985hdm6wwcgx3lagbl373h9f9d6j7y28",
+    "url": "https://android.googlesource.com/platform/external/curl"
+  },
+  "external/dagger2": {
+    "dateTime": 1620954134,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b4edf0f5e9b70d6b5d430f292c5e6dce30cc5b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0aa3q04an07rmyf3fjjs797fpm49mq4fi1y0arqdk3jcn44ha8al",
+    "url": "https://android.googlesource.com/platform/external/dagger2"
+  },
+  "external/deqp": {
+    "dateTime": 1628910129,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f7b1dda229803abfbdb39c96445d4870c290b09a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r2n9yw3iy9wdxwj6kjlq7fq7kfgsldjj0zr6zpz9h017nai8j6n",
+    "url": "https://android.googlesource.com/platform/external/deqp"
+  },
+  "external/deqp-deps/SPIRV-Headers": {
+    "dateTime": 1616029314,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "128cc3a5bcb8ac168ba972bb4434dbf22dec12da",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "106mp68abgajvp2bqk0882sr0hi6y4zqwhf8vhzfyfjz5pf4q5d2",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
+  },
+  "external/deqp-deps/SPIRV-Tools": {
+    "dateTime": 1618628536,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a9f6baaafb1981fe490ce49ae804d4abc935b94e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0453rrnvnzb6hifypla8sjjyzc2fk94b2ga14fb7v739lksl7yzi",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
+  },
+  "external/deqp-deps/amber": {
+    "dateTime": 1616029315,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d25d70037f5c357524434f5695d5f0bd7ca94a16",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "012vrgcf5afz99avy1107z40ly4dbnvaldzmm60zm074ys2gpczv",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/amber"
+  },
+  "external/deqp-deps/glslang": {
+    "dateTime": 1616029315,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "49c205b0d66f349132c5d726abbc00efcf442650",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0m4pvypx9l7d16pslkf8imqm3k21jap1vcb05pm6213rwrgl11im",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
+  },
+  "external/desugar": {
+    "dateTime": 1613531669,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e07e3b0caced3e6a3dd623bd35b8b56a383c122",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l24kgg5lm93aawfknf9igbhcag5jlacs0v1h0b2cwk7ffq6igyv",
+    "url": "https://android.googlesource.com/platform/external/desugar"
+  },
+  "external/dexmaker": {
+    "dateTime": 1613865751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1d146f4b5e61aa2e3761196ff7ee1103ec256d8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c47k9acimibwfm46zkhnwxr9ijjhz300w14dwzkirwk6hacsmy4",
+    "url": "https://android.googlesource.com/platform/external/dexmaker"
+  },
+  "external/dlmalloc": {
+    "dateTime": 1588216455,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "33d723aae623ebf8d609d81c59ef4de2458061b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yz7c4y6jppq2gxgc7bnrhis4na6r96w3i9y7rqb32hyh971ym8h",
+    "url": "https://android.googlesource.com/platform/external/dlmalloc"
+  },
+  "external/dng_sdk": {
+    "dateTime": 1613865751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e240e974de2afac6256ccb35907c3797361ca83d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n0kz9ffs327mwd06qj7msmfwrhyiabcvapxsr172az0skr9980p",
+    "url": "https://android.googlesource.com/platform/external/dng_sdk"
+  },
+  "external/dnsmasq": {
+    "dateTime": 1614909737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "23b3f139eee808cf77da6568b3c2635b21184958",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06lwhhpprrsv7bz2jysf1wjx50zmck3q7wpmnci28lc2r2b39xv1",
+    "url": "https://android.googlesource.com/platform/external/dnsmasq"
+  },
+  "external/doclava": {
+    "dateTime": 1620867748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b6ae37102c1e9c9552e10c5c9102e32ec5ddc5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1aa1aycv47aavy6j29wkivspdg6fxhrpzkb9fd7mpv7im2z134zi",
+    "url": "https://android.googlesource.com/platform/external/doclava"
+  },
+  "external/dokka": {
+    "dateTime": 1620954140,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "867d587a94eff9955b017f4c792bab9c6b38ada4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n9lbm134yr4gd9lddlc6kykh0f18q4s3jvp3y09xy6r8hbilxx8",
+    "url": "https://android.googlesource.com/platform/external/dokka"
+  },
+  "external/downloader": {
+    "dateTime": 1614650525,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad93fd0771c24fd0bd5769abefb6e3e18dbe6147",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1prbsya7mwnk2f6z7zmg4a62873kk5yfhjrki7dwb8rzwzq9mm5n",
+    "url": "https://android.googlesource.com/platform/external/downloader"
+  },
+  "external/drm_hwcomposer": {
+    "dateTime": 1613865753,
+    "groups": [
+      "drm_hwcomposer",
+      "pdk-fs"
+    ],
+    "rev": "22a6588928b46245afa1f936121e3671e89c202e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ign732qcsnima7bv7pr63v7c58pr17pw6yrb4y9wip26jq5g54c",
+    "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
+  },
+  "external/drrickorang": {
+    "dateTime": 1613865754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "906fb6fbc6321f29423b5ae6b530f27949c0cfd1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c705icrhgcdkxlbz125yn61hglzbnyvmwj6prafs74l3jb9h2sf",
+    "url": "https://android.googlesource.com/platform/external/drrickorang"
+  },
+  "external/dtc": {
+    "dateTime": 1613865754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ba8f657dc77ee1db01ef9a66cc6c90642d73e96",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x6qsq1d8ay15is649cy900b6n4syl37m8705fk1x5972gm3s833",
+    "url": "https://android.googlesource.com/platform/external/dtc"
+  },
+  "external/dynamic_depth": {
+    "dateTime": 1617238920,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8bb4c9204631d59abf09c2cb0297609fa0dc3ea7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11mw0dwirrrirgrap33k8dvngpilf6qdzwsz0phzbpr05900915j",
+    "url": "https://android.googlesource.com/platform/external/dynamic_depth"
+  },
+  "external/e2fsprogs": {
+    "dateTime": 1613865756,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5988beba338dacd4a92e64bb8f774704854ac31d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00y5a8kkqiqwg8q3mgns7vph072s3jiv7ih6b43qbgha622d9xq5",
+    "url": "https://android.googlesource.com/platform/external/e2fsprogs"
+  },
+  "external/easymock": {
+    "dateTime": 1613952131,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15c2b7c1e66e65ebc64e6ccc8693a06ba59197f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13x8mwwilrqva7wknhcab80lhmh0j55mgdiha3w5v1crlk7nbgrz",
+    "url": "https://android.googlesource.com/platform/external/easymock"
+  },
+  "external/eigen": {
+    "dateTime": 1617238921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cfa670af4576cb1fabcfa6d1b3c02370ef0c73f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mja982a49hx7mzplq5vb3igzkyv659032hfha4qhg83qc5svpm3",
+    "url": "https://android.googlesource.com/platform/external/eigen"
+  },
+  "external/elfutils": {
+    "dateTime": 1613865757,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c6c143d459cd98a85613c83f147ae6231a33746",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1znxr9qbz5mgdl35g263c0n2k33siq2qhgdx0kilf566l9c7cjpp",
+    "url": "https://android.googlesource.com/platform/external/elfutils"
+  },
+  "external/emma": {
+    "dateTime": 1613613729,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e7a6993af4783eaef7967cc4cb8d2f7a8b3cff0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q783p5xwhrw2hgq2lihxdz80n7gyw6pri9l8ryrzgdklxqgpdhy",
+    "url": "https://android.googlesource.com/platform/external/emma"
+  },
+  "external/erofs-utils": {
+    "dateTime": 1620867754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "987e0a71e3d34dc1cf039b653d944d4e50194b3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jj89j02d66jzcf53yjvrv7rgbwcmfpbi8839ygab0m5zxjdlshv",
+    "url": "https://android.googlesource.com/platform/external/erofs-utils"
+  },
+  "external/error_prone": {
+    "dateTime": 1613865759,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cafb3e531b60de38c289bd90ca5e89ff1a165788",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x5ikif1igni9sh9fcl9ma0k670a8gykvjv8bxl745mhzfnyfwqb",
+    "url": "https://android.googlesource.com/platform/external/error_prone"
+  },
+  "external/escapevelocity": {
+    "dateTime": 1613952133,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dbfd72589ca11c457407bd03a138d5941303296e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12g3s6l40sncayrl9hvwkixb0diq5gkdf0i3j3llz8yi5i9bh1pp",
+    "url": "https://android.googlesource.com/platform/external/escapevelocity"
+  },
+  "external/ethtool": {
+    "dateTime": 1613613731,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "169cfe55e0fb5834e429a29bf078560805fd7941",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17i4hhqfprqilra51s34l07rin3k32pzw36sb5xazmgr3g926giy",
+    "url": "https://android.googlesource.com/platform/external/ethtool"
+  },
+  "external/exoplayer": {
+    "dateTime": 1621386154,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5108fd971fb2b61e3f965e269eabcdad8270ab8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hlcyd6wz1lp5jc3fylcabn1193xvl4nn72l75anizjz1sidgy6p",
+    "url": "https://android.googlesource.com/platform/external/exoplayer"
+  },
+  "external/expat": {
+    "dateTime": 1617490928,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c907a9d3bb9f3e5d8169370823afca5939831d2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p1ckravpadk36lb04ahd40f2ivc921wrd21swq7n69c16g4a920",
+    "url": "https://android.googlesource.com/platform/external/expat"
+  },
+  "external/f2fs-tools": {
+    "dateTime": 1622862159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c8dc961af511ebab91554fe4d1ed0eda6b66368",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0yizrhyjqrvp0maxfci473yzbz0m173fg2bmg41x8s8w1sl8pfsw",
+    "url": "https://android.googlesource.com/platform/external/f2fs-tools"
+  },
+  "external/fastrpc": {
+    "dateTime": 1587870615,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "23da42745b22982006a632a8eb2fc3677f4097d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mfid59pw4qkv4zdj86g8mm0gsrdqkpc8kcwx6xbq8l42k9br4jl",
+    "url": "https://android.googlesource.com/platform/external/fastrpc"
+  },
+  "external/fdlibm": {
+    "dateTime": 1614909747,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2749dc52fb406bd91c4cd98eb2fe47302e1a17a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0cxx79d3l3w7p3b1pzlmnargzw8svaqx3jpl69a816ipq274y5kg",
+    "url": "https://android.googlesource.com/platform/external/fdlibm"
+  },
+  "external/fec": {
+    "dateTime": 1625706188,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "876de003255fe24af8e8e446351f2ffa5c3012cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j0s8xhs6hgzjlybzks1brkjq7xlwlr17xkvay6lkjqb57cdsqxv",
+    "url": "https://android.googlesource.com/platform/external/fec"
+  },
+  "external/fft2d": {
+    "dateTime": 1616972529,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "38faf658988365f1d6e2dffac86d48b2648b464e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "061p07mzli7srnhzvnz726j849446yyprlgxc300f5zwjla3cz3j",
+    "url": "https://android.googlesource.com/platform/external/fft2d"
+  },
+  "external/firebase-messaging": {
+    "dateTime": 1624928546,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7571a69be8e16a4505e09f34807232683589f2a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18c68j3cfc906x8glmlmcsxrbxfqy67dlim116grjmihv491zlsi",
+    "url": "https://android.googlesource.com/platform/external/firebase-messaging"
+  },
+  "external/flac": {
+    "dateTime": 1616814166,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6bceedadf4be67c7f88737c226ae6be69d5049cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bxl0m0kxfzwjk10nbm8i2fnsvn92d7793yv8bpwzqj4k7kcrg5m",
+    "url": "https://android.googlesource.com/platform/external/flac"
+  },
+  "external/flatbuffers": {
+    "dateTime": 1613865764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "33553b82e0461f61304a3cb61e488ed656d0c659",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0aqwlh168j42532l0klgx6gsbqw7lhj92l25b8b1380j2qgz23hs",
+    "url": "https://android.googlesource.com/platform/external/flatbuffers"
+  },
+  "external/fmtlib": {
+    "dateTime": 1613865765,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5ce760990823fbbc7ba893dae53f7ef0f249b4f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16x73827rr1sfvxpd4gg4rpx30vqfdp2r2md9ynmbl6lf2qwgqfg",
+    "url": "https://android.googlesource.com/platform/external/fmtlib"
+  },
+  "external/fonttools": {
+    "dateTime": 1617418927,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4149fd5adb32d0245c263b2c22d22f6a1e183e20",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "082gbxzxji2hssl0h25yxvs0caf8cyaisjd6k09s2wcgvnvvc7n7",
+    "url": "https://android.googlesource.com/platform/external/fonttools"
+  },
+  "external/freetype": {
+    "dateTime": 1619233354,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6206c777d130ac5f3fdbdfeb3541d65b8c33095b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1higwvkpvh6wz0ryjbq31v00fqxq14q9xrr3p7ww32q2nvkych80",
+    "url": "https://android.googlesource.com/platform/external/freetype"
+  },
+  "external/fsck_msdos": {
+    "dateTime": 1620262955,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d0ced89081af08cab766570113ea7a5ae9ca008",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08js9q4kzic0i6sj67cdppga0q818277a3wivp7dpaxvz4anc40s",
+    "url": "https://android.googlesource.com/platform/external/fsck_msdos"
+  },
+  "external/fsverity-utils": {
+    "dateTime": 1613865766,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "008e0b7361a7283fc06ab3de03c3dc10ed64938b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v541yjbvlkkddynwnwakrhj77jmawm1niz1nwbr2ish612v07p5",
+    "url": "https://android.googlesource.com/platform/external/fsverity-utils"
+  },
+  "external/gemmlowp": {
+    "dateTime": 1615600934,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5968725050e181653c400759936483f4aa240a50",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dff6jrd314xnib7jhqwpfc4hyv6ycjgrmb92wwany30drmlnw9l",
+    "url": "https://android.googlesource.com/platform/external/gemmlowp"
+  },
+  "external/geojson-jackson": {
+    "dateTime": 1614737217,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ad929e196897f6f300810404e9548e2e416e4c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0qrp98sn4q997q5szpz37414hlm3yl6183r504sv14azfwm7ymyf",
+    "url": "https://android.googlesource.com/platform/external/geojson-jackson"
+  },
+  "external/geonames": {
+    "dateTime": 1605485112,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0f9e6f3aae7557f03f616d344af03d2a4a6ac5f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xcdyb82cs40am7x477cavyczh1ijm5zx785fw2in1wkqah4zp0a",
+    "url": "https://android.googlesource.com/platform/external/geonames"
+  },
+  "external/gflags": {
+    "dateTime": 1613865769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1840850261af7b43690a0d9d066f668fbb5610d8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wyiic485x863sdm6834dsl3b4c40fqpagz529v091kribmmm8gz",
+    "url": "https://android.googlesource.com/platform/external/gflags"
+  },
+  "external/giflib": {
+    "dateTime": 1613613740,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "0ef45551314e010b8b9b61ace3264d7869410ee8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sibmcf4ld5cda63fyklr7bd0naydy5c39rszg0fp7iiivx3n8il",
+    "url": "https://android.googlesource.com/platform/external/giflib"
+  },
+  "external/glide": {
+    "dateTime": 1613531687,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f12b0ca0a8af997eda1d87a109c0ba3235c6afe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b38i7kvsivigic627hxi04k9sf5iq6ry176drcx9mr6wkbysbvf",
+    "url": "https://android.googlesource.com/platform/external/glide"
+  },
+  "external/golang-protobuf": {
+    "dateTime": 1613952145,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd28dd0143d2d4d5d3dc9e60eea44eeaa6a69921",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1za35lgd4h3vfqhv0a9kjbi0arrq9k0phpks113mddzlfg7dxnbw",
+    "url": "https://android.googlesource.com/platform/external/golang-protobuf"
+  },
+  "external/google-benchmark": {
+    "dateTime": 1613865771,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bcd065ffce23d9d95cd052ad0360b7c35f01f2de",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jnb9fbib4gp3w9smw5s1nvz2snbz414yxxa1xb58p5wjp7fqx4w",
+    "url": "https://android.googlesource.com/platform/external/google-benchmark"
+  },
+  "external/google-breakpad": {
+    "dateTime": 1614823351,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "98ebfb01b3f24aaaf46bec12b477e6140172146e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13l54qb6a8ba4g80h59mk1xxbdiqa0219h4p78rxzx1j75cx7m6h",
+    "url": "https://android.googlesource.com/platform/external/google-breakpad"
+  },
+  "external/google-fonts/arbutus-slab": {
+    "dateTime": 1613865772,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "400a10810ee7a4d85e6cfb3c4e0c5cb47364c765",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18g7n073qp1ii4gx11n6fpsv8si0ima4ldrx7mraca9mdq72w71m",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
+  },
+  "external/google-fonts/arvo": {
+    "dateTime": 1613865775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0e1b7162a0421344ac302be6d4d4716c792e723",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "144j3kjdp9gm5qi9x0j571m88vnqs1lwm8672qh9l3m7lxxsy0jl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
+  },
+  "external/google-fonts/barlow": {
+    "dateTime": 1613865773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf90e61d44d6ae1e9a15dfd095c1d22aaa278883",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "029n04xijjbwwxmz8lbihwcl9a30bgy9czdzg82ybwylnwq9pfwm",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/barlow"
+  },
+  "external/google-fonts/big-shoulders-text": {
+    "dateTime": 1613865775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4770a025f9e237415e7cf644408f04f5f24f66d4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jpm0ld79d3g66iwiwmx4dn2gxdlrgwsblynf4zwcgcq7ydi4zb0",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/big-shoulders-text"
+  },
+  "external/google-fonts/carrois-gothic-sc": {
+    "dateTime": 1613613744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "651324087da765265a1725f7db8a101b3e510d71",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "067xqhgd67ngvkr7frxdy1y774pfpzzkih3jjk7fj24wqnkc6d5j",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
+  },
+  "external/google-fonts/coming-soon": {
+    "dateTime": 1613613744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08ae452bfd38b5fe1abdb3bbf40b245d36025a9f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wz6aji68kbhg58dbwn0zmjg2ywk6cfdq7j7awg38zl2q26nfmq9",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
+  },
+  "external/google-fonts/cutive-mono": {
+    "dateTime": 1617238942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6afd0eaba57c9bcd4406eff0239e57445f740a2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00wfjacl0sqncivpa3za9jmki9wva9q0vf85ads6g2rz4z6nkrff",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
+  },
+  "external/google-fonts/dancing-script": {
+    "dateTime": 1617238942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7bcb591594be94f63c64793e34f2f8c442edece2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hdp4a0gn23n88gzdi65dfqq3pmvw3nadf1p8xnqxan34yv8adyl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
+  },
+  "external/google-fonts/fraunces": {
+    "dateTime": 1613865774,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ca2d9b9af2a6dd180819aedee2bf2f7719a5aca",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gr0x87wrs8qh2ykpggcvxkxc1qmd6hw0xq6hn6p6s8078pw5b6w",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/fraunces"
+  },
+  "external/google-fonts/karla": {
+    "dateTime": 1613865773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7d0287c298c748c6e1e13cf9bbcf53cb5af2a27",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0c8ny537pvhjfh0b87lfpc0aga4x0mlry203wkacgx2a1h00irhx",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/karla"
+  },
+  "external/google-fonts/lato": {
+    "dateTime": 1613865778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d0bcb872d901936838eebe41d6a17365fd34988",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hdy27r466jd7ik69257hiazjqsdzv0hbpzkmid6rq1gk2lkijgz",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
+  },
+  "external/google-fonts/lustria": {
+    "dateTime": 1613865774,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "55b0519b474c192237adf2cf4f1b58012948167f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16i0vknh3z23mr79iilxyf6kqs5kqp198by9cx9rmzcg3phgx03y",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lustria"
+  },
+  "external/google-fonts/rubik": {
+    "dateTime": 1613865779,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc0aea0e7fe2819db05954941fc2cc14271a8264",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10ap1n0s7qs742m3xzxrs91xyirp0280xvg4wz8hmpyip631h7f3",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
+  },
+  "external/google-fonts/source-sans-pro": {
+    "dateTime": 1613865778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cfa6ff648fc88297ecd82566d9eacd2c607c4e03",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nmdmb80pf2pzcdn369q5skspmlqv56sn9in0fcfhx14pib64w86",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
+  },
+  "external/google-fonts/zilla-slab": {
+    "dateTime": 1613865779,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "546f18108612cc983c11ee141bc6e5add7dd122e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rm6wp6849wpw32ys5wbrx9836937j1zx310fdyyl07kqgx4vhmh",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
+  },
+  "external/google-fruit": {
+    "dateTime": 1619838169,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf3b6fe7df7be32b39cfeda01d6b23a71e3a01c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wksa168xyk42yijf2idhpvzp8225ww165px3lc9ff9ph883g0ya",
+    "url": "https://android.googlesource.com/platform/external/google-fruit"
+  },
+  "external/google-java-format": {
+    "dateTime": 1613865780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1243a95f407a891737baba7dc7641ac519de1c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0g1i78c3km8lly0rb3b6axma754vxl9s9s48jfa0n2l565h2zk0q",
+    "url": "https://android.googlesource.com/platform/external/google-java-format"
+  },
+  "external/google-styleguide": {
+    "dateTime": 1588129597,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c81a6de0c0a40aaa8255b3a554ed38c97666a130",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1krqv8srgkf85hrj0shwz9j4xs6nx4jbj8fzjsbwjg1f589dd8iy",
+    "url": "https://android.googlesource.com/platform/external/google-styleguide"
+  },
+  "external/googletest": {
+    "dateTime": 1625706267,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab43ef5fcf256a14ac4eec833e8f42768ae3769b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hs29iy2v24vl66qqa85sdzvxlw7awjravhy53gjv9vnq2dzpb84",
+    "url": "https://android.googlesource.com/platform/external/googletest"
+  },
+  "external/gptfdisk": {
+    "dateTime": 1613865782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86c875ca2725b866158018ff3d9cb8bf98271d86",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "062g4a8s71lwdh2rkqjcdklbxsb551334rd07hhipygjllwhixzy",
+    "url": "https://android.googlesource.com/platform/external/gptfdisk"
+  },
+  "external/grpc-grpc": {
+    "dateTime": 1616720569,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "246d3ff8a7081136052c1001c9b260040e4d6a9b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b8mdx9x08djdm8fss25r1dc2xbq1hb70zdm782k2rmbwp47axa8",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc"
+  },
+  "external/grpc-grpc-java": {
+    "dateTime": 1613865783,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "886c6f43491f4675309cd3152935a2edd0eda2d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hwm7wb4zg81cx784piqc316ik0dihbm19iiyn3y22ahhkd3ma4r",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
+  },
+  "external/guava": {
+    "dateTime": 1613865784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "086feb648fc8c3622e56b946aefc5db3200e1195",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hdvqppxkyafrpkv9qzs5c7kab57vi4xhqacbqbwfr7dj0plca56",
+    "url": "https://android.googlesource.com/platform/external/guava"
+  },
+  "external/guice": {
+    "dateTime": 1613865784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e357696e300ab9842e759e73073dfd51d45ed26",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0f9k7ribhyf0n7p9ff2jqk18qk1gim4vbln1bhiazdlfs3v5laws",
+    "url": "https://android.googlesource.com/platform/external/guice"
+  },
+  "external/gwp_asan": {
+    "dateTime": 1620867781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db8c17c410e15c525b21c5249281748b451deadb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k71w8a36dhr4l5r661rvnmj4bxz49is9md78hndks4jqcnzn036",
+    "url": "https://android.googlesource.com/platform/external/gwp_asan"
+  },
+  "external/hamcrest": {
+    "dateTime": 1613952159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c81548096be4d39db5e9b8d696c8026c2045555",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0i05qdmz9zd904apqxk6kdbffbydgj7k7n9yjvgrlw0m7xbynadj",
+    "url": "https://android.googlesource.com/platform/external/hamcrest"
+  },
+  "external/harfbuzz_ng": {
+    "dateTime": 1613865785,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "442fc46d10a12ae6093b5a02c02c63d52e25963e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m7a4ln2v5dxy5dkcfdxyjsvsrsd3hjbxvmhb4gyx6am6lk6lca8",
+    "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
+  },
+  "external/hyphenation-patterns": {
+    "dateTime": 1588302820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14d5e33538993a5cb2a7f266c98afa14a2194720",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "184jm20gaz36kwskqkhax7n1allfjanax6rz3vqs70rjgsdvv5i4",
+    "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
+  },
+  "external/icing": {
+    "dateTime": 1627002163,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d8001572feb595ef618690902207fa739cb1813",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "167siw8fxdjrw4dl6a4k25xilj3qv8y59ih2s9a7g5rb3sz6pfl4",
+    "url": "https://android.googlesource.com/platform/external/icing"
+  },
+  "external/icu": {
+    "dateTime": 1628910170,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2b7f99a7f9a49d10f0127b8856d6b8847db9ac0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17ncsqdp28q238a5hhpkw3z3yskf6yw34hf39cb4nfmdn858pa8s",
+    "url": "https://android.googlesource.com/platform/external/icu"
+  },
+  "external/igt-gpu-tools": {
+    "dateTime": 1617843761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ce9ef3306909bab5c8dd0a41966d14e537c7794",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c5cw7jgcfny776y5cqx7jcy8w4sqanx4b0qwrza6zqhgcc2cqhi",
+    "url": "https://android.googlesource.com/platform/external/igt-gpu-tools"
+  },
+  "external/image_io": {
+    "dateTime": 1613865789,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d4ba4946f59caa122f71739ec2c881bf077e1ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0257h57ygzpj2vknj5k8whkznrsmqd2fhzzb9gl3rys9qgljjmvx",
+    "url": "https://android.googlesource.com/platform/external/image_io"
+  },
+  "external/ims": {
+    "dateTime": 1620781377,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e5f01768c74c2ac9e49825f071116c85393ed77",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1476c1dbyhsmvak2m5ffrgjxrf8ixigx5fsi5w805kfaifignmin",
+    "url": "https://android.googlesource.com/platform/external/ims"
+  },
+  "external/iperf3": {
+    "dateTime": 1613952163,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0f8df1f1981818419e40b294560b12134787c91",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1malr0g6ha2s0qb6qrr4cly161vcj2d4xy5wbnxj43pnhg0k4gqb",
+    "url": "https://android.googlesource.com/platform/external/iperf3"
+  },
+  "external/iproute2": {
+    "dateTime": 1622682186,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ea3575d1ec907507f3bd8fb010cf52c476dd2d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1527d8lzl7px9b84fxm1742nvz6d4h0r8nwibjh0d18j62xhz1mg",
+    "url": "https://android.googlesource.com/platform/external/iproute2"
+  },
+  "external/ipsec-tools": {
+    "dateTime": 1613613757,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd87e622472e37646b988c3cc3126f688ca17b32",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qz2058mcb75x22jarlls8ki6zhh9zd422nsn9wdzq29xk4a9cg1",
+    "url": "https://android.googlesource.com/platform/external/ipsec-tools"
+  },
+  "external/iptables": {
+    "dateTime": 1622682186,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb81bdc40ee783c29cbfed2cdf8b1827bcd86d84",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d2vfhzixszwl3nwch9f996yx7kafr9rn7fni41hbzrh8nra476y",
+    "url": "https://android.googlesource.com/platform/external/iptables"
+  },
+  "external/iputils": {
+    "dateTime": 1613613757,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ad9c0ba47f99cc04b0308878683e44e303b0a36",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q24bn8swbjsaa19kc6jdk2fw93cbipi6xbdh95w07pdp3v1xazr",
+    "url": "https://android.googlesource.com/platform/external/iputils"
+  },
+  "external/iw": {
+    "dateTime": 1613531707,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "06c1876ed2f8c6a612705ea43914997e4218dce6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01k08an490nvpzjyb7f6p8l67gxpkkg9fnc44f1lcc6ygb1rymsb",
+    "url": "https://android.googlesource.com/platform/external/iw"
+  },
+  "external/jackson-annotations": {
+    "dateTime": 1616972560,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68560e0022bcabf08fe58d6bf4f928cde907e66d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0apc5cffr02drfhfxri1fqs449i6bsk62a5kb0yfk73maya5wlw2",
+    "url": "https://android.googlesource.com/platform/external/jackson-annotations"
+  },
+  "external/jackson-core": {
+    "dateTime": 1616972561,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f31867735fece1dfd03c39f55e4004da2cea543b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c1amlrk7idijwhbhr2xvs822kc8cvfcmz2vxw9y03ylbicwnq42",
+    "url": "https://android.googlesource.com/platform/external/jackson-core"
+  },
+  "external/jackson-databind": {
+    "dateTime": 1616972561,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b555ac66fe2f72e93ab08b0a42f1fa56049f29a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f4qf4dy0cyjv9cbmsvqawq0xp3r68snv5nidhj00jdnxcixh5zi",
+    "url": "https://android.googlesource.com/platform/external/jackson-databind"
+  },
+  "external/jacoco": {
+    "dateTime": 1615264597,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48173d42bae03000e9c8294afe2b78904e805f88",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v0gdd5rasmh1q8sbq2f3ckhrlra73h1n9m0j9p3j3zpgq5a4x9s",
+    "url": "https://android.googlesource.com/platform/external/jacoco"
+  },
+  "external/jarjar": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a94053cedba532384bfa2c06db3fd3dc8c7807ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vn1j4pmksskgdjak31yc2vc1l8ph4m3mw06nsm0ql7fhbmy00yg",
+    "url": "https://android.googlesource.com/platform/external/jarjar"
+  },
+  "external/javaparser": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e670b7679ed69787c683b78be8d1d53086360e1a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l5hikg3bhk5fasrbwgbiascl8jwimacmpj0if2yqmbzcr6bglzs",
+    "url": "https://android.googlesource.com/platform/external/javaparser"
+  },
+  "external/javapoet": {
+    "dateTime": 1613613761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5517d9596a5d36685f3e18339279deb56cdeb6c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kwklwk1xjnnvwblfb5hga4ks1p3jdmh9dc30c5mifksrp8fsyr6",
+    "url": "https://android.googlesource.com/platform/external/javapoet"
+  },
+  "external/javasqlite": {
+    "dateTime": 1613531710,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02848163d94d6ace8b2fb5b90507d978febc2688",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1801cchvl1nys58y41qxk9if6wamrakpvpq6c2k3fj65053kizi6",
+    "url": "https://android.googlesource.com/platform/external/javasqlite"
+  },
+  "external/javassist": {
+    "dateTime": 1616972564,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "692915bcf9f834bf9e2d8cdd5662381b13b1993e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zfcnqlgyl59pv4h0s0nnc8lhgljpq5dq4p05anay43lnrszn3ca",
+    "url": "https://android.googlesource.com/platform/external/javassist"
+  },
+  "external/jcommander": {
+    "dateTime": 1613531711,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90d74243a2bc127bc2ee8f66c53b5c9e232406ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m4a69hc9k4ixn8sah9rz9n10xgbz06swcfcsx96cjk0svpqyw4w",
+    "url": "https://android.googlesource.com/platform/external/jcommander"
+  },
+  "external/jdiff": {
+    "dateTime": 1613613763,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5cef8b829bf4103623773a0d8cac8b5da6394c5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1j5bnl4lmm2288dvbma7mxyx0x52d3jn5d9wpd6idg44ii9ra1ap",
+    "url": "https://android.googlesource.com/platform/external/jdiff"
+  },
+  "external/jemalloc_new": {
+    "dateTime": 1613865800,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f866f1c26fc33c75d5349eef0c26dd8afb533974",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xbgga8jnizv1588dh1bd2av005wfmc69xzh867269j0523djcdr",
+    "url": "https://android.googlesource.com/platform/external/jemalloc_new"
+  },
+  "external/jimfs": {
+    "dateTime": 1613531713,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8d7215608347ad9070c807372c678f0ee7edfc6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lgiryx40d8a5854yczzvm5x6fydncj06vaclq4hw07rlwh7kvn0",
+    "url": "https://android.googlesource.com/platform/external/jimfs"
+  },
+  "external/jline": {
+    "dateTime": 1620262988,
+    "groups": [
+      "pdk",
+      "pdk-fs",
+      "tradefed"
+    ],
+    "rev": "27b33bb7c0b4c788fd1ba556b69c32b9da8e6e1d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qxn0vwnbz0sh9ax9ad52wg7373f48dcpq624bgfiypjgxfniqls",
+    "url": "https://android.googlesource.com/platform/external/jline"
+  },
+  "external/jsilver": {
+    "dateTime": 1613531713,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "008874e38e4a9d036e090c503d0a1ca661e2c0c4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "198msf9yaqbjy52aj4wfshdnxy5nyf1jwn7p2l4gndn1212vkqa1",
+    "url": "https://android.googlesource.com/platform/external/jsilver"
+  },
+  "external/jsmn": {
+    "dateTime": 1613531714,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7512776fb9dfa773d43e0f70ecec5041fa1473b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0czn4n8j87svwm1kgsnjd8qzyriygcjlkwskqj2w79v1s113rlb8",
+    "url": "https://android.googlesource.com/platform/external/jsmn"
+  },
+  "external/jsoncpp": {
+    "dateTime": 1615680185,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1512d376078bd60ec9d2ffd697780b152305e89",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00985j9k2yspfp6vi5rhnb4pwbzig055l3p08mq8k1sqm3q47vqy",
+    "url": "https://android.googlesource.com/platform/external/jsoncpp"
+  },
+  "external/jsr305": {
+    "dateTime": 1613865803,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "599636b0fda3a1606b037e914c0827fea825c531",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q8sc6rb67j35r6jk55ap37b9bbrgdca0a8dyyy04ipx07ccw05y",
+    "url": "https://android.googlesource.com/platform/external/jsr305"
+  },
+  "external/jsr330": {
+    "dateTime": 1613613767,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c388a644defbf3af12c1b2bb389fcac2efb69146",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1s0jbmdd3vjaprwalf10i06n8sfmg1x356y5gz0jfimbsknva989",
+    "url": "https://android.googlesource.com/platform/external/jsr330"
+  },
+  "external/junit": {
+    "dateTime": 1615514560,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca5b8174714015cabdadd25bcb7b39541c90000a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n7rfvpi0pg1m6qjh6wza310gf01p2kv564bnkf3dfsjsczfs0nb",
+    "url": "https://android.googlesource.com/platform/external/junit"
+  },
+  "external/junit-params": {
+    "dateTime": 1614308876,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b55a541bbdfd4a14ce76a8317bb9cc27d1fe0b95",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wda5sh5jy1ww8y50nfsw508ijw185h6g0mn5nba9iv95zs44zmq",
+    "url": "https://android.googlesource.com/platform/external/junit-params"
+  },
+  "external/kernel-headers": {
+    "dateTime": 1620176595,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac5dad7400975c9e69e844f8cf03c00e9f2638e3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vj1hy930nr1pxrc0jdm9j4fhxnlcr05lcg6700ai5qqgz9i06rw",
+    "url": "https://android.googlesource.com/platform/external/kernel-headers"
+  },
+  "external/kmod": {
+    "dateTime": 1613865807,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e9f37f2f90b1cc6270cd8f5c32c8476dfa80878",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xv7xwkz8mhn41fq7jv5hq2fy9r2l4srnwkcf3xbaca2ai177g1m",
+    "url": "https://android.googlesource.com/platform/external/kmod"
+  },
+  "external/kotlinc": {
+    "dateTime": 1620954192,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7288a54124a63310a4cd5fbcfefc5ad539ff3ce4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0dzms659jz4zjm07pwissifi7v57xhmrlzkx7j63s9za6az63719",
+    "url": "https://android.googlesource.com/platform/external/kotlinc"
+  },
+  "external/kotlinx.atomicfu": {
+    "dateTime": 1620954193,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3f60d6f13df59b88a433f756c3ef52b8bc5ce2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14zbi4fc70xnspx5kn6jdqq9yf8p177qmhx2bprsflrcdb1np9r5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.atomicfu"
+  },
+  "external/kotlinx.coroutines": {
+    "dateTime": 1620954193,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dee6185f0ae9ef38a9469a06e40489410285025c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xg0g0yn8qzk23p8vvh4laavmvinbmqch5ib1ca44g6fkf7f7df1",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.coroutines"
+  },
+  "external/kotlinx.metadata": {
+    "dateTime": 1620954194,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1a2fc3683f91a555b23c9431bdff373bb6a96c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fz2mbsb51b6h5d8a1p099iccxi4ll2w4cnw3i8yikjmq5pl64k5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.metadata"
+  },
+  "external/ksoap2": {
+    "dateTime": 1613865809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccec70c351283ca2269fccf6fdd9f5354a5e6b66",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kvfan6g57xczcv075439zlqaw3rxmi5mdz7rrfjxv2qyh3sp2v2",
+    "url": "https://android.googlesource.com/platform/external/ksoap2"
+  },
+  "external/libabigail": {
+    "dateTime": 1617757377,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3368d44e2ac04b54c1700fa39a0d6fb86fd0a7d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13rn7mvpwsvahryp1c8ka6rghblpa0vjsvrji3g86map3ij0shac",
+    "url": "https://android.googlesource.com/platform/external/libabigail"
+  },
+  "external/libaom": {
+    "dateTime": 1624410189,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f9b0666573a47014abd7da28d617d1951b230d41",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01v88ya40i58w9fmwc0ak4rl9l2sc5rm9yyh7j8r388ynhy1rldb",
+    "url": "https://android.googlesource.com/platform/external/libaom"
+  },
+  "external/libavc": {
+    "dateTime": 1623200600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "421d97cc0a20b17a3006d8d16618c6760aa8bef8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00xn0j2ksbm181j6826liqjxxmpx0vxr0qs7ir7kzg3p8sc2pk8v",
+    "url": "https://android.googlesource.com/platform/external/libavc"
+  },
+  "external/libbackup": {
+    "dateTime": 1613865811,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "99a537b829d88f631c4dc04c0114f9e2d933f627",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ll3ryrbrh2xz90b6r928jck1q0ghnq8wrn5zdy4y9w6naxjy8vc",
+    "url": "https://android.googlesource.com/platform/external/libbackup"
+  },
+  "external/libbrillo": {
+    "dateTime": 1619485386,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6471017b2b496686ab4a63db1a9f11393a01c6c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p9fnd8xjv5xf7jbkp7vmqzfmj0ip219lpmp4d291wxzc1jhy1cy",
+    "url": "https://android.googlesource.com/platform/external/libbrillo"
+  },
+  "external/libcap": {
+    "dateTime": 1625706301,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "542a3a488077bd38d72f2530afdbb789a504a289",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f4jkab7ws0sjzfgfvrf6mwrrl8q3ghnm885l8nkrlghqd7s3j9c",
+    "url": "https://android.googlesource.com/platform/external/libcap"
+  },
+  "external/libcap-ng": {
+    "dateTime": 1613531722,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf347628227c3ff47c4d75dc8fcaad51919c1719",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dsr6r0s5m2aqm2wz9zq023abgvjxdrajjnsfrs8ssi30zxzrxyq",
+    "url": "https://android.googlesource.com/platform/external/libcap-ng"
+  },
+  "external/libchrome": {
+    "dateTime": 1625706303,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dbc75e6548ac9e0e0fd04d8ba158bf76345f3b3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mi55n6sb3wzc67a279cnabhx179s8dh4bh0j72ngwbaj9sln1fr",
+    "url": "https://android.googlesource.com/platform/external/libchrome"
+  },
+  "external/libchromeos-rs": {
+    "dateTime": 1613613775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b729a223aa9fe776946652e59b69aa8e71f21597",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lkwghnsaniv3v9lbc1r011ff4dk9d0ja9xzxxk4b58xds6zjpil",
+    "url": "https://android.googlesource.com/platform/external/libchromeos-rs"
+  },
+  "external/libcppbor": {
+    "dateTime": 1625101425,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5ccc0bccd2c05ee0cd7321052e4032d675bfe89",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "009j2acfkk6207s40y37xcp3aj9jd1m72162xpaqf0r62y4lby4y",
+    "url": "https://android.googlesource.com/platform/external/libcppbor"
+  },
+  "external/libcups": {
+    "dateTime": 1613865814,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9af8a68aaa0db5b379800c5c590f73eb7a199645",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1986mbxc28sxi377ydjj8b7mdhwwvsb1df4n3da1cf0m9rrh90vg",
+    "url": "https://android.googlesource.com/platform/external/libcups"
+  },
+  "external/libcxx": {
+    "dateTime": 1625706304,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9587cbb7baa37530e35071403bca6425918701e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qvz2zyl6j8pnwbjv1rb7kqvjgq13nmbym2zabb64nch2h0vfs4w",
+    "url": "https://android.googlesource.com/platform/external/libcxx"
+  },
+  "external/libcxxabi": {
+    "dateTime": 1617757383,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6eafc4bcf0069e9a6340db38fb019fec60bbbed",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11zz64d974bs5gm1b4vin5bjvq9a13h9gzjhk68lm4ksi1yaga96",
+    "url": "https://android.googlesource.com/platform/external/libcxxabi"
+  },
+  "external/libdivsufsort": {
+    "dateTime": 1613613778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "187131d38ffbd9e21f7b56cd9854e8af46dc7801",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lh8s06r0fvkjsrdb0ns3iv0n97sibvbv3jy97c9s0zp29mfi3wg",
+    "url": "https://android.googlesource.com/platform/external/libdivsufsort"
+  },
+  "external/libdrm": {
+    "dateTime": 1624496594,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dcd4969a30d01986b0cc43f0f94655bf09cb69c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v85xcr4k6vmdplnq3apm20yvd3jzwsv1rh570prrj15ba552alm",
+    "url": "https://android.googlesource.com/platform/external/libdrm"
+  },
+  "external/libepoxy": {
+    "dateTime": 1613865817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4cb3921cb46561be80423cf7d411f070e9367b5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wdjlwf9cvy1wz3xymrxmjxlqj1w7zxd2vxy0g90bnpslwcngc7l",
+    "url": "https://android.googlesource.com/platform/external/libepoxy"
+  },
+  "external/libese": {
+    "dateTime": 1613613778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9295b8485e705986caf392b4e2394a2023acbaf7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0g10bprh155ys18zvsxs0annjzh39cnyxfldy9zbxcpcj5dlvirl",
+    "url": "https://android.googlesource.com/platform/external/libese"
+  },
+  "external/libevent": {
+    "dateTime": 1625706309,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "182c4203098e2882d1d3da336e646a4595aeceb1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03gjyf91xycyd2g8nfkvvjg1kibvdm1dlzxn9x50sbhbig43i9gx",
+    "url": "https://android.googlesource.com/platform/external/libevent"
+  },
+  "external/libexif": {
+    "dateTime": 1613865819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3428fca826a5603df5291b3e64e80f8a045832e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ppfmlnbh8vmhicdnvs4vfmsfg608pvmq60g8yylbr44c2bg208a",
+    "url": "https://android.googlesource.com/platform/external/libexif"
+  },
+  "external/libffi": {
+    "dateTime": 1613865819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "18df2dfff127c5120c2bd2921ae1da4fa9f9a88c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kfagm0922z80061324a4w74231aic3p9wsw6qi67nasf7f1fbjs",
+    "url": "https://android.googlesource.com/platform/external/libffi"
+  },
+  "external/libfuse": {
+    "dateTime": 1620954205,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90b74b733e359752a91da1419de5f8c86df3bafc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10c514vzj2mihk97d69zxzdqgxc65fyqkllyx5glfsqhsr156lwy",
+    "url": "https://android.googlesource.com/platform/external/libfuse"
+  },
+  "external/libgav1": {
+    "dateTime": 1619140084,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f9e98f6f2b758c17866ffaa30acf16572e293eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0w3rkagg3c83rf8j0i6409jxx0wya7yxyx5xx3kgq89axymlb7gx",
+    "url": "https://android.googlesource.com/platform/external/libgav1"
+  },
+  "external/libgsm": {
+    "dateTime": 1613865820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a587005426bfc0f54b303535aa95c07c3c3a1af",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13np111m5nqvzza0mllnvmm0frvazy1nmlhp6lfn31d00vdrn936",
+    "url": "https://android.googlesource.com/platform/external/libgsm"
+  },
+  "external/libhevc": {
+    "dateTime": 1625187829,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb5fd1f25c2f3d9fc30c72e29500320645b311c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pwsmr437jags5xyxpsdiqg4axjp3n9i5fpcfcp1d2mha3win6ry",
+    "url": "https://android.googlesource.com/platform/external/libhevc"
+  },
+  "external/libiio": {
+    "dateTime": 1613613782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "feb4b6531ec41dc3fba6c0b37de3b662f8f18ffe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "049lcsyzmzympsk6s3rphcmql3y4rs2c1fsh6bfjpg4sdqjcf5w6",
+    "url": "https://android.googlesource.com/platform/external/libiio"
+  },
+  "external/libjpeg-turbo": {
+    "dateTime": 1620443015,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "466e6303546136a4cb67933b98f281d54e8fe8c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "003d689i5zbmfv9xqqi3bfc1fb0q9xl37x8k0lb5lv4pxr27i432",
+    "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
+  },
+  "external/libkmsxx": {
+    "dateTime": 1613865822,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de32a4f753ce53e4ad812ea42cfeba9cfb83ebc7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f3vr8khghmcw1pr9kn71ql7s1a0vwnclmqgm2dl27cbkfzf4qmx",
+    "url": "https://android.googlesource.com/platform/external/libkmsxx"
+  },
+  "external/libldac": {
+    "dateTime": 1613865823,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b1df73cbb91c926c5c516a256a9eb7401650cbe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wsy4g8bllsnhdca0s4kh7g986qixrqc3x4pn0jlwg8hnzdc26bg",
+    "url": "https://android.googlesource.com/platform/external/libldac"
+  },
+  "external/libmpeg2": {
+    "dateTime": 1615075443,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "853a5819f152178fc4d3f1961967ec978dcf2f3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04qb3lvjnizsyzs59zdxw1i9ng1dibnn3a15szzw8dmfrdwdfjv9",
+    "url": "https://android.googlesource.com/platform/external/libmpeg2"
+  },
+  "external/libnetfilter_conntrack": {
+    "dateTime": 1613531732,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e7ab20ab68275ae50dabf956e1276b40b7a60f0e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v6lpqqw7h19l9jzs43apw4kws39av9bhikarzlvym5xs3b6jhm6",
+    "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
+  },
+  "external/libnfnetlink": {
+    "dateTime": 1613531732,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24b2fa5c599c62c1c911d64c79d4fef190a5bece",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c6w4mi3xc6gxly949fh30ni84yk5w0bwqmipv857hpbq4cl3p9n",
+    "url": "https://android.googlesource.com/platform/external/libnfnetlink"
+  },
+  "external/libnl": {
+    "dateTime": 1613865825,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b17b0c347e3cdba8053458d071b536911fa90d7d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f54wdvb46iwmm725yx2hj6nmfh6g3sfiar27m6qd2i01ah8fb8i",
+    "url": "https://android.googlesource.com/platform/external/libnl"
+  },
+  "external/libogg": {
+    "dateTime": 1613613785,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a438300198558e87b6c5735eef71c553ebd9b3b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rdync9bnrw7gxwn69nkk1y8vn42il7145jlq9ry247qskd06hg9",
+    "url": "https://android.googlesource.com/platform/external/libogg"
+  },
+  "external/libopus": {
+    "dateTime": 1620443019,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f072ebff9afd0780f119e919129ebbe4687010ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v4d1qwd88j8p0fb9ykgq2npih0qpdprw21wdcy6dd64lsciaigh",
+    "url": "https://android.googlesource.com/platform/external/libopus"
+  },
+  "external/libpcap": {
+    "dateTime": 1615075446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "801737cd91ed0b1ec608cc2473b32790a0dea269",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16pjxifk3vmzkb66ga85ngcwmx555nzbms57fwm66k19v526m1m7",
+    "url": "https://android.googlesource.com/platform/external/libpcap"
+  },
+  "external/libphonenumber": {
+    "dateTime": 1613865827,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a21285fe04cb1cc30b8d0eca882c6b37bb00974",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rn08wi8q4b6bb00rcchiv4zida0i7dz9vryfkadb15k4mqh79d4",
+    "url": "https://android.googlesource.com/platform/external/libphonenumber"
+  },
+  "external/libpng": {
+    "dateTime": 1616547793,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c203c72e8b9dcf4b180b68a0aaf6a8c9eb505580",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "177jf1vizmmkp7zx4kh99jp66zaqqxkcj6zgk3n080qc91jh3xbx",
+    "url": "https://android.googlesource.com/platform/external/libpng"
+  },
+  "external/libprotobuf-mutator": {
+    "dateTime": 1613865828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d0b5cc6a493978d2b375c6452ac25d29139a9646",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0qd6v41shmz918cv8h2jbgh3pvg65mk7c9m03afzz8gy26zl6rai",
+    "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
+  },
+  "external/libsrtp2": {
+    "dateTime": 1613865828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1414cdec70d3ed155f0dc2d88a7a3e2fdf2e033",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mr1gb60ryh71makvab277w1lrwlk7bv6alhh369jikm5sj78dyw",
+    "url": "https://android.googlesource.com/platform/external/libsrtp2"
+  },
+  "external/libtextclassifier": {
+    "dateTime": 1627095817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a6e1159cfbbd1ca336268d64841087af2770308",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0grqsvf1zk2658a346pbrfv4mcc65j49pq4061wqfhsxad0gipb2",
+    "url": "https://android.googlesource.com/platform/external/libtextclassifier"
+  },
+  "external/libusb": {
+    "dateTime": 1613865830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b00e4289b2bcf6427fe8475330c425a630b18c73",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v007hjbbbs07mq2y84511mv31b8h8hhac7hp2lqmrwp8f2jldxx",
+    "url": "https://android.googlesource.com/platform/external/libusb"
+  },
+  "external/libutf": {
+    "dateTime": 1624496607,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2cd7e15323eb6b43c663a24d94758c0dc7f99f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d0d5ljsb4amc6a8xwkx1hmzy712gww5vsh4fq0926nnl195vp8s",
+    "url": "https://android.googlesource.com/platform/external/libutf"
+  },
+  "external/libvpx": {
+    "dateTime": 1626224610,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c59734da17e9ca196ba49ee16256f38b2729d869",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y883jrkywpy64xay77kxh1j2ijc77lmggyby8860y608a1227f4",
+    "url": "https://android.googlesource.com/platform/external/libvpx"
+  },
+  "external/libwebm": {
+    "dateTime": 1613865832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3dfb746e015d2e70f1a1379a97bf6ec2e5f57bc5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kkb0mm6vqbv1ri6br6d4xisvbgx947r8d9vynbbw9bl03g2fbpp",
+    "url": "https://android.googlesource.com/platform/external/libwebm"
+  },
+  "external/libwebsockets": {
+    "dateTime": 1618628619,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0bb9bf0e01569e9320720a639faf5b905d11d0a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14l852ww7vwc5vpi0b5vdqall31afz743qyqs67kdy1xdzz906mq",
+    "url": "https://android.googlesource.com/platform/external/libwebsockets"
+  },
+  "external/libxaac": {
+    "dateTime": 1615075453,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b10bfdf5b91bd954f030bc86a52d19afdd22ca5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k85nq28kwa9jhma9xypm9i3p1317njryhcsvmiqk0w3cn5xxlr5",
+    "url": "https://android.googlesource.com/platform/external/libxaac"
+  },
+  "external/libxkbcommon": {
+    "dateTime": 1613865833,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f90e159190e5fbbba6e9c015871089fc75ed437a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ffqp52cwhvb7kkkvr993sj0z63jk7cx0jkv4fb3apjczp8rlnlx",
+    "url": "https://android.googlesource.com/platform/external/libxkbcommon"
+  },
+  "external/libxml2": {
+    "dateTime": 1620954220,
+    "groups": [
+      "libxml2",
+      "pdk"
+    ],
+    "rev": "fe6f8e8bdbfd5b7a087674453fa6b6f1726b6bfc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kni8714vrwwrrbh3pg3fa5q7fillik22qzsrgy2i2d8y1jsbgp5",
+    "url": "https://android.googlesource.com/platform/external/libxml2"
+  },
+  "external/libyuv": {
+    "dateTime": 1613865835,
+    "groups": [
+      "libyuv",
+      "pdk"
+    ],
+    "rev": "4bc22eec5d2578e6530dd551bb0f4c50f53e28dc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wqd724hbmyk1nqyz2ixk14dq074897raqnb72h8zfbshkxrdvp4",
+    "url": "https://android.googlesource.com/platform/external/libyuv"
+  },
+  "external/linux-kselftest": {
+    "dateTime": 1619838220,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "b71fd7295adce19ba98c416df2727b862cf5bf02",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wfr5vcjbswirbk0dla14bkz7q34imxd7l7r311c82vqf4wdk04b",
+    "url": "https://android.googlesource.com/platform/external/linux-kselftest"
+  },
+  "external/llvm": {
+    "dateTime": 1613865835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5518f499df2b9e92ebd74d346ca7ace8229faebb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vsbyazjkpdd4gpmr9cbj94bl4f3ddhqx56rz9apyd50bzbi8dnb",
+    "url": "https://android.googlesource.com/platform/external/llvm"
+  },
+  "external/llvm-project": {
+    "dateTime": 1607536677,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb61c0e16326b3f7c54d252374d509320fdaafc9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ikzmd238agp9ldng39y1yn4yj2nqah251h5nrsp3b97qvd05wk5",
+    "url": "https://android.googlesource.com/toolchain/llvm-project"
+  },
+  "external/lmfit": {
+    "dateTime": 1613531742,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6721895c1cae086196aac29bded5b41697653a7a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11nb4xcnbnqgq0b15hqdyppixhyri8kwymbvaznfi1y370jw66bp",
+    "url": "https://android.googlesource.com/platform/external/lmfit"
+  },
+  "external/lottie": {
+    "dateTime": 1623891822,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ea47fcf4d77b1d814a799201648c44ce546ff33",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xbfmzrpj7j32s4m7ygvhbx4x4s3gdvzqn07jkh2bmi7r3kws8nz",
+    "url": "https://android.googlesource.com/platform/external/lottie"
+  },
+  "external/ltp": {
+    "dateTime": 1628910218,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "691b746630a882e9c3e4d0d673d98882198a1bb6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mqyz806pbqm0m40p3lnxjnbnkh7y4rasymk1n8c2a48dm6crxdf",
+    "url": "https://android.googlesource.com/platform/external/ltp"
+  },
+  "external/lua": {
+    "dateTime": 1620867829,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3cc1756a755c7876e6c10d72a977dd92075bc03",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pr4np5di8pj7r1yaab4nrvh4bb5fkakr4ddlv2f9h0jhx32y2yq",
+    "url": "https://android.googlesource.com/platform/external/lua"
+  },
+  "external/lz4": {
+    "dateTime": 1613865837,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc6391501729cfe3cbf8574fda864cdf0d85a06b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z9qlmhzzd6zssc897sy2yz2iqpq812qfpyszxv5nsmj9ml48swq",
+    "url": "https://android.googlesource.com/platform/external/lz4"
+  },
+  "external/lzma": {
+    "dateTime": 1625706340,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "035e2872824f4d180ba422953a6582aa1b58298b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08wi3bisnknkz26iw3r3lna9zxwnmbql6iz550793nbq8bnkvci3",
+    "url": "https://android.googlesource.com/platform/external/lzma"
+  },
+  "external/marisa-trie": {
+    "dateTime": 1613865841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c3f00b5babb42de2e68181a837c1781bf616d071",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "131spy2m80s752028pqqkhylnd2y8ibz1bajdssxjhw6ybhfh4yc",
+    "url": "https://android.googlesource.com/platform/external/marisa-trie"
+  },
+  "external/markdown": {
+    "dateTime": 1588215782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "682db3aa790c39cb65c44c05ee591428307f3db5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1g8ziq2pf7gnyqcv6cbpigs7vaghd269lxzqvq3gkmqq5nvvp51k",
+    "url": "https://android.googlesource.com/platform/external/markdown"
+  },
+  "external/mdnsresponder": {
+    "dateTime": 1613865841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a0098e06941ef40c4e59546960b51f1e47d34b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11fw71ghxij6q9zrn3bp7plz05yrw0a8w9yjkdcfjiicf4may28f",
+    "url": "https://android.googlesource.com/platform/external/mdnsresponder"
+  },
+  "external/mesa3d": {
+    "dateTime": 1619305419,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f8b72ace3903cbce6bcce9900f9853100e7e38b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gj14c9wnhqpfpf3wkvfpf967rcsf151clamr6d1prf36m917a43",
+    "url": "https://android.googlesource.com/platform/external/mesa3d"
+  },
+  "external/mime-support": {
+    "dateTime": 1613531746,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7efba835fc35400db540e06087f5e601eed59658",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lkwshpnbp0hgz4azb63c83xdk8hrqywcbh501frjc8d5zgxvm6s",
+    "url": "https://android.googlesource.com/platform/external/mime-support"
+  },
+  "external/minigbm": {
+    "dateTime": 1623805446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "99de13282f3f4e38cba1fae9f4f08cb75d3bb2de",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lbk54q5w1qad1qjyjn2rzkvn6ab85ibx7ixqxhkha3lm2i33k5q",
+    "url": "https://android.googlesource.com/platform/external/minigbm"
+  },
+  "external/minijail": {
+    "dateTime": 1620954229,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "794a2755c24fed4636dca3f43998862888fc3c74",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18341lkx5k0svyj3z60cdv153h8aq0fvc00dssxm3rssim4ax3gl",
+    "url": "https://android.googlesource.com/platform/external/minijail"
+  },
+  "external/mksh": {
+    "dateTime": 1613865844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "13f29da36ed41956cdeb446d4f555f605dcb57e7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d8xqv9r3qa7vvwqs6ifpl77j5whvn67dk0b4xgfbsqf2rryrk71",
+    "url": "https://android.googlesource.com/platform/external/mksh"
+  },
+  "external/mockftpserver": {
+    "dateTime": 1613531748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80916c8ba1399a2dad4db55a246df8b0e2f5c86c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rm29k2285ibqklbgijdmi4mp694pzg7pgj8n9zl9a1ar1cjv5nf",
+    "url": "https://android.googlesource.com/platform/external/mockftpserver"
+  },
+  "external/mockito": {
+    "dateTime": 1613865845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1f77d6fdb8b4fd7324e794950533175b2f35737d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fvgaw450rhb5cmq2blh2y4zi86x23jjngrskprz9k4is3yw8zn9",
+    "url": "https://android.googlesource.com/platform/external/mockito"
+  },
+  "external/mockwebserver": {
+    "dateTime": 1613531748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ef04f023fa20d972fdd773188eae69139739fa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yxf1fgfkb7kgzz5pqac8171952gfviv2043njxnxbaysmy5sn1n",
+    "url": "https://android.googlesource.com/platform/external/mockwebserver"
+  },
+  "external/modp_b64": {
+    "dateTime": 1625706349,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da509f63f62f5560acb01ba01604a75f12ae68e6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l11d9qw0qlh6ab2ybwciscspqscdydj23q5998va4qxpapdcrjg",
+    "url": "https://android.googlesource.com/platform/external/modp_b64"
+  },
+  "external/mp4parser": {
+    "dateTime": 1613531749,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "160decccebcea0112592122f760d564675c618df",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "167wv822ssx9n3z0bnbk72p532wy7ck7a0ayi0rrppz5whilg262",
+    "url": "https://android.googlesource.com/platform/external/mp4parser"
+  },
+  "external/ms-tpm-20-ref": {
+    "dateTime": 1613865847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09fb9f32256876b2778eb62166d2676b8af71b83",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j5gdirvbvqr3kw0d212s35awisanlmc1avyfk2ky7rqa82yqp85",
+    "url": "https://android.googlesource.com/platform/external/ms-tpm-20-ref"
+  },
+  "external/mtools": {
+    "dateTime": 1619140113,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6346ea76038054042369c424be7f0d0d35b1b5f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0i0dbrkfj889qx63dz0iwvs6klablp5ydyria9s4j21bp3zmgzp4",
+    "url": "https://android.googlesource.com/platform/external/mtools"
+  },
+  "external/mtpd": {
+    "dateTime": 1622682239,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aae5f3d29cbcd6223c8a9767b7f457dbdc41d941",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kgmcl1ll4mpzfwnl95y2qhv7d825s4i3rkd36wgvg5h6jkf9zjv",
+    "url": "https://android.googlesource.com/platform/external/mtpd"
+  },
+  "external/nanohttpd": {
+    "dateTime": 1613613804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "325d4da5f56814e54bb7ec2c2801f6b0109930eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gq2hhgy0rq5ws42vjkqjdawn6dns6kl8cb5h46lx8psvh7pdgz4",
+    "url": "https://android.googlesource.com/platform/external/nanohttpd"
+  },
+  "external/nanopb-c": {
+    "dateTime": 1613786619,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8204ccd833b92d511b5bae1a18c788f544e5135a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1089qzm6713npyb6q1zx1lmapjlhww36rc4b6lmzwgxv39afk5ii",
+    "url": "https://android.googlesource.com/platform/external/nanopb-c"
+  },
+  "external/naver-fonts": {
+    "dateTime": 1588216286,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1ae532518687c5988899cd226e9a36881688c1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ihcg6mpzf8lnygnn82l5z8pv6m8iyw0mzsc76wmyn9j7wdyhg9s",
+    "url": "https://android.googlesource.com/platform/external/naver-fonts"
+  },
+  "external/neon_2_sse": {
+    "dateTime": 1588302392,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bbd7acb5d9ebaaaf02a0732a954b993be923ebaa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12ivga8rnf1ibchrwczfs38n8kpjrjkyrfn9hav2w8z3xdrhz8p2",
+    "url": "https://android.googlesource.com/platform/external/neon_2_sse"
+  },
+  "external/neven": {
+    "dateTime": 1613531752,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "32a012024c7163287f7b56133cb97e28afcd11ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wl4zg5zkcgnrj9lzvm6l49awpar07hny1admj6hi06k0w2id3f9",
+    "url": "https://android.googlesource.com/platform/external/neven"
+  },
+  "external/newfs_msdos": {
+    "dateTime": 1613613807,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "412c073464eb4b167f444f1c6450e29d9b67fc50",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0shrw82gl4bsvsdyk21fwmjvdk9mjg24ylng2jbabki63xp4dmgw",
+    "url": "https://android.googlesource.com/platform/external/newfs_msdos"
+  },
+  "external/nist-pkits": {
+    "dateTime": 1613531753,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69142bc81627080560c65ee40430faaaa01e76d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xdr99aqr4g7drh4gmr88ah0q2im8aq5cs8w834qanygpg694dr1",
+    "url": "https://android.googlesource.com/platform/external/nist-pkits"
+  },
+  "external/nist-sip": {
+    "dateTime": 1613613808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d7d04bd62635eb2132a2bb37b972dff6a305974",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0k5qg8bbg2l6g3fv9x4bikpa7b0sf08lacayxgm3pnpyn2bmai43",
+    "url": "https://android.googlesource.com/platform/external/nist-sip"
+  },
+  "external/nos/host/generic": {
+    "dateTime": 1623114220,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6a9e600b07330b5834383265fab459b3f89e2a1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "038s9b8d09avaqb2z8yfcdx9941jyb09g0axq6r06gya4aaixfvp",
+    "url": "https://android.googlesource.com/platform/external/nos/host/generic"
+  },
+  "external/noto-fonts": {
+    "dateTime": 1625353485,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25c8fc984ab2554697930e23953eb703988138f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p0r230lik5kbmysq0ahwdsdj9qg8h8p8305651aw3zmn9ad23g9",
+    "url": "https://android.googlesource.com/platform/external/noto-fonts"
+  },
+  "external/oauth": {
+    "dateTime": 1613531755,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5181c0ef3adf6a77cd6fed1789cf6271437ba7de",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1iy7n0krrann5fkm46znlm1q598wzr4jlxv17d5xw4dwc5jp6p5n",
+    "url": "https://android.googlesource.com/platform/external/oauth"
+  },
+  "external/objenesis": {
+    "dateTime": 1613865853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb1bdad4e417b311e8bd30051b66b13ea673299a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0cvmp0wrf5lqag44wfjil3bdq4zkdc3dm4fr49g6qcchd7h65gmm",
+    "url": "https://android.googlesource.com/platform/external/objenesis"
+  },
+  "external/oboe": {
+    "dateTime": 1627002228,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "443e53b2ed7169154d4e81b583e8660b3bb32f2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z95091yv1akx277a4fsy0hxdlav1b7kn969b6cn5z6cnzm66fyl",
+    "url": "https://android.googlesource.com/platform/external/oboe"
+  },
+  "external/oj-libjdwp": {
+    "dateTime": 1614909840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2082c38860b87afa634f0c58e6d8a534255acb30",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l4l046zxwqw991qadiawlwsrbv2chwh0rapbqry93l4ygikmbqf",
+    "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
+  },
+  "external/okhttp": {
+    "dateTime": 1628910235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "acca812516265e2cb33430661798cb385cfd2052",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "097dqcz04kxb379dvrhzkgn7w3dm65lwpq0g9hadqaq6pv1ymf9r",
+    "url": "https://android.googlesource.com/platform/external/okhttp"
+  },
+  "external/okhttp4": {
+    "dateTime": 1612297295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4371592e93e7a43e0375ca2be313e0b10cff6fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/external/okhttp4"
+  },
+  "external/okio": {
+    "dateTime": 1619053443,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81655fdd8610e86fd68c0167a734db7a5f1b61dd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ln8mr5cr324v8dzjk35hhy0333sa74j9ay3xns35yk7g2pprxbg",
+    "url": "https://android.googlesource.com/platform/external/okio"
+  },
+  "external/one-true-awk": {
+    "dateTime": 1617419018,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3a688b32ecc23d27531255cba109e2b9d7046b4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1g7v3ayb691jhr8fpcrdz5a5396qbilf9gkddx5wvl52cxrfd72j",
+    "url": "https://android.googlesource.com/platform/external/one-true-awk"
+  },
+  "external/opencensus-java": {
+    "dateTime": 1613865857,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "b86f1ed059c4a9438b76409e158b0b767b2aa44a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1i22bm033fn223k4hjiqn55aj1xr3mvcgl6880cqhr2i8cnw7ij2",
+    "url": "https://android.googlesource.com/platform/external/opencensus-java"
+  },
+  "external/openscreen": {
+    "dateTime": 1617757426,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61dd4fed541e4c84bba25481a04484b42d2cb582",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v1y1ar5ak3mn893gi7jxrfkly7wl45m84gyj33pspcni831bsfc",
+    "url": "https://android.googlesource.com/platform/external/openscreen"
+  },
+  "external/openssh": {
+    "dateTime": 1614045846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df99fc8f0939557fcf990152c7fb3ae894cb6a2b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ch7jqxxw4cv80w60k9nkfpxjp3i60xd575rchlyizvlxka6zwjq",
+    "url": "https://android.googlesource.com/platform/external/openssh"
+  },
+  "external/oss-fuzz": {
+    "dateTime": 1617419021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "666704bb4501070378e43cdb6e5fab55199c9aa5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12ysv0nncqlx7gry6m10ac6x34y1kqs3y9jg5bzkb6dsb677mi6r",
+    "url": "https://android.googlesource.com/platform/external/oss-fuzz"
+  },
+  "external/owasp/sanitizer": {
+    "dateTime": 1613531760,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "506bb8de82e0086f4916666501d20d0c4b734f4f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bw90dnh8irryj7sn0n0swlx9vllvasxj8r01gh7prmawi97lh9r",
+    "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
+  },
+  "external/parameter-framework": {
+    "dateTime": 1613531761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b75fa4d1e1da55302b1fc44f751487f72527a66a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bf4fjy9p4fz7rp2plga2zam62s2k8jcwgn8mg0qka7jkddf1qrb",
+    "url": "https://android.googlesource.com/platform/external/parameter-framework"
+  },
+  "external/pcre": {
+    "dateTime": 1613865861,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6f05f5defea6f5d4cfaa13072e5c894ecea8ae8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dpm303wwx264bc6hxqlrfkfmavqwzb1k914gpxmdgfn0iv7hn2m",
+    "url": "https://android.googlesource.com/platform/external/pcre"
+  },
+  "external/pdfium": {
+    "dateTime": 1616461440,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "392aa7faeae5e7d167a8c69b61c088dc5d838815",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1g50kxs8y74bklsmnjzazd4nk8ajhksyapm5r0g2qidb3nmx3cl8",
+    "url": "https://android.googlesource.com/platform/external/pdfium"
+  },
+  "external/perfetto": {
+    "dateTime": 1628910243,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "182265bc333f2b699f1d5f9a9800a7ba424b01f4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05k7j5ynnfr7hpa9320jax8yiaka3va8q5v1iwzjpdln7bmi8jp7",
+    "url": "https://android.googlesource.com/platform/external/perfetto"
+  },
+  "external/pffft": {
+    "dateTime": 1613865860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec6469adc6983e4e5a22f4bb683f3ebe9342686c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qgf52lcq58ixhrhqnwcpixkkbrd586n23r14yikvbqhspdfar0s",
+    "url": "https://android.googlesource.com/platform/external/pffft"
+  },
+  "external/piex": {
+    "dateTime": 1613865863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a1ba6cc77ea472815c3156c1fcb6ee611162ec2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05lyk7vmhf7kq9bcwpg07nwvx1pdadjv1g3c1ny2wq2l2jchbps3",
+    "url": "https://android.googlesource.com/platform/external/piex"
+  },
+  "external/pigweed": {
+    "dateTime": 1619053450,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81ab6768c92d261152df990cb5438485377b03d8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zh25gjyykp19xpg9jh5xjqaz87j75nb5qzqg08gf7smspb34rvz",
+    "url": "https://android.googlesource.com/platform/external/pigweed"
+  },
+  "external/ply": {
+    "dateTime": 1613531764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b9e76e37f0030bbcf1ead165be9fcd708cfb4cbf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04ran6mcqvfm06d2pqw9x62vwdr782h14xmn9zw8c7pw0hqzkqfz",
+    "url": "https://android.googlesource.com/platform/external/ply"
+  },
+  "external/ppp": {
+    "dateTime": 1623114233,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "694a4fc133cc6258e741b90233ab68d75a50c9a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x8kmf219svcclr8yv94f06y9m7i4hf1sshs4vw557l7g0c56rs5",
+    "url": "https://android.googlesource.com/platform/external/ppp"
+  },
+  "external/proguard": {
+    "dateTime": 1588734599,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8d9430ad956195bc9a660097f52337199a07c6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y15jn4kysl40rgbgh68z7gy9d1g5jjhkvms6gz1jz0vql7a0izc",
+    "url": "https://android.googlesource.com/platform/external/proguard"
+  },
+  "external/protobuf": {
+    "dateTime": 1625706379,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9de31af156b6228d2801867420fcb0b19eb94b49",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ikjv3r0yg4iffq7s13l87va3f8hhhbinp4bb37kl26wb6wdjkzx",
+    "url": "https://android.googlesource.com/platform/external/protobuf"
+  },
+  "external/psimd": {
+    "dateTime": 1613531766,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04ab92dcefc3f9374b82cc89d8d0d7f1d20a5c24",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rq4alzwxxvls4pb4jb02sapag63jpvijjpjh2g2gb3rxnh9kg8q",
+    "url": "https://android.googlesource.com/platform/external/psimd"
+  },
+  "external/pthreadpool": {
+    "dateTime": 1613865866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f454e5dcda64822b4decd9b79a216641b5ed9b02",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ixzpaa6335mcn3sd2kqxrbfr3835fxnfrz2afdyq17h65nvx3b2",
+    "url": "https://android.googlesource.com/platform/external/pthreadpool"
+  },
+  "external/puffin": {
+    "dateTime": 1613865867,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb0aaed34a38129f399e4f983e884305c1ecfa74",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02jrnkqcr9jp2s6igb1nz3gbcr5zsb28x1983p5la5wq8cvykvf3",
+    "url": "https://android.googlesource.com/platform/external/puffin"
+  },
+  "external/python/apitools": {
+    "dateTime": 1613952242,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "38f16e604f6e60d018f2d7fe24bff6bf4192a971",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17caach33h2m4a25fwbdkfab2kmj8c5gbv3wf5zfzh84k27v18md",
+    "url": "https://android.googlesource.com/platform/external/python/apitools"
+  },
+  "external/python/asn1crypto": {
+    "dateTime": 1613865868,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2f4d8b4f1740642ad47bdbd1374dc48ca0ebb7cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00a85gygijpclgdcpp6ggr9zyamxval6k6pkq5ps97c88d2av40h",
+    "url": "https://android.googlesource.com/platform/external/python/asn1crypto"
+  },
+  "external/python/cffi": {
+    "dateTime": 1613952243,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8194e231318636ee95c2df59a7771aeccaf8f9ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m4cr3zy22iahhiskp5vpn0b60rp08a368vkg4jzbkvwcap1z6ag",
+    "url": "https://android.googlesource.com/platform/external/python/cffi"
+  },
+  "external/python/cpython2": {
+    "dateTime": 1615264669,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f6f622297c7b3109678e09bec57260dc7e45019",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jki6h7sgdaak46rff8iijzdcdf9phrdi5935j86595xk5a3d9vi",
+    "url": "https://android.googlesource.com/platform/external/python/cpython2"
+  },
+  "external/python/cpython3": {
+    "dateTime": 1615264669,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab7bb6acacb26a77ab4e0d2bf94828cdbbe8683a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07asjr9d3wlbphfy1l55xbvkxdilc6wzm8fhjqkmha70a7bxj7vm",
+    "url": "https://android.googlesource.com/platform/external/python/cpython3"
+  },
+  "external/python/cryptography": {
+    "dateTime": 1613952244,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "068cad86dd037d409d0d36fec75d4c1884df37dc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10dgm0mh4ljqaj3b5wl39a2v0lgch1jcsrsxbjzx3n25alph1cpw",
+    "url": "https://android.googlesource.com/platform/external/python/cryptography"
+  },
+  "external/python/dateutil": {
+    "dateTime": 1613952244,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e129191411f1385a15afa0fb203b69120038fe5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pjs7hnd3yd3wqqacxis72jyzjcwd0f2bq967ysg8j18vzwjsx0q",
+    "url": "https://android.googlesource.com/platform/external/python/dateutil"
+  },
+  "external/python/enum34": {
+    "dateTime": 1613613824,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f72976379d95f9bac29fc27393b516a809fc3579",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xzl7iybydjfwj5wg6bmxzzmdxv6zpl6qn4w6aw0zws3mra6jhk4",
+    "url": "https://android.googlesource.com/platform/external/python/enum34"
+  },
+  "external/python/funcsigs": {
+    "dateTime": 1613613824,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6dbbdc7c842770abbaf024a934f0e7f40e25832d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05v4kd9697gpxiyh83gsghh8c2vwc2gn9zlc9naj8k3apnc9k2j4",
+    "url": "https://android.googlesource.com/platform/external/python/funcsigs"
+  },
+  "external/python/futures": {
+    "dateTime": 1613613825,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "b3de80b47352253fde330e15dd122e2c8a57d5fb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y2dviz6khx9as8kk3fq1dci62mi08yddpqfcsca79nqsfwf6rig",
+    "url": "https://android.googlesource.com/platform/external/python/futures"
+  },
+  "external/python/google-api-python-client": {
+    "dateTime": 1613952246,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "16f9c8724b0ffb9a43a1733f34d50f0438d39a84",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hc7mrg2sjghznm5fysxqwq2rq8wy55rw1r66g57ripnzrn8xbqm",
+    "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
+  },
+  "external/python/httplib2": {
+    "dateTime": 1613952247,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f2b87eca62e39f5447fe798627776e9b5bab9cbe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jfbxrd2prjm3nv3bmwlqqwgx6iqna777ydd430ljki9dymchj4h",
+    "url": "https://android.googlesource.com/platform/external/python/httplib2"
+  },
+  "external/python/ipaddress": {
+    "dateTime": 1613952247,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0db895b17ab1219a26c2fa18e50f9bd29b7ca3ed",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rvld36ky44qc8yz64a5k6g52qsss96dadvsdd8yqmrx8zincd0b",
+    "url": "https://android.googlesource.com/platform/external/python/ipaddress"
+  },
+  "external/python/jinja": {
+    "dateTime": 1614737319,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3cb0945795aee864f885a447f58473dfc52422af",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0syg2yndr59f4mf3hvw6vs43fx8hf60678ky4ha2liypymazf2kf",
+    "url": "https://android.googlesource.com/platform/external/python/jinja"
+  },
+  "external/python/markupsafe": {
+    "dateTime": 1614737319,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "feb89b5881afde8a1849618ae564a176ff7f28c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18qjh0xrnc59w7divzjrriz7ppclhhlisypzlgd8b8hbd4ali3rz",
+    "url": "https://android.googlesource.com/platform/external/python/markupsafe"
+  },
+  "external/python/mock": {
+    "dateTime": 1613952248,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a78443f1b2761e8d824d1a1d61abd358dd7f8fe7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1c8fbmxnl0h00dnwqywba008lm6bs8zrmvhagnp7gpr84if60gr7",
+    "url": "https://android.googlesource.com/platform/external/python/mock"
+  },
+  "external/python/oauth2client": {
+    "dateTime": 1613952248,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "84df17e9d4f68d9f1be1f052c94364bf27e05001",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0snxs8dzmx5farizh7dk6kyw3pnw9dwq4lgjf55pz57zdw4w5h7c",
+    "url": "https://android.googlesource.com/platform/external/python/oauth2client"
+  },
+  "external/python/parse_type": {
+    "dateTime": 1613952249,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "082afae7f00f4405f775f739a2fe4b290bb2e2f4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jl9ij257zg68c3vbb8wnkpl9cqyr0k115374hh0xwl86cc38x5x",
+    "url": "https://android.googlesource.com/platform/external/python/parse_type"
+  },
+  "external/python/pyasn1": {
+    "dateTime": 1613952249,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "c4b283e8f1ae1c23d276dfe37fe9722f55476792",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0m5fjmifgskidmbvnnq4rvbqkwzkdmvhpi7pya6b58s3cwmrwc7x",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1"
+  },
+  "external/python/pyasn1-modules": {
+    "dateTime": 1613952249,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0e5ad7039d299a3af1088fa88990c34ee5d94c92",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0n7isv62gq7h7i605p3lpkp67hqdbmcnmzzv30jr2m0g8bb52fjr",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
+  },
+  "external/python/pybind11": {
+    "dateTime": 1613613830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cda0598183b2783eff3828dc5709cd2f1497fe39",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r4s6cadrw8g60zhq9nh2cyzvbc52w1amj4ydp5apz2z4hz24fmf",
+    "url": "https://android.googlesource.com/platform/external/python/pybind11"
+  },
+  "external/python/pycparser": {
+    "dateTime": 1613613830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3c14f96d192fb8bcd66241b030e99548011216b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "120qdb67ag3yy0cgwdxijjc32s54irpvyid8dgmkd4jdl3jii7ry",
+    "url": "https://android.googlesource.com/platform/external/python/pycparser"
+  },
+  "external/python/pyfakefs": {
+    "dateTime": 1613952251,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b4277161d443d05b4b6ac52a84d812f5fa5f6aa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jw07iqzrjac1p3vfs3r2g0lg4nsfqxxi6vkk67as939ggkas836",
+    "url": "https://android.googlesource.com/platform/external/python/pyfakefs"
+  },
+  "external/python/pyopenssl": {
+    "dateTime": 1613865879,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21f1b59f3f2308628ca1ba18198da28cdac23f2b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0h50kdfwm9wp4c6vyhf34p3lirz0r69dckdm6hjw45h4piqafdwf",
+    "url": "https://android.googlesource.com/platform/external/python/pyopenssl"
+  },
+  "external/python/rsa": {
+    "dateTime": 1613952252,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "eb69512ac78b91344a7985e4525518313cbe1416",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x7jflip5dcbxd4z9ax3pzlqd0lw1dmgbjjffrrrjbq3ms5vg88v",
+    "url": "https://android.googlesource.com/platform/external/python/rsa"
+  },
+  "external/python/setuptools": {
+    "dateTime": 1613613832,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "30e0287d41b565f01c47068a48c4b9449b92ab98",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ypsmnmng16c8sqx8g3nsiybw7qfxyykpd74i1nqkx0x8qdfs9pi",
+    "url": "https://android.googlesource.com/platform/external/python/setuptools"
+  },
+  "external/python/six": {
+    "dateTime": 1613613832,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "2cd8ece14a805fb6a1c2b48649d7853cf4b673fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j9sx6jph7hz7axrmrmd2wpyvlp8d1gn16ph94vnwcm3izx9a7vr",
+    "url": "https://android.googlesource.com/platform/external/python/six"
+  },
+  "external/python/uritemplates": {
+    "dateTime": 1613613833,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "588b948eb9a43ac94bc1bbf51cabf843c2989f9c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mzkgmy5lxgsbd1az98lvqz50z12l862zgqhrak5jvmgxy33asm5",
+    "url": "https://android.googlesource.com/platform/external/python/uritemplates"
+  },
+  "external/rappor": {
+    "dateTime": 1613613833,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5e944d79eaee8969701fd4245b683c51b7fd401",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0k2pwhs721qh0h3x77z9jzl9vww7gvfdqf9ypxlgia2mha9m2y97",
+    "url": "https://android.googlesource.com/platform/external/rappor"
+  },
+  "external/replicaisland": {
+    "dateTime": 1613531781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f27ac859f53692c905234c599ab4753626ceea65",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16bi4iv9ya7ylwhf4qm7rnymzzcl6wjl68rrrjqrsp9my28h4mrx",
+    "url": "https://android.googlesource.com/platform/external/replicaisland"
+  },
+  "external/rmi4utils": {
+    "dateTime": 1619838267,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "165c895b791dea4accfb86b0173f6a6d697d5abc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lwxkzw2xl6mssvzivzgrnn3wmxkpbm9r3hpd0iif8124ha02zq1",
+    "url": "https://android.googlesource.com/platform/external/rmi4utils"
+  },
+  "external/rnnoise": {
+    "dateTime": 1613865885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb39f41c1e5722eb6511dbe2034f2174bbcc491d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1flgs86w4k7vrrq7mh962rf7y2vxnzfwsd12hpa44375rc06lrm1",
+    "url": "https://android.googlesource.com/platform/external/rnnoise"
+  },
+  "external/robolectric-shadows": {
+    "dateTime": 1622768665,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ff1d68c8c75bb0101bb524a63b14bdaf9f158668",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p96ghpc1ffq7mk4k81y346h2ky1x87mnv80c359mvl71ip1ai1b",
+    "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
+  },
+  "external/roboto-fonts": {
+    "dateTime": 1623200674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5484f12a2a746fcc0e7194b27f1ec96b2d40815",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ygzmkkp1nj8c4spq3rgbdjx40vgmhkivkywikrab3wp3c469lw4",
+    "url": "https://android.googlesource.com/platform/external/roboto-fonts"
+  },
+  "external/rootdev": {
+    "dateTime": 1613613835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "069b0e37b9d2e8df6e065256bca75e76b7316f2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kyqrr4lavpbqz47ajvf03vylgxs72l1nhxkx93hpl52w1kyqih7",
+    "url": "https://android.googlesource.com/platform/external/rootdev"
+  },
+  "external/rust/crates/ahash": {
+    "dateTime": 1619233470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "05f6cf3cd4ee269811def585af1bc850e30974b2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hq34bv8dhqq4dh16bqlv49fsszfp1y08llsycpv8wwxhjwjbc1f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ahash"
+  },
+  "external/rust/crates/aho-corasick": {
+    "dateTime": 1613865886,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e59a85b72d5eaef4da8aa75ae1b5fccb6995b9ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pjnv2f5g34fd8qrzdkhqi9fz1x5mrcg4539gjrkr3kfrwbxsnb4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/aho-corasick"
+  },
+  "external/rust/crates/android_log-sys": {
+    "dateTime": 1620867878,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "32fc9b5d22b3377122edf3cbae2ced89dc87c8df",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1j5zn9ckhs1l9n8wgq1j5r4ahk7z5wny7idxqg5zlpf4nn0m6kr3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_log-sys"
+  },
+  "external/rust/crates/android_logger": {
+    "dateTime": 1620867878,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f5f298ae9c2c50aee4073359c0ddc73d98cfe83b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xvwcn8dy0nas0kx33k8hhxvirkngyd8rn5d37bl07xr8lnqw82y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_logger"
+  },
+  "external/rust/crates/anyhow": {
+    "dateTime": 1620867879,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90c87cb0621d2be1b805f3b0c861d3b38c28a5e5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xp7kx5x6kfi6ginshvg605h5zg3x2hldjfr36y4y5qj899039av",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/anyhow"
+  },
+  "external/rust/crates/arbitrary": {
+    "dateTime": 1617757455,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1bd8a2cb45043ea1f2de2903958704efde71374e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zw3zrfzlwaidbzsl0d166jpmi2hywk1gfjrs2b9wr2dln61dg2k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/arbitrary"
+  },
+  "external/rust/crates/async-stream": {
+    "dateTime": 1614650657,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c3689db8cd9594f3e41ac7b25953aef87986449",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1s0h4zsr8bkygz1d4i78cp5897yvm0bz5iaffbph53n1gryh8ddf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream"
+  },
+  "external/rust/crates/async-stream-impl": {
+    "dateTime": 1614650657,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67ee996a6759c7ab56210e3ff260be012eefd023",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d30bmadkkr0hjly1033l7f3jr0bl1a30q8sdz1l58nx93c2sayp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream-impl"
+  },
+  "external/rust/crates/async-task": {
+    "dateTime": 1621047901,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24b38fcbb351252b72d1c7b950dfd5513da11bcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1a0j7nxi30zng0i6q2dkqqkg70a8bxgbspl3pflv98bsxjhcnc19",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-task"
+  },
+  "external/rust/crates/async-trait": {
+    "dateTime": 1619053476,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dfea1f9b6a0483f152ee9762e98ebc172174681b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rfbqsx81bhz1arfgzgql5kggqgfqq13yc65h69k44z91lq18227",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-trait"
+  },
+  "external/rust/crates/atty": {
+    "dateTime": 1616547855,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af48627127d5a8375360d0b6e5d632925d40e85d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ypvk3r03x00sq5qxd7c358049mzv2f0z364zkj2lr15yakp40f0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/atty"
+  },
+  "external/rust/crates/bencher": {
+    "dateTime": 1613613840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "201e3874a246ccd584ba04aaf1566cf6a3b00793",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d7skrpb2ipsqlcdsrl46cgdf8q7jf8bv5izmxd6cnw733zf5sv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bencher"
+  },
+  "external/rust/crates/bindgen": {
+    "dateTime": 1618880675,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb6a92212e0e24548e62d3f915b64c699ff3fe70",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "185wjwx64ldpyk4y3w67jjqd8q54pgy34pi0cif198zk6wjz0v11",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bindgen"
+  },
+  "external/rust/crates/bitflags": {
+    "dateTime": 1619744711,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44dbdd7d228888306a2b6aa27d4bbb6061fcb468",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ahjp9jmjwm6gm9wgfi4znwvpjpyfkyixk9pjrkx88v7d5c3jmdj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bitflags"
+  },
+  "external/rust/crates/bstr": {
+    "dateTime": 1617419053,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a18eb604d143a726e8bf6b78d6178ff15d93147",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sri0n70g1iak5831zqmkh00w90kk3g70cypy86g4zpzpafyl250",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bstr"
+  },
+  "external/rust/crates/byteorder": {
+    "dateTime": 1617419054,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1104446cea5757c2a9588ae53159f6da7a018643",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z56bdlmm8jf5bvb88ddk95b386xlc6hdaczm530jrzi07r77xjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/byteorder"
+  },
+  "external/rust/crates/bytes": {
+    "dateTime": 1620867884,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b8c8f43b366daf5c46823769a5989a76f1f9382",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f7g96awyhi3sj71rbllbsq9c64j228r2g4wabnncrl99clma441",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bytes"
+  },
+  "external/rust/crates/cast": {
+    "dateTime": 1616547858,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02e7e3bb4d1239e9a39319d6a96a47151891282a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17c2z30zxyfqni9b9j1778xxjc1lvrhafhzlaw6jajp9a6kwn61r",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cast"
+  },
+  "external/rust/crates/cexpr": {
+    "dateTime": 1613865892,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0e465a405da9ea3a34c7bb190f377329fd6b39d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xq9rrmn61yjwzjv61zad20b5irsznvz5w8c7pn5hnjw83aa64ac",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cexpr"
+  },
+  "external/rust/crates/cfg-if": {
+    "dateTime": 1619744714,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c63d3197836e0cbfc5323852e924e1f1f3d019dd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08666bjm2z2hagfmwbhy7nxa00fprq4dbv1si5slhi6mlkmhhxf3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cfg-if"
+  },
+  "external/rust/crates/chrono": {
+    "dateTime": 1613613843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1c71354a86534efffa0bbc1138b8a80e5f6432e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x8si59fb4z6xpmn5kg48lamfx76s76vd443pl0qgc37jcdxx0wy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/chrono"
+  },
+  "external/rust/crates/clang-sys": {
+    "dateTime": 1614650663,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11df75b57cc7f8e0860b111fcb25569f8b39201f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15x52kc16ak83l3l08x0crp2rk5x594bj6jkqbjkkws4728d14xa",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clang-sys"
+  },
+  "external/rust/crates/clap": {
+    "dateTime": 1619744715,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6da519da2abb1b7cbf397f65b750a8d4f09d066",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wwiss20xa3x2dxznfglzrkb36v0x38c651dbhl9h15swjirwqf4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clap"
+  },
+  "external/rust/crates/codespan-reporting": {
+    "dateTime": 1617419058,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "370e6c72d72cb73bcb7cf8ef5be9170b2cbbf3d8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zsiq4anwyv212zznq8cm32rcigvf5xjvn817zav4pmwnq0gjqci",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/codespan-reporting"
+  },
+  "external/rust/crates/crc32fast": {
+    "dateTime": 1614650663,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "671926e75f1d8ea166a6d18f83ad0ddf610b086d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0w1knl6nfgsbvf7syqayrs86hlqvx16giyg9pmi2gqvf03b1dfqg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crc32fast"
+  },
+  "external/rust/crates/criterion": {
+    "dateTime": 1618362267,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb0bcaac164533cf67f6855e4566e949e3788449",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rv1c32p524j7v0cn0lhin8g1qy0v8nnnn7670ak6w3vb3lvxb12",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion"
+  },
+  "external/rust/crates/criterion-plot": {
+    "dateTime": 1616547862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76e9b05c7fc7773c2402ed18752b645ae3cc5fa9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0a72appa3mnq7rjpv4q3kpnmrbmvv3hrk14yai12qbzw72v08syg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion-plot"
+  },
+  "external/rust/crates/crossbeam-channel": {
+    "dateTime": 1616547863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0fd02c1c2710361ab3d7fbbfd7657e8788eac68",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nj6qicjbdkdrkycc43fgg0w7gyskmy3ahl6r9zhsb0dpqhys6c7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-channel"
+  },
+  "external/rust/crates/crossbeam-deque": {
+    "dateTime": 1616547863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db542e0a65785999dc262d159bdcbd58bfcf9ffd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q88z0w823ap29c1qv6fqy9bmgvb82zs836332hpka1lbrfw0c0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-deque"
+  },
+  "external/rust/crates/crossbeam-epoch": {
+    "dateTime": 1617930275,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6b38f31e0c71bcf7571166a3ce45c9af0f4cf22",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gwdzc4f1p0ch46zbfdbmrk59mg9848nj1acas9x91xcrn447j77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-epoch"
+  },
+  "external/rust/crates/crossbeam-utils": {
+    "dateTime": 1618880684,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb424d2b77202e0813d6590fb7ae18b563a686f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0n97x42nmc8mmwraz879ld6nqdgsq613wiahq066w5j8jvsn1ll6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-utils"
+  },
+  "external/rust/crates/csv": {
+    "dateTime": 1617419062,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3338caa7f015f22706d7d75d8982a2ea16cb8baa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10z3nh974sckbcfdxw8ah7h8mxvx1c6mfcjvcfr6pw8vzbq84mdc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv"
+  },
+  "external/rust/crates/csv-core": {
+    "dateTime": 1616547864,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5785ba704f60fca94734a1ab195b2fde75f6e971",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y6kq025hkpl5yl4vakqd3h08ipbx15n2yayvw654k3vwl9290da",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv-core"
+  },
+  "external/rust/crates/derive_arbitrary": {
+    "dateTime": 1617419063,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "149cf6ece46946e1faf1b840d80786773dfff6fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d83srj03644dvy59r5612779gcp8g9dj3r6c1gf7c03vlfpdm8k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/derive_arbitrary"
+  },
+  "external/rust/crates/downcast-rs": {
+    "dateTime": 1619744721,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4be37ecff2249799dc308d0b200c8a6a4be07451",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1325khrkxyr04bzypvdf44azyq5fvbgf3rxxygyfwx8567vyjhcg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/downcast-rs"
+  },
+  "external/rust/crates/either": {
+    "dateTime": 1616547866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "633eefa4c2726c0660e571fea076ac02bc418fae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jbnwc9iiiyyyf5pa425ysnjv14awhpzylc1f65xiw4zg16l8d6l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/either"
+  },
+  "external/rust/crates/env_logger": {
+    "dateTime": 1620867894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e4f396f1828a393ebcd530586b250588d48099b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j8s6pp9l87lpj5cx73cqkwsbxgza1hjv376h35sdf5zznv8gp1a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/env_logger"
+  },
+  "external/rust/crates/fallible-iterator": {
+    "dateTime": 1613865897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "344d213762c57b0e37dbce3ced58b367221f6a9a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wwq8gzcwmwn8nd25m0p7s165d2fpm3gd0bh5qvacca5krdwbapx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-iterator"
+  },
+  "external/rust/crates/fallible-streaming-iterator": {
+    "dateTime": 1613865897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccfc0465b8fe49a29f4024c84a67d1f21ed4700c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0934fiwj33yqkyya8fxlbkwncpm1p48xcvs4058nc8xz92jxms59",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-streaming-iterator"
+  },
+  "external/rust/crates/flate2": {
+    "dateTime": 1621991111,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa0a47a5ba394139485f0352e4554d32d9103afc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1j5kchixqzs9axz3k0k27mp7bwayjln4xks52r59rmzp1vxnld0q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/flate2"
+  },
+  "external/rust/crates/fnv": {
+    "dateTime": 1613865898,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4fb61601b1d65899b41784964b1f58ac664aa013",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "176wqsijl9f64scdjgj92r1q4l9bb96s2wapsgj6ldg5d4sh04q7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fnv"
+  },
+  "external/rust/crates/form_urlencoded": {
+    "dateTime": 1619744724,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "077a3993f34dcff5fdb58f9ee9ed53de1af3c60f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bm74vin0rx5h0ihgzg258ihkxvmx2dsrac7wj76y8xgj99x2k0z",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/form_urlencoded"
+  },
+  "external/rust/crates/futures": {
+    "dateTime": 1619744724,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ffefefc55530584e7ca9794747325cb4523829c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d0w7s3rbb90x8y6sxzg22cqqlfy2zabcbbzyllq40dazg5f0rzi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures"
+  },
+  "external/rust/crates/futures-channel": {
+    "dateTime": 1619744724,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f0cbd2bf3d377097ca2b7bc4c06a5472d3d9e5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mjrc60cjhkfx1s4qzd7xjwb44wfff41p1vh1l2ibvmq3f80z15a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-channel"
+  },
+  "external/rust/crates/futures-core": {
+    "dateTime": 1619744725,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3621e6dcf66a48ca8b7aec196c2d53f3749a2daf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07fp7v1lcln8v4ajyafq71s80z0904i5xrmn5zqn4mv4q1az1r8v",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-core"
+  },
+  "external/rust/crates/futures-executor": {
+    "dateTime": 1619744727,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a41d0e345b13cc8184864e5454cee0410c7e14e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0myqw6i9ckl72hdb1yklxjn1ay4zs81pflshy5p8336lqfw7v7ly",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-executor"
+  },
+  "external/rust/crates/futures-io": {
+    "dateTime": 1619744727,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73f2260a2182d3231e14419e48792df784cf7356",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d573cpchcpahlcbgfjkmqj1mdlbn70p2yxhzzgnna6a931h358c",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-io"
+  },
+  "external/rust/crates/futures-macro": {
+    "dateTime": 1617419069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "567e6fe216b4a6585ec78e26ee1e514e78ea88d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p5z0scaqqsngwgwgrmy1m1dzavalj8al9566q48pnrsj6xr8lbc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-macro"
+  },
+  "external/rust/crates/futures-sink": {
+    "dateTime": 1619744727,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6274f8899a50bff652f62cc84e077b8329cf76a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sm91gkcaif1qgalfv8pakak3jaf6x9ryy63w9hcb6vv1rj599k8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-sink"
+  },
+  "external/rust/crates/futures-task": {
+    "dateTime": 1620954295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "85bf8fafb99c1402b7e73d7f89b6b4f502ed5b48",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19p56hy20hrs8b1pd1ba6cpnhf3pcbpy1vz5hqsrnzhca1yb7mfr",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-task"
+  },
+  "external/rust/crates/futures-util": {
+    "dateTime": 1619744728,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c56c507f8ae7c3985967c973351d84b2e8e731c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v5rpkakmi3yqakzwmyn3n9dvla3phwjq2y1h5rn7qm8ymvkfgk9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-util"
+  },
+  "external/rust/crates/gdbstub": {
+    "dateTime": 1617419070,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "876bbac0de646d347c839a534783c0d2f28b485f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05s1b54bwl1fa4hgh9kr4ip8513vccg8bppbkpfqcjqlr68nh31y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub"
+  },
+  "external/rust/crates/getrandom": {
+    "dateTime": 1616547873,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "265fd84de682a7e4d9a0bdf6f90e7f79c33035f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wzp0cy89g8kvsn2q5kxsfqa5bq1319kvcs6wjimm03zd9jpsbq5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/getrandom"
+  },
+  "external/rust/crates/glob": {
+    "dateTime": 1613865904,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e28d82f0813b547e7fb9b668912582f98397127",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sd6b3y7w2lhma4d0y4930sv3adi97pkyq6szd765mxzaxm5dh55",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/glob"
+  },
+  "external/rust/crates/grpcio": {
+    "dateTime": 1617419071,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0090a4dfe437edf979bd5454e5574e2cd8a57cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dc2x1jl20lb93833dkrjksszkqnjlwh9lzf2z34kjib5whxyicc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio"
+  },
+  "external/rust/crates/grpcio-compiler": {
+    "dateTime": 1617419072,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "918bf41285f289c80bf5df2ea50b11a5a6722df4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xd739ka5f56zywd9xnm934z472c7drqiz6hqg64cw9qxgp96fyc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-compiler"
+  },
+  "external/rust/crates/grpcio-sys": {
+    "dateTime": 1619053499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4b0240a1928dd737586b68572a950457de6317a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hmydw85ih7cjdb3rdmpv1hmfqqb6wvz24z4ba9kwxn2y4vf2hnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-sys"
+  },
+  "external/rust/crates/half": {
+    "dateTime": 1618275974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5b9d031ac59fdae14b76b515ac565632f85641d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08l0jgdfi6qmbqp5v2q8hjpf9rwqmampl9ki7qramhin3p6c620f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/half"
+  },
+  "external/rust/crates/hashbrown": {
+    "dateTime": 1617671096,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "742b07ea1121ee79e2e4b791b302142166433a3f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lkksfn0kqd6sqjlm35m4h6nv8bx78fw4c1dbkj2q82sqy63r88j",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashbrown"
+  },
+  "external/rust/crates/hashlink": {
+    "dateTime": 1613865906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fd3f5b99bfd528dc53f13d445edf67678336096",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m1zxa9kcq561wckji7m2rsrp7h32zcsl67nz8sm3crmfiih89p4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashlink"
+  },
+  "external/rust/crates/heck": {
+    "dateTime": 1613865907,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "102f05819a3ee3af7f3ccaf8a10e65cfca758f68",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0x4djw1sjsl4p906fpx8davjlrnxar843aiap7qph620fa8f5p92",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/heck"
+  },
+  "external/rust/crates/idna": {
+    "dateTime": 1619744737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e63f3705fdd15ddc90380e01864b6134c887731a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ymmrdxp31wpqwhfcaan2rjfhcj0gv7zigshhpcai1xv5zfb9ax2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/idna"
+  },
+  "external/rust/crates/instant": {
+    "dateTime": 1613865908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6c7651d5e1d04295ddceeafcc5e66e9245497b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07w1pii8i6qkfnwvhsm4iivflxqq6hpbmiyq7jsw4qbigsrjjrc9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/instant"
+  },
+  "external/rust/crates/intrusive-collections": {
+    "dateTime": 1619744738,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b61a9dbc26da0b764eb0f8a1cd55a447cd5ce80b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06rv3d12ds3kdnsxlzv4318i1nykvsmh9hcvcapvhpxc8av9xj9q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/intrusive-collections"
+  },
+  "external/rust/crates/itertools": {
+    "dateTime": 1617757484,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "763ddcb2e7d3d6f9268693ef4406b3cb96b4b9d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0w0h9zdc938l057zjbsvai9s5mnhyx9nga55agwarflg39gr12xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itertools"
+  },
+  "external/rust/crates/itoa": {
+    "dateTime": 1619744739,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a22841d0254949d176821027d51baf4225adf2d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rji01a0sfkfh18jx243hbm69mqjx9i013df0zwisnvq4680536i",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itoa"
+  },
+  "external/rust/crates/lazy_static": {
+    "dateTime": 1619744739,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "832b7f6f87c891d333632a1b4ca78e7038d82067",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wbi944w289ihsvirwzy9y0casx6xfnyd6vlbrlp6mrly8i9f1n8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazy_static"
+  },
+  "external/rust/crates/lazycell": {
+    "dateTime": 1613865910,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44b228b4fa42c7f4c4e188e525d404cd16a58fa7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06di56bnsz4msyj77nwha4g1mi08k19ymh15isd79wc6x44z9h5h",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazycell"
+  },
+  "external/rust/crates/libc": {
+    "dateTime": 1620954305,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d12f7118f5039716735e034bb559f9b61249570a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zx4l0w87azhy1pc6mnvzw0ksbjbfrv6gvbvnn2d5g2plp3ssja0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libc"
+  },
+  "external/rust/crates/libfuzzer-sys": {
+    "dateTime": 1617671102,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41b8fc68c423d3fe23e704af8fa7e188cdde3839",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0f5a2zl26ydvffwzfw3yk2mfpy63qkhc97vbmg6nqp03jd3gxdhv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libfuzzer-sys"
+  },
+  "external/rust/crates/libloading": {
+    "dateTime": 1613865911,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a4f3dab2719410bd2b71a9d1c66f0d25500d8a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "125hn4cvm7d73y1caagf2vm17qzrkl6hppw8icibiwzc3cvq509p",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libloading"
+  },
+  "external/rust/crates/libm": {
+    "dateTime": 1619744741,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c2c70e7bc1b8e897b65a608660b2a2ac0bb95b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "111agfhx3rid2cgg0va4rblsdvr5xa0lpzwqbbk15nh184ckbn14",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libm"
+  },
+  "external/rust/crates/libsqlite3-sys": {
+    "dateTime": 1619053511,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a73d4f2cd817c1ddc836afa831c3a037d8ced6bd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zw7ak9v8fayazqi33nvy6laysh2rxd424l2c8sxb5sshp9csp8m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libsqlite3-sys"
+  },
+  "external/rust/crates/libz-sys": {
+    "dateTime": 1613865913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "331af6984aa2230f7986498e51c0c8ddc8e628d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1snrdfqxghyiwd3w7yxbp0vl0kpx6w1ciih3hhvwhfg83yh754h1",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libz-sys"
+  },
+  "external/rust/crates/linked-hash-map": {
+    "dateTime": 1616547884,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9234253d384a62e884dc5edff4a6cfcdfd6b7ec7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10avx3pavwvc6w9pwwbkazahbrjffkq1bw4rd48fwbapsx2c1axj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/linked-hash-map"
+  },
+  "external/rust/crates/lock_api": {
+    "dateTime": 1613865913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "29cf29d3e6c3cefb863c0cb5670a203842044f67",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18m7p6hd57zbhc4nr0l63i38zk9riw8vkrs172j5zzwfc086v3vy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lock_api"
+  },
+  "external/rust/crates/log": {
+    "dateTime": 1619744743,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b2a087da7469d103db476a41823fde258a7c7eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zzb335rk5bpi75jm4sb5pf8rmnpf6dznbd5n4nzl1i226zfqvz8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/log"
+  },
+  "external/rust/crates/lru-cache": {
+    "dateTime": 1613865914,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3c8bd03864fd1f8aa119a7fd3a4775103c2ecdc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1cba2cgnkp681l5dhppipfidlj244mzzv0iwgi0qmaja99cdyzfz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lru-cache"
+  },
+  "external/rust/crates/macaddr": {
+    "dateTime": 1616547886,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c8de297f1f5444e33e7354d7194a5d118fcc89bd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ih34msm26vya16vkqxsvf0zrxxhbdgm3gbxb80md6wlv4vmskjm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/macaddr"
+  },
+  "external/rust/crates/managed": {
+    "dateTime": 1616547886,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5a17743047c1a3ec151abcc5e2f315fc5476abb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05a90v3jq9yw5bj547qjx31l5fm6fafdl1mbngbkglmmw0i2bzmk",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/managed"
+  },
+  "external/rust/crates/matches": {
+    "dateTime": 1619744745,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19893eb107bfc9feed3d918ea6dea90ed90e93f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sp2ddidbl3h0hbrkbg194jpqpdb1l74pi8kdga3sxczp3dlmkyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/matches"
+  },
+  "external/rust/crates/memchr": {
+    "dateTime": 1620867916,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8edcf716ce1831a52e3b4adcd9704c306380a6f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hwsviz4jz3c7n7lcf95m6brifngx1r6s3h57d1xkqqz6vz7y716",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memchr"
+  },
+  "external/rust/crates/memoffset": {
+    "dateTime": 1619744746,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "092d6f0bb457684021caa0a28fd39979f0807f5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1vkrp3y4l7vxcsbgf8wxfl1w9icwnikb69b2jjw77cy3r16c43qg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memoffset"
+  },
+  "external/rust/crates/mio": {
+    "dateTime": 1619744746,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a2be099de4c8ef0e1cd836da662702e881f09cc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jhji521v8686xn5zzl3myy4q6jdnsw8wn3bh6fa0cnyl60gmpb2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/mio"
+  },
+  "external/rust/crates/nix": {
+    "dateTime": 1619744747,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c04f14a7d1d21b1e637265f33871c06ca70d847",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wvpj5950hvj55gajh3yp2pf514shscnp4z39h9md9rjzig9qwr7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nix"
+  },
+  "external/rust/crates/no-panic": {
+    "dateTime": 1613865917,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5187b4d4769cc976ad8731784e8aef3e93f7433b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0cz0nj5d58s0p03pf4j3k14d9my2iss4gap87ln7fkx63kll7l9b",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/no-panic"
+  },
+  "external/rust/crates/nom": {
+    "dateTime": 1613865918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "031bbac81cd029afaf48926272aa61b28ac551df",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00iz5lgxgdlshwmsbppiw509y574dicmk3zfyba4xz0scd564xnv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nom"
+  },
+  "external/rust/crates/num-derive": {
+    "dateTime": 1613865918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4386e0c1a589a37593d2f6925f2d3e915a401783",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07l72iv3aikhcfywfll8rjh7ylclndxr7cidcq6a8i0klxfibiv7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-derive"
+  },
+  "external/rust/crates/num-integer": {
+    "dateTime": 1613613865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f4e7c3b605a69e5e3e3c6a7b4a3d4422a91f834f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b0i5j8vgn1xvp66dcwdvfcq8hymn7hx04411lrbcha9v1zrjl23",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-integer"
+  },
+  "external/rust/crates/num-traits": {
+    "dateTime": 1619744749,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4955e43567ca78928442857660c14bb27f630e65",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05ar1k2x8pqqr9hn4cchy5kbv5cg80aaxq0k6xp794m3cn7j275s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-traits"
+  },
+  "external/rust/crates/num_cpus": {
+    "dateTime": 1620867920,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c937a3841a5d2fe33bb279ea0b6ee701161cbb9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13l3ss2303qgx780ppsp7y8zkz5rh78mznml1mbnhk1j177zdjwp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num_cpus"
+  },
+  "external/rust/crates/once_cell": {
+    "dateTime": 1619744750,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6c87a03aa449d700e906d6e7cbfdb7be44142ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pn4aj49f25r5jz4dm9wmdf1rmmghzff2yzplikbgkx4kl31q5zx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/once_cell"
+  },
+  "external/rust/crates/oorandom": {
+    "dateTime": 1616547892,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2225411be1dd594d70c9bfbc5a4d436c6cba1ab0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05xsrs0hvzh9z28lmfq3slmjzia6dg6nqlsx5qzwzn06qximykaf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/oorandom"
+  },
+  "external/rust/crates/parking_lot": {
+    "dateTime": 1613865921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a0ba299bd0ed9c17cd1027657451c7fce0927998",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lfv9la7lm4m8k5wln2xv4ghv1yv4z99mgzl2rx5hz1rfrgg38g4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot"
+  },
+  "external/rust/crates/parking_lot_core": {
+    "dateTime": 1613865921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efab35072d188df386b832ceda58bc1ba257ed48",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rkzqb6is3c3s08m4gf16s17i6siy5xhcc77s25rwlvx6waq4k8d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot_core"
+  },
+  "external/rust/crates/paste": {
+    "dateTime": 1617419092,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ae01315b5b36da9ea6414ac7c0754756b9e4342",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vy1knxk1rckadyjyl72dcyqc6wz8dvq0c986z3652cl0g0q1pji",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/paste"
+  },
+  "external/rust/crates/peeking_take_while": {
+    "dateTime": 1613865925,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6d603ebfbd1dd1fcde24b7f235d0a343726ea6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12901vqlv7ciffpdq7bfdcfx2vpylwv16czvrm6174g7d9l68fv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/peeking_take_while"
+  },
+  "external/rust/crates/percent-encoding": {
+    "dateTime": 1619744753,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0408b83d725888650d9683a761e8e9cb6888c688",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vrdcvkv72306calx7q3hxmsk2b0kcac9hjn9s92l01am2svpa65",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/percent-encoding"
+  },
+  "external/rust/crates/pin-project": {
+    "dateTime": 1619744754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "58df91a045f3088ffa57a430d8ca64920e144dfe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y0037f6zw4qyjjmb8qgxr15mdf8a36iym0r2in978bx6vickbyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project"
+  },
+  "external/rust/crates/pin-project-internal": {
+    "dateTime": 1617419093,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "10a53ff9514dcb22441881c81ced81cb0fa0bd0b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dyjczyl7rjyj3qlslhvks0cb5hfmiz98g6il06837sl7sa7r435",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-internal"
+  },
+  "external/rust/crates/pin-project-lite": {
+    "dateTime": 1620867925,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87cd0beefcff5172d5f37c4376f1393c9d5ccea5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19hx6g9vkwl07f5d65irylb82dj96w9sfcrpk2g5jnj4q35991di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-lite"
+  },
+  "external/rust/crates/pin-utils": {
+    "dateTime": 1619744754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "656f3e52018808b4f3ac260f17245293d27f7a7e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wc5x25b440l1qlfslhpvnm9yppwxjmx284wy7s0wz9jr9ikdn3k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-utils"
+  },
+  "external/rust/crates/plotters": {
+    "dateTime": 1618362305,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "deab5dff31b5c8ea549b073365cb94f3f3cfeef6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0w3hzsr0hz5zz7cyn9r6hscan9arf8nbiq6fbgjaw67vjzzgjamd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters"
+  },
+  "external/rust/crates/plotters-backend": {
+    "dateTime": 1618362305,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac1d9fa23e2e6dd9f7cce1cbe58b256f938a3bbe",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f6vxfgg2nb130cs0ykr4clhzwm9sd37hh87zk53v2yh1k2nsx63",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-backend"
+  },
+  "external/rust/crates/plotters-svg": {
+    "dateTime": 1617757504,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51173a2ef97ee4a1c955a6c89ede7aba5f9c02c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0knjd1657r31h5djbkacpiapax09adk2ryf8izayli46ifyx11bz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-svg"
+  },
+  "external/rust/crates/ppv-lite86": {
+    "dateTime": 1613865925,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36102cc940256a921ae0a4df70db177d592435a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02gkxcgik9jaw36hm59bs2pkgirrgz71ngsmxdda98h1ydip7i04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ppv-lite86"
+  },
+  "external/rust/crates/proc-macro-error": {
+    "dateTime": 1613865926,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c73462eca8d8b49324239b2f2d425ea149c6c4e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1knxgc7r9x289qmm38vmrh6sdyfp06i4n4ajlknyirb7gkqmw2br",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error"
+  },
+  "external/rust/crates/proc-macro-error-attr": {
+    "dateTime": 1613865926,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f680845620ea3eb0b1f8bb4764f2180cd56c24f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00zdh0yjlvp8lfc55a9vpf30b1q4m5cnyqdd1sfxxjlfv5fjbddc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error-attr"
+  },
+  "external/rust/crates/proc-macro-hack": {
+    "dateTime": 1613865927,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "10fbd4db46f142efbf60a6309aa2bed36c87a9dd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k1ljy6alvx8hq3ym48ajavdljr6199xfd75ql72926nwk9aszxv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-hack"
+  },
+  "external/rust/crates/proc-macro-nested": {
+    "dateTime": 1619744758,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c8a4ce17a468ce285224c024b38dced25a191af6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1cm5csfpjbxbqs80javai4s0cdaz1d0a9i9mj45ck1dr1k9xzd5d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-nested"
+  },
+  "external/rust/crates/proc-macro2": {
+    "dateTime": 1620954325,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d558bd59e78a4e789ea7bb15b1570f537941c51",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01f5n87cdwhmw31b2433hv8fq9345haqhpg6k54as37g5pf4r052",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro2"
+  },
+  "external/rust/crates/protobuf": {
+    "dateTime": 1619744759,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f11f53084636206baebb1225c789348c2e72c8a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v05llm5p3y1w36vnxlb58n0p5bdg5k2sr9vjrcq14biqapcm3di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf"
+  },
+  "external/rust/crates/protobuf-codegen": {
+    "dateTime": 1618023915,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4644462e5b1d480215c02a1e88a78070e860ac5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yp4dly0d57gcyh4jp76jkvwxrbnv5w8vdklfmdd2gnad3gg5qjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf-codegen"
+  },
+  "external/rust/crates/quiche": {
+    "dateTime": 1621904751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6333a3740198d5cf6904560b6ac5535df1801c16",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09r61vnj962kpz4s4r47mj21823244lnm60j0vnf9gp6yr10xv6w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quiche"
+  },
+  "external/rust/crates/quote": {
+    "dateTime": 1613865930,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b508a611dbbac229b28338313e6a2d25f130fb7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lmnm2xvq7sqz0vqprqfgah04rwfgs3jga4za3ijpzmqr4bfqxbs",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quote"
+  },
+  "external/rust/crates/rand": {
+    "dateTime": 1620954327,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab3242cecb94677ae79ecb043a0db08f4381fd2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1q0xgznpka23616c4c52jw87yf2yf1nqxk4nrbs37idvdax3370w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand"
+  },
+  "external/rust/crates/rand_chacha": {
+    "dateTime": 1613865931,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb818f283b083283289f53cdd99722dd1fa038a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11nlq925r5jay7akqzimrk5lpr38cyi5izlpzmjqs73jv6j21n4l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_chacha"
+  },
+  "external/rust/crates/rand_core": {
+    "dateTime": 1614470705,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cbedc080e5eeeaaed35bf89e6fe1877ec2d9e761",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yagpl8553a611mywlvf7zqdsqdgqh661y51lw0b9alh3m0dix5k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_core"
+  },
+  "external/rust/crates/rand_xorshift": {
+    "dateTime": 1613700317,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "677df53b5adc11a3cfe0c40a19365c8fea58bde4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0pxla85gls4kib4ydlpzzsj3yw2s7ryk1yvljgjx7avkam3ba86m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_xorshift"
+  },
+  "external/rust/crates/rayon": {
+    "dateTime": 1616547905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "819b6a0fcbe51a91786b5e976bda9f282e636642",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xffdyamd965vw93hl7zw6mgip01mybck8pfljr9msza39wfvp34",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon"
+  },
+  "external/rust/crates/rayon-core": {
+    "dateTime": 1616547905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f8dc61b61af5785dd0a59f163397e471f04728f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kswciinmwn6f3xfgnxgqpnd6m3v6sm3m7d14vn2xp7938hi7s9w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon-core"
+  },
+  "external/rust/crates/regex": {
+    "dateTime": 1617419105,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "197daef5281f0586e8cd7055f63430db01a836ff",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0liqpk6bqwdypjawgcgwpdiy76a6ab5vvhi249430spb8552rvr2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex"
+  },
+  "external/rust/crates/regex-automata": {
+    "dateTime": 1616547906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a29867ea0c53760c1563b77864e02f2557ae01f9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "060cvq9v43k2wca81bcyxyqspgyww0lw08xkiq0bznrql2vp7f04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-automata"
+  },
+  "external/rust/crates/regex-syntax": {
+    "dateTime": 1618362314,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb7a9b1e4201482c22568d37085dc5a40afe6789",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1amzxpm2072myiyzwqvipr1nsxbdikhz49pvm19kbzmasnnx7gin",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-syntax"
+  },
+  "external/rust/crates/remain": {
+    "dateTime": 1613865933,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7fb28d5c16a296d11cd73a5a9c5bebb203b9aa94",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d53xbgp935395b99anix9l3193ss2imi0dwzxqpr1b3x5imbff6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/remain"
+  },
+  "external/rust/crates/ring": {
+    "dateTime": 1617843929,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "721b6572033c1b9aa39e4251b3f1dd290bbe6922",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1svc2bj08si0x9frpkz90i7zal3lxbfi4kgl20w8r4018hk30c28",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ring"
+  },
+  "external/rust/crates/rusqlite": {
+    "dateTime": 1613865934,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "57eeeade66036af5d9298a96a66953ff7f654982",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vq390rcdxx95pnj75j3dp393irh0rxsc0frz6mwpcfy7qvlkz7k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rusqlite"
+  },
+  "external/rust/crates/rustc-hash": {
+    "dateTime": 1613865935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e766dc548c8047b0b2e03de800afb35c729c611a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v30cz4b7ckpz4i6yzcz4xcnkjvvpfd9ijz2qf0xzfqjaybfhlyb",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustc-hash"
+  },
+  "external/rust/crates/rustversion": {
+    "dateTime": 1614470709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f94611121ba9cb5586aacd9bc1e49d70b7827fdf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jjn769sm5h0j1g2ysxip2c3qn5fgiyklnc80kpwpbc8pz359vlm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustversion"
+  },
+  "external/rust/crates/ryu": {
+    "dateTime": 1619744768,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2301e6fd1d84a75d4ccb86184b5c79de6c01b53c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0x7nx4w6pmy0bwbrlqgkdmjmbp4823gd1mfxxk240g0wy7zbpc8w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ryu"
+  },
+  "external/rust/crates/same-file": {
+    "dateTime": 1616547910,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ee4f07de08c8fe1c30406ecce4bdddc0f5ef83c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hqv1pdqmjpnicwzmk5ysjicp552l61ppqv9liy201iz7bl2yagn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/same-file"
+  },
+  "external/rust/crates/scopeguard": {
+    "dateTime": 1613865936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6890bfe655722283faaaf1d1d29db7f4cf11608",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0yc9w5xz3vyjyyw17la529kz4jy4ayk1s98js871ha4xkbjwh840",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/scopeguard"
+  },
+  "external/rust/crates/serde": {
+    "dateTime": 1619744769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6917b29bb8030324507f261a1751e4a359cb95c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z74h4ir11fk52g0fs54mmalc4cd1ixycmngz3dam3li86hami8n",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde"
+  },
+  "external/rust/crates/serde_cbor": {
+    "dateTime": 1616547911,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b030992f7e10c841c5b0c395529af546b4057739",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hcd2xar0ymvly9qn9sxkwzg9cgx4isnks3v51dfdhz7np2rrj06",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_cbor"
+  },
+  "external/rust/crates/serde_derive": {
+    "dateTime": 1613865938,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "634d51d5cd4add495684f90022e82304f9bad90d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1api77r6ylamm2zlhl76n3jbfrzqkqbjq42kn9y3bq6akn7ixvw5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_derive"
+  },
+  "external/rust/crates/serde_json": {
+    "dateTime": 1619744770,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1377002c8023cd8e4dfddcc98bcea85fc5e587f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qcw6skd8wqgy6mdh14am0wp30dlc7cwp09fg2ml0k3w6d6zrz62",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_json"
+  },
+  "external/rust/crates/serde_test": {
+    "dateTime": 1613531825,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a9c326d214ca482e7b2f9cb69a3c0e17a729f7d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07hdv8n29f5rrngjn7qxmq9dw37j1y5awlbpga204jzj52bg8sax",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_test"
+  },
+  "external/rust/crates/shared_child": {
+    "dateTime": 1619744771,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c19f86006f9face02f72bfecc04beb282e59f60",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l52r5sxgr164fqmlhfhdk7hr5jwwqfrp558pk41h314y3pr1gg4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shared_child"
+  },
+  "external/rust/crates/shlex": {
+    "dateTime": 1613865939,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb036682671c0b04c5516e2ee3d87813a2bf1b5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "135jawxfirwgh6dh0k25bl1k8acmvpwwpah62dcr775x3g885srj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shlex"
+  },
+  "external/rust/crates/slab": {
+    "dateTime": 1619744772,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3fff7eb6559f180171524dd43a6009437247f124",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rvrph29d850l06wi8z0j3gzsnfbzlxnpgpqwxqwy3nqvvi90d9s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/slab"
+  },
+  "external/rust/crates/smallvec": {
+    "dateTime": 1619571922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "860fed61c48a41bc6f301b5b72f59ff9dfe9914f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02mvm1c3d9axdf9qkg2rylvhp7sgxcx9n338xfmaaq1c76wy0l7x",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/smallvec"
+  },
+  "external/rust/crates/spin": {
+    "dateTime": 1619744773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da5c2a4f7f5ddbaaf61faaf0933253cdd75233c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00kv0aicmq07y6i44hz382h4fzhz4gbl31ckbch0f9c6xyhm0g8a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/spin"
+  },
+  "external/rust/crates/structopt": {
+    "dateTime": 1619744773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "560ea65e3a80fbf8088e52f82e1130dcf04e0133",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0n6lk2i8z0brsrg8gilmlx58h58c6j02jhln9rm9x9r13vhy09fq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt"
+  },
+  "external/rust/crates/structopt-derive": {
+    "dateTime": 1613865941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f3a8729ad53fe255fab745f700dc4922dfc3b60",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16yjhl98qilspdi2rk0bhs3ckav3rysdccbq7nm6w6zpvn4jm4zq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt-derive"
+  },
+  "external/rust/crates/syn": {
+    "dateTime": 1620954342,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90fe94109ca6d0a136544e7f63644c88e96007b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "086z6n4nkw8sdjwjfvnrzrsmiyahq2s6aw4fp776kgwg7lxl7shp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn"
+  },
+  "external/rust/crates/syn-mid": {
+    "dateTime": 1613865942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "033ae8f7d6cd6a5509661b8db58f521a3e226ecf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hhvqxhk4rkwm0qkfh71rc1h3p1naldxw11691igmn6rgr8q94in",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn-mid"
+  },
+  "external/rust/crates/termcolor": {
+    "dateTime": 1613865943,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db0706da1afd8466f695cbe0e4452418b8a04262",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0cqjgbwvccydjz2xrsrbsia3lmfzw275g1lmxw4jla1zfja4q9n0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/termcolor"
+  },
+  "external/rust/crates/textwrap": {
+    "dateTime": 1619744776,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2198be67c9621df22daedebbae1245340e22fa49",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hc46d3jlx6v5swfj4d0p9267snl4xx6wpwx26s3bb4s98z4bdfn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/textwrap"
+  },
+  "external/rust/crates/thiserror": {
+    "dateTime": 1619744776,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f267c29e239a875fceced8ef6064c90a1a670bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02n6qiz8qpq972a06xdzgxs5bffpgs6mwx63chyxgnqy6726flh3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror"
+  },
+  "external/rust/crates/thiserror-impl": {
+    "dateTime": 1614650714,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ab5a1a6cd2b0d42ce22cbf54130276072c9f9d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gg7s24ady7zlh46nffk7yh11rrddg8wvsdcr7c711dsbxxb5584",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror-impl"
+  },
+  "external/rust/crates/thread_local": {
+    "dateTime": 1616547918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ada0fdf2f5fae753be2ee8dbd5cc46efb7d60cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ln79byy89kpxygpqd11bbi5xsjypy1n28wrp91hy6sx786hla85",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thread_local"
+  },
+  "external/rust/crates/tinytemplate": {
+    "dateTime": 1618023935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b0ba2ae0805a8dcbc2caec26b03283ba1728c2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10wg6wj3bzynr1z9pb50bmr6pc8i7xq56lwjydgwilhwi6p2g96w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinytemplate"
+  },
+  "external/rust/crates/tinyvec": {
+    "dateTime": 1620867951,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e7ceb17994bdd93ff562ed7e66ee9cdc391e6286",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1iarzdmdck0f5fdwidd665m45wxl9aj32s1lm30nd5379cprmrwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec"
+  },
+  "external/rust/crates/tinyvec_macros": {
+    "dateTime": 1619744778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e44443ca3224ccd4b3c4cbe299edd1794e81682",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y1c5xaq9nbiyi52zaapdbbhm7vmq6hizxmg0kd0nlyagd95smsx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec_macros"
+  },
+  "external/rust/crates/tokio": {
+    "dateTime": 1620867952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8514f864fabfd820d4c0e629f37ae7e5b541e4ed",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zjh0cik5kwp6vfisza3bifjyplp8ymc52navzgqyf2zc5x4lnvx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio"
+  },
+  "external/rust/crates/tokio-macros": {
+    "dateTime": 1613865947,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "590826a9bcf3c4b37c173d309e0dfe53b49fddbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0py405c2b4bci1gj7gf4swv8s80fzqncm8kppfv04xd78ph9mmwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-macros"
+  },
+  "external/rust/crates/tokio-stream": {
+    "dateTime": 1620954348,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a63f05373a3fcd6a536be1b870fb3252f8c7d1fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1369f0daiyy9yvbf9k3caifcnp7b2wjywy29if55kl0rb0pgs764",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-stream"
+  },
+  "external/rust/crates/tokio-test": {
+    "dateTime": 1620954348,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9d9c627eb7eb92fb8f1abed77f9e27e0fd36e6dd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r8ddxhlrqdi8qwwj9frqp40l8jzzp3jk2w3bmm31n97sp8ma0xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-test"
+  },
+  "external/rust/crates/unicode-bidi": {
+    "dateTime": 1619744780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65d88890dec7939642183eb17a85579518e92320",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r6bd31wn5nbs18rrgaf47gyrivlxd2rni86qm78f4r7kabzadhc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-bidi"
+  },
+  "external/rust/crates/unicode-normalization": {
+    "dateTime": 1619744781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cce5135ce46c95ad2646e69113d65c2887532bf0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z5amlnpv23q5n01093rx4j6byjc58yg1r1y0f0lcxxky293r718",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-normalization"
+  },
+  "external/rust/crates/unicode-segmentation": {
+    "dateTime": 1613865949,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "33ea694589aaf96a68599fe166a8a24a9553a164",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07fp8jn2fm4jpy523ifpc7fh9gsb1dqja1x9f508ggigmklgxhic",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-segmentation"
+  },
+  "external/rust/crates/unicode-width": {
+    "dateTime": 1613865950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5270ccc698944bc888eb84349ad6260f46b656f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xqr3v1kq561xbw126kj4xfvysd47sfj7rz4ld9pr9vm1nxmgr46",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-width"
+  },
+  "external/rust/crates/unicode-xid": {
+    "dateTime": 1613865951,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c7ec7a3a76aca99219218a2d5236b779456d0ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11j24rxm4r9zykcidasjhgiy37p1lqrmkpa7dl0rdb7c1hyj7lnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-xid"
+  },
+  "external/rust/crates/untrusted": {
+    "dateTime": 1619744782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67d1cd987e68d1c5162c9088ab6e26f479185451",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "135jcnwi4f8a5lx7lphdc9w9qsdv0xj63lxh7wxgkkz00d12hh93",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/untrusted"
+  },
+  "external/rust/crates/url": {
+    "dateTime": 1620443160,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e430d56a7afd362f9f5a6d50ee53e361b986ede3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wm10msikrg7l999qkrwddiy6q609j07agddz71gk83gar6nfid2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/url"
+  },
+  "external/rust/crates/uuid": {
+    "dateTime": 1616547925,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43a52b249b630726f0b5884abd002e25da08b39d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yi08nmd74fiixrpsjgrafqsa8lrzwcg7srhbsnf6j5sx7bql2jd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/uuid"
+  },
+  "external/rust/crates/vmm_vhost": {
+    "dateTime": 1620867958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efba999e49ed02f804446b3d7c3630469ff043b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vxy8rasfr2acj4p8hzg3ysaibfl4kz7f8sd8lp0frpph18v579d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vmm_vhost"
+  },
+  "external/rust/crates/vsock": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87b799a5349be667e51b1b61c3e357a465b46ad0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13x5kiyz72rcssg5ldfdq77ss5xq2q6ixixijcn4sq5411j75dmd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vsock"
+  },
+  "external/rust/crates/walkdir": {
+    "dateTime": 1617419127,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd5009ab0864ee81718381cea88a8da1277a5f61",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "081x2cvl8zh0xh0nb2402kgdv1pak1j5hijlh3iz3msndcsqgrmm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/walkdir"
+  },
+  "external/rust/crates/weak-table": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "82ceece3d48fd4b686c57399cf24ac96d9585251",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18hkrqykf2rh7hbwzvxmwr58ixybbi7m6sl9mvb3pwk8yf2qzq43",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/weak-table"
+  },
+  "external/rust/crates/which": {
+    "dateTime": 1618362337,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c0febd8b678233584058e89f27e4e99edabcc745",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0svgz9mn1d6a14dnhghvw102s82bjyk3s9kh5ja6h08kwch2yzv5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/which"
+  },
+  "external/rust/crates/zip": {
+    "dateTime": 1621811147,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "208b59c80e9c53f9d57136ed6f9a9371359a2e33",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07da00h2m2kar3r2r891jhc625d5z99jb03vb3c56135kiasnzqi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/zip"
+  },
+  "external/rust/cxx": {
+    "dateTime": 1618023945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5559df80e74afb898b4f9662ad5fe5cab0993daf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jlw2bpzhynqzgdaw4f23j41njwxhd47gi3iy64g29z6hqicmdcg",
+    "url": "https://android.googlesource.com/platform/external/rust/cxx"
+  },
+  "external/ruy": {
+    "dateTime": 1616029537,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8667028864e47eecaf69fbca20ca193e87f2fd0e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sl38mw33dcla901rq0dmw98lvpdsnwyis8fsxr5qkvar7fsfai3",
+    "url": "https://android.googlesource.com/platform/external/ruy"
+  },
+  "external/s2-geometry-library-java": {
+    "dateTime": 1615342012,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34991fc03966e76c2890f8455c51858484b0eb72",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x5lyg0jhcnyh647vyyhn28l7x3qgf3x7b5pasd732rqi6kkcibz",
+    "url": "https://android.googlesource.com/platform/external/s2-geometry-library-java"
+  },
+  "external/scapy": {
+    "dateTime": 1614909942,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5bbd43f0ee55fca2413624f3147c0cfe7370c811",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vq0sjbxagkkinxvzx77h6sxcvqlbl9fz9z5845q8kb9wrf2a0b7",
+    "url": "https://android.googlesource.com/platform/external/scapy"
+  },
+  "external/scrypt": {
+    "dateTime": 1612577137,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26fd1be0e507b32c34895ae3c000852dde251648",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12y4bhrw9wbp470b6pzpwcnxgy8nvlaskwa13vvpskyydiwxwr4f",
+    "url": "https://android.googlesource.com/platform/external/scrypt"
+  },
+  "external/scudo": {
+    "dateTime": 1624676750,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90043e500b9b174a4491bca673bf8ef9991c0f37",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02wxvm3fsg67aff80n5602ymxm45nwys3ygv7wrmifh1vk7rvbg3",
+    "url": "https://android.googlesource.com/platform/external/scudo"
+  },
+  "external/seccomp-tests": {
+    "dateTime": 1612577137,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8ba4603cc17e9643edd5f1e8a6693caf2ef7526",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "150n3hfdna544dfxw4xcd74idcz1c6rzdfzpxz26pv88ki79nzds",
+    "url": "https://android.googlesource.com/platform/external/seccomp-tests"
+  },
+  "external/selinux": {
+    "dateTime": 1621047986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1984648c6fffdb53b39600a2265b1e85c2491628",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19lc7df0wygsx22iljwg3528vxsib78ancc1rkq7xjdkhcv8nz7p",
+    "url": "https://android.googlesource.com/platform/external/selinux"
+  },
+  "external/setupcompat": {
+    "dateTime": 1623891961,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3243955966cbf7b07cfae32f2b78b72b9e973afc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rsphhzb4r70d2fp30q60d4zqpqlwcrdnvh3sg31m5nzrgljypmi",
+    "url": "https://android.googlesource.com/platform/external/setupcompat"
+  },
+  "external/setupdesign": {
+    "dateTime": 1625015184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4bec42cd1001c6b1df1b022a83497fbabede7da3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p528d0ilgj0hmbzb5mss0zdf6qlrlzhzias8ppaw8l3zv6yq28q",
+    "url": "https://android.googlesource.com/platform/external/setupdesign"
+  },
+  "external/sfntly": {
+    "dateTime": 1613952333,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "90e35af6024e9b7926dbbcd0845e917af3faa60c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kakd4icw5z61imziwk9xrvrmzr0kz0c3xkx7ajqf313jl9i895w",
+    "url": "https://android.googlesource.com/platform/external/sfntly"
+  },
+  "external/shaderc/spirv-headers": {
+    "dateTime": 1613613900,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e0186eb2d50b4f78abdf55ac246b036cd7d944d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1krwchhxqhsgjkj701884g0b40dh0j0ys78psi5g1mzvllbcnpq1",
+    "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
+  },
+  "external/shflags": {
+    "dateTime": 1613865959,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "666b55dca87b7688044339373844cd9bdea83962",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ffv97gprb7a2j3apfj97ss1ddj4l6zhpjacr63kxkwd4cd1sx5w",
+    "url": "https://android.googlesource.com/platform/external/shflags"
+  },
+  "external/skia": {
+    "dateTime": 1632177823,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "11717c7d75477a3a5d4c38bbd884193c65ec45c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06y1y8148wswb0y49ziax0yiw4d7v5glzp483dsx2pzn52ggkj97",
+    "url": "https://android.googlesource.com/platform/external/skia"
+  },
+  "external/skqp": {
+    "dateTime": 1613865960,
+    "groups": [
+      "cts",
+      "pdk"
+    ],
+    "rev": "a98aed3587804f79b8f25ecaf91ebf70f9ef1491",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rbdbripv9gbym5rannpyjycz7jc02rdsnf92l3ji6xz1k962a0c",
+    "url": "https://android.googlesource.com/platform/external/skqp"
+  },
+  "external/sl4a": {
+    "dateTime": 1628816766,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "472fe41c72da757f0935efd8068d0a45a7ea27df",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0arkj14xx0hjmkffka5v076y6lj9ikjyvf41y5qlb2aj15142n4q",
+    "url": "https://android.googlesource.com/platform/external/sl4a"
+  },
+  "external/slf4j": {
+    "dateTime": 1613531842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "adb5242be657ae59bcdf8c8f751a006a1faa5fe9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rqxhr85x42h7nl59j3hg9zdn3f8wgv44dk8g2nmvgzfd3l63ymp",
+    "url": "https://android.googlesource.com/platform/external/slf4j"
+  },
+  "external/smali": {
+    "dateTime": 1613865962,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df4d55ab4f0c5f555cc93fc81a693a49e107a319",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m2z3hm7q7hyqfabnw21sglarig5g5kjhv4b12387ckx9lzyxz9b",
+    "url": "https://android.googlesource.com/platform/external/smali"
+  },
+  "external/snakeyaml": {
+    "dateTime": 1613613903,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad111bb022abe95a54559a2bebf9b39cea5f4fe9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11fyx45gqx1rqbk9cghj8lliv7g7qhfrfdbif9r0zjrmq56ap128",
+    "url": "https://android.googlesource.com/platform/external/snakeyaml"
+  },
+  "external/sonic": {
+    "dateTime": 1612577143,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d018a3fcae39106f31a7bdb794d187afe50d94b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17yl2bd3zy8wf0s2snz5734w3appr33c5f3f0jayw9crzdb8kksm",
+    "url": "https://android.googlesource.com/platform/external/sonic"
+  },
+  "external/sonivox": {
+    "dateTime": 1628730364,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "56bb64a1dad530e6b05d70fbc56f0ffbbb5a4f56",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1h04qlhr8cv0xxicw1ylmnznnqizbds7j150bxh2bgyk2nkja1p3",
+    "url": "https://android.googlesource.com/platform/external/sonivox"
+  },
+  "external/speex": {
+    "dateTime": 1613865963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "672c5526749ffe062ebc09f34d1349b9bfda5043",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b4iafcxynjq2y0i6hh3j7wgqzr51bnqm09ngwql72d12g7pvx8v",
+    "url": "https://android.googlesource.com/platform/external/speex"
+  },
+  "external/sqlite": {
+    "dateTime": 1628910363,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2e035c4b02cbf3f04374da7ceda00303d9b45a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nfx4l4ip228y03p6wpd5rwyq0sl8101xscgr3nb981vn2b8nny8",
+    "url": "https://android.googlesource.com/platform/external/sqlite"
+  },
+  "external/squashfs-tools": {
+    "dateTime": 1613613905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a94d96ea2f076a5deeab064b69946c12a39ea6a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18yry9s66q0569l6kgnavxd84lpgqqg2zh7wqad7i7ca8kppagqn",
+    "url": "https://android.googlesource.com/platform/external/squashfs-tools"
+  },
+  "external/starlark-go": {
+    "dateTime": 1618095956,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76315269348530d9a98a7023c65780ed9b33030c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kq1npxz7skla11q33az976l0kk4n5wpf3djyrhw0kglcd176vi2",
+    "url": "https://android.googlesource.com/platform/external/starlark-go"
+  },
+  "external/strace": {
+    "dateTime": 1613613905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7f1486a23a56341905def4ac94f6327e261c6630",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rx0660d6z6s9id9mh8kjbmalm7qj38qrc3557k817iy81ac6n3g",
+    "url": "https://android.googlesource.com/platform/external/strace"
+  },
+  "external/stressapptest": {
+    "dateTime": 1612577146,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9633c78edcbaa1b53f9f68cfdeb48759e985cdcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q9kbldax37x783ijnbwsr052kmqb87hs0m6z0cpnw29gdkmfai1",
+    "url": "https://android.googlesource.com/platform/external/stressapptest"
+  },
+  "external/subsampling-scale-image-view": {
+    "dateTime": 1616029550,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb7a9ad7073b3afe62b303bd29bfa73da49411a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0brk3l0gd33d4h8rjb06r7vnlaz821yc3bhpsyskvfv6inkpxh1s",
+    "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
+  },
+  "external/swiftshader": {
+    "dateTime": 1615865686,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d73cee9578d44843aa1875a1bb515ae3f38e5ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19drp33i5ha2qlxj3xgv37s8lxx0h0gmzh834fga2ydiazc2lprx",
+    "url": "https://android.googlesource.com/platform/external/swiftshader"
+  },
+  "external/tagsoup": {
+    "dateTime": 1612577147,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3a2f17641b19cd762e1eb3cf54b74bfcafd4eb4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "092v7vx5md9lkgsnds9iaknsx7n1hm7daazy3icmahiwkq3fs684",
+    "url": "https://android.googlesource.com/platform/external/tagsoup"
+  },
+  "external/tcpdump": {
+    "dateTime": 1613613908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3070b3ca72d698d647d5f392dfa48d2be16f27a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sy5691a5g4lbdzq449jlywn2pl7g57bfc5a70238ivdi57351bs",
+    "url": "https://android.googlesource.com/platform/external/tcpdump"
+  },
+  "external/tensorflow": {
+    "dateTime": 1616720769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8361462ae1a3b7ab717e2a418c45dd76dd9f579",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "163p13dy1ghbpii05y2z2ljcnaf6w40i1cbd1ipv0wbf2pi57d7y",
+    "url": "https://android.googlesource.com/platform/external/tensorflow"
+  },
+  "external/testng": {
+    "dateTime": 1613531849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49f82ee54d89f7870cac4b527ec187b2e746146f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06hxhlmx7958xbfj925xcmmzm5h3s16jxwqcahh5yp4zzn19af37",
+    "url": "https://android.googlesource.com/platform/external/testng"
+  },
+  "external/tflite-support": {
+    "dateTime": 1616547944,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30c532cc73cb5d8a68948975dce1cd405fe82529",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00mj6sp3h53wpwgyfwmnxfch4j53sfbdijfrwg1n4g0ymafr2adr",
+    "url": "https://android.googlesource.com/platform/external/tflite-support"
+  },
+  "external/timezone-boundary-builder": {
+    "dateTime": 1595933888,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "388a20214ef46feca6ee3650c01d834a63082e4f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09laamss9pk6q4fbl6gppz8d8ix47qvazqd3r8x4p36qga68n6wc",
+    "url": "https://android.googlesource.com/platform/external/timezone-boundary-builder"
+  },
+  "external/tinyalsa": {
+    "dateTime": 1625188099,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e5d93422998b40f968e17799da678500eeb3a0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ka8qwa9j78gsiygs7rlk78lf79yir26202rf0j26xwb5aq2rw7r",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa"
+  },
+  "external/tinyalsa_new": {
+    "dateTime": 1626743186,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "023d39bc4b994f8afcaa5c74113dab78c7ea7e4d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jjl611jjrh65kk92zdp5y5jar0qyfrcv2yz86wsf71rld5ljm48",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa_new"
+  },
+  "external/tinycompress": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c432cf0f840f0032ed5a515f17135f78254a59b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "148k9dgzbrrrpx8c1f8plv9zdv66m0kia8ijc0j4mgfz05cnl0wa",
+    "url": "https://android.googlesource.com/platform/external/tinycompress"
+  },
+  "external/tinyxml2": {
+    "dateTime": 1613865971,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df8cd3ebba8206f359ed8fcecbdcee293618e7b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02cns5hw21sqy0vdd7601aj8v4cdi4rzm08fvpf8xav04xc6n4k7",
+    "url": "https://android.googlesource.com/platform/external/tinyxml2"
+  },
+  "external/toolchain-utils": {
+    "dateTime": 1615428340,
+    "groups": [],
+    "rev": "3a578a49c4e0ab2b970a69f4aa62f19a5412e2e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pi0shn1aqwn59yxids5v0jnbbhn3gafplfhp5iy9waazwhl3pfd",
+    "url": "https://android.googlesource.com/platform/external/toolchain-utils"
+  },
+  "external/toybox": {
+    "dateTime": 1620515162,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eeaf395760cb9cc4710a10edf05196be0bbca56b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19msz3f8ggk2qy0xif0m92aa528phlg74ibssy2b447yj735vkrn",
+    "url": "https://android.googlesource.com/platform/external/toybox"
+  },
+  "external/tpm2-tss": {
+    "dateTime": 1613531853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b95e0eea0345c69c03ebe56ead7a0bfe8b10516",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11niy75h4yrwp73sbrx24v36l20syyl77cvnfy8lnxz51khs73g8",
+    "url": "https://android.googlesource.com/platform/external/tpm2-tss"
+  },
+  "external/tremolo": {
+    "dateTime": 1620263179,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b141a0bf37f8027648be568ad7db8cfaac6a6172",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13258aj3bjycaml8gqyw2ij8sxkcriva2i1pzv8pi9i91n23qk2v",
+    "url": "https://android.googlesource.com/platform/external/tremolo"
+  },
+  "external/turbine": {
+    "dateTime": 1613531854,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5333e230a7f8d78c503155f56aa8c711d14da3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m3n7da7cg181nd9y80fm6zg7dr6i26baxg47yxkgls1agc0garm",
+    "url": "https://android.googlesource.com/platform/external/turbine"
+  },
+  "external/ukey2": {
+    "dateTime": 1613865975,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2376bd89fe0612e4eb0b221042bd58e4452d0059",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wprw0h3d5qvzikh24b019506fwmjgzah0j0lmdraiv24vqspldj",
+    "url": "https://android.googlesource.com/platform/external/ukey2"
+  },
+  "external/unicode": {
+    "dateTime": 1613865974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa9360246f12e1e579c0007111f36efe22886083",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12d79gr4w732rz15dnqmgmfxs0kji8ih5sp1l5pksh3ak0z0syng",
+    "url": "https://android.googlesource.com/platform/external/unicode"
+  },
+  "external/universal-tween-engine": {
+    "dateTime": 1613613914,
+    "groups": [],
+    "rev": "7a6bc1a677efa8ddd05a2c8c553d0407d5273031",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ah027mh8lgrsdcqp8pbv1l6gcxjxaj8ksyji4v244awrqdhmpx0",
+    "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
+  },
+  "external/usrsctp": {
+    "dateTime": 1613952352,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d0a448b27d08843858f85b5b0bea538a0deacc8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ys21xj86zc4rx0x49d3r62mdi8kwx4035xbyslxqs4qlrai618c",
+    "url": "https://android.googlesource.com/platform/external/usrsctp"
+  },
+  "external/v4l2_codec2": {
+    "dateTime": 1620867984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4d3613eccd79d18393500b058e1c30cdf53f3b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10j7qfbd5dn5mycywxr8a6j19px7rz6nwwxijr8kdkkxkr2lsb4b",
+    "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
+  },
+  "external/vboot_reference": {
+    "dateTime": 1613531857,
+    "groups": [
+      "pdk-fs",
+      "vboot"
+    ],
+    "rev": "2d4fa8d21f6cbfa8f9d10234c1e9749d97656f0c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0dbrh8hy96vrfdxs7p4vz6y7k256sr6rk9dn1d0nk69pzf58xssa",
+    "url": "https://android.googlesource.com/platform/external/vboot_reference"
+  },
+  "external/virglrenderer": {
+    "dateTime": 1615075605,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40408c0b62b98cccc81a9d0e97d97713c4b18e22",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m5588rz56xb42hghfkqw5qp5s4mcwcwy97hqnrxcl4sbngmmpx5",
+    "url": "https://android.googlesource.com/platform/external/virglrenderer"
+  },
+  "external/vixl": {
+    "dateTime": 1620443189,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5adec01acddc1d40a37f8a7fb0f97e74b4ed979",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kgrgqmprmiy2rha9idcqljy7xixgn9cs64vwx3b8swpb08bymar",
+    "url": "https://android.googlesource.com/platform/external/vixl"
+  },
+  "external/vm_tools/p9": {
+    "dateTime": 1613865980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c3a34bff8dc70cd2e31cb23fc304b16e9dcd9af2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0iwq1zq7g03drxl6a8qn079a0ijc16s1yp6c3licqjdddqg74gx2",
+    "url": "https://android.googlesource.com/platform/external/vm_tools/p9"
+  },
+  "external/vogar": {
+    "dateTime": 1619744815,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "875f6ea7c4642de5b10800d79d68697455fa27f5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0pzid6jal940rcrimdf22128c458rkjqalnhz56k8mh0i049pzgg",
+    "url": "https://android.googlesource.com/platform/external/vogar"
+  },
+  "external/volley": {
+    "dateTime": 1613865981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e43d189e7ca8d04491a949ccd8e869f3a7f0a28",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1679hx3m8h1k6q8c38pqam01dsbdvrb9y16ylxahi53cc1xqj9c3",
+    "url": "https://android.googlesource.com/platform/external/volley"
+  },
+  "external/vulkan-headers": {
+    "dateTime": 1619658372,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94dfc56b617c433c00229fa28e0473e92e22dce7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04dgizyvxg2p8s46n8ha24yhjmxrzqvaqy8w9v6q5q9v62z2qix0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-headers"
+  },
+  "external/vulkan-validation-layers": {
+    "dateTime": 1613865982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "95e50d66f49a6029cd8de434eb478145ebb988e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b07rm2880j171mswhqmppf6mn2ijrdl3hz6bicaw41cixz4ckm0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
+  },
+  "external/walt": {
+    "dateTime": 1613865983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7fe05fee8abb6f2c2cf7d5c21b0981f55d730de9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04g2zdf06pyk0k6s9ss6yswannhjqhz2m60msq206nvl1qdz81l1",
+    "url": "https://android.googlesource.com/platform/external/walt"
+  },
+  "external/wayland": {
+    "dateTime": 1615075609,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9410fb6a6ac36a801f4ece572dd322f3f00aa815",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03wp3x0k8lys9jkm4arkcf0zkc9xal2jx9yhi2j9j3qk4h25pi4l",
+    "url": "https://android.googlesource.com/platform/external/wayland"
+  },
+  "external/wayland-protocols": {
+    "dateTime": 1624676777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a6cca4173350d7dbe82f0e2a7d5fdf3903acf54",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1znvrprlp128kakcp5f1zqdx0r619hnbia9b64cmfqibmqfdhplm",
+    "url": "https://android.googlesource.com/platform/external/wayland-protocols"
+  },
+  "external/webp": {
+    "dateTime": 1613865985,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "d61da4959b88868aea8a0942c75b4b7108c91eaf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15zv6w3wcw11qwx5f95p5cxb1dbrfkyzlmcl6w5dx9wn0cyxjd55",
+    "url": "https://android.googlesource.com/platform/external/webp"
+  },
+  "external/webrtc": {
+    "dateTime": 1613865985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42ee4e51ec8383fa2319433d7980922e0f6f802c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00jjyl1zwgqdzmakvgsw6iyasiz1y9fwh2k3n2yff0050vk6499p",
+    "url": "https://android.googlesource.com/platform/external/webrtc"
+  },
+  "external/wpa_supplicant_8": {
+    "dateTime": 1628305589,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a6cdb02fb4454171ce7e791f1434e7fcc59d7f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d9g4x2lvixzkqb44dqzvcyg0b043ihi9z2gdc71jqhcxgj2d6pb",
+    "url": "https://android.googlesource.com/platform/external/wpa_supplicant_8"
+  },
+  "external/wycheproof": {
+    "dateTime": 1613095562,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2a933cef9ca9efd29737b121ed82a9d2e6ee289",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0waib4n8k684l4nl339w9h1f5g52461qh51kk1inknj2bpvy78vn",
+    "url": "https://android.googlesource.com/platform/external/wycheproof"
+  },
+  "external/xmp_toolkit": {
+    "dateTime": 1612577163,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7783b038f4bc8391cacef9c1c636b3aa1049add5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vni2h737zxzcd9lg7fgxh3vv88508kn1kli04nh2cqmld9a9x1v",
+    "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
+  },
+  "external/xz-embedded": {
+    "dateTime": 1613531863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b544500057233888bfeb96ec1db788c54199b714",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "073plk8szhih5chpaf91jfi9w3f8sgx3s38y79zk9g11mms40dpl",
+    "url": "https://android.googlesource.com/platform/external/xz-embedded"
+  },
+  "external/xz-java": {
+    "dateTime": 1613613924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2534dffdc46289f46a80b10665d1851cbba6508c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "106wni1mvkx7jjag4401v8dkmqrl7kyd17a8nlik0wqwai9akmbb",
+    "url": "https://android.googlesource.com/platform/external/xz-java"
+  },
+  "external/yapf": {
+    "dateTime": 1588648216,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "cda6db1a6a280d89e125957b39282a91ed4b1f3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04cxpdc46h0z75d2b8a73lx3x25k881qkps309sa7irxvqjlq4av",
+    "url": "https://android.googlesource.com/platform/external/yapf"
+  },
+  "external/zlib": {
+    "dateTime": 1620443198,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2aec429961a774c51b503b6542f1c30b94a36c47",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12640wzjmqgjdya2zdb14ir5d3q1fds04hs878wsw8jw84aw3jkp",
+    "url": "https://android.googlesource.com/platform/external/zlib"
+  },
+  "external/zopfli": {
+    "dateTime": 1612577166,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8137adf80020540061deadf2f1bf2145d655a172",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y0lrn1mcw9233dr93361d0mjwpqlsrq4d31l1kgr1lyfdx2lf5l",
+    "url": "https://android.googlesource.com/platform/external/zopfli"
+  },
+  "external/zstd": {
+    "dateTime": 1613865991,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1416d650c78e7aa0cdcbdcedc12a9372816693b9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nc7pf97s580c66hyd11zjcj1ah7dd2ls3nkgdia3qmrfphwl74x",
+    "url": "https://android.googlesource.com/platform/external/zstd"
+  },
+  "external/zxing": {
+    "dateTime": 1613613926,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cee789ff50c305dd8fb5e101016a758d7c47e849",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hn3cmj8msdwggbqzaqvscri38df1j35c921i2k518wikghi7wh0",
+    "url": "https://android.googlesource.com/platform/external/zxing"
+  },
+  "frameworks/av": {
+    "dateTime": 1632365187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f802e36be4988dce3326868d828d921233cf1a9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11hrpl4y1i8a11fdawaxyrawknm9lfb3xpz74frjjvcx3731rriw",
+    "url": "https://android.googlesource.com/platform/frameworks/av"
+  },
+  "frameworks/base": {
+    "dateTime": 1633492568,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "947cb478a60dc7575b11946a861a1b5b73556499",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13z7g7gn107h15ybh0n65bfj77zvgsbpf90jx58yq9sxvc6xw8fj",
+    "url": "https://android.googlesource.com/platform/frameworks/base"
+  },
+  "frameworks/compile/libbcc": {
+    "dateTime": 1613865993,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ff1ac94d9a411ca39b746e4e616950d853792a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n03c58wxfp76z0hk2y93r6jfhi7rvrbmv5iwnj6gy9aw6a5a4fg",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
+  },
+  "frameworks/compile/mclinker": {
+    "dateTime": 1620781592,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ca46f587fdf26cd9e2a08eca0154cbf5e05d31c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "162nkr6acndsx278g31ygazpv9raxigb69qnic1sv97n94v7yyvy",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
+  },
+  "frameworks/compile/slang": {
+    "dateTime": 1620443205,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34526119dcadbefb845991b699c9fa9ebc04958b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16jzz2xrgipqlp8ixmssapxpqnhyz0x8rlwkv52v6g90psl25jl8",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
+  },
+  "frameworks/ex": {
+    "dateTime": 1628910392,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c3a8c4c7c525dd81a3679191b8315d2b879a12ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pr2k2a0hk47khbl1bp9ljxcw95k78b37qbkql9vh51r89hrhyis",
+    "url": "https://android.googlesource.com/platform/frameworks/ex"
+  },
+  "frameworks/hardware/interfaces": {
+    "dateTime": 1622077676,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72c56af08345ad9e44d969a19babb57f13f62cff",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ddxzhisgwpn2k13zkk6a0adbpiw954wfd0y9spy34qd2hzwwagh",
+    "url": "https://android.googlesource.com/platform/frameworks/hardware/interfaces"
+  },
+  "frameworks/layoutlib": {
+    "dateTime": 1619053601,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "904456acdeb055188ea2c501e2d33f62cc2662ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1cw2y7xcd3w1nzljvzgckli8d328y5xxj5ynmxpnszcrlyiymish",
+    "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
+  },
+  "frameworks/libs/modules-utils": {
+    "dateTime": 1623978408,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "db596058f1b43996bae9606b896d78cc340e643f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fsixxvkxw1g26jjlwmmrybbzzwgxl1gswbilyk73dmf1cnmx711",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/modules-utils"
+  },
+  "frameworks/libs/native_bridge_support": {
+    "dateTime": 1621559261,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db0d2123c37becff5c02d36ec78e5c3c34773991",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1babnp0g01f25albrjsyxyc68n9j3hd9wwizy1vn01b3r1pyy08i",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/native_bridge_support"
+  },
+  "frameworks/libs/net": {
+    "dateTime": 1625620006,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ac0fc2c110eead4e26c46c92a80d0a3bffb3fb95",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "186ahnr1j3jxslc7nr2kkpz35ayr9pj5r0cyxv6szalzrizy47gy",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/net"
+  },
+  "frameworks/libs/service_entitlement": {
+    "dateTime": 1627520793,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98130d834c059f79c367ef26b990d2398af7e15e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z9kin6rn0dh7h1av6larf9swnzcni5ckjc4v8pzyrdvff9qj3l3",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/service_entitlement"
+  },
+  "frameworks/libs/systemui": {
+    "dateTime": 1627002388,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "abb5c9f95304f463c2a3e6bbf5ef6a175856c2c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rjycdga1dqgzh897h9zla9pm4j893n920nz2f92bvp0zfznza6r",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/systemui"
+  },
+  "frameworks/minikin": {
+    "dateTime": 1623805618,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "50b3c1517f95491da2ca1c45862e16f2810a3dbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gja9jpb28rzvjk25ii48vq8mzlnsrhv3ja9k9xmab0jhkpfam99",
+    "url": "https://android.googlesource.com/platform/frameworks/minikin"
+  },
+  "frameworks/multidex": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "98610ada06c468c27db73902ad13713422e20d39",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xwqn0ik1in5rpwnr1xygbggjm8ysiknp2hvf2m24859zg90lng7",
+    "url": "https://android.googlesource.com/platform/frameworks/multidex"
+  },
+  "frameworks/native": {
+    "dateTime": 1632177836,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14ba8c131dd1babf01f0bde1639e717f5bb83e5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ddagwl7izkqlrhcxf0izz9srdakj1c95ggd4hsji5g9gggm08w0",
+    "url": "https://android.googlesource.com/platform/frameworks/native"
+  },
+  "frameworks/opt/bitmap": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4bdf1b6bb2d7eabcff31c4f98f581a1bd7d518bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ipvhhkj8d1fpixx5s51133k87riqdczaarw9lnr65anx4s781sb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
+  },
+  "frameworks/opt/calendar": {
+    "dateTime": 1613531874,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bd9499775213577e7478de7dc0eabe4b62c54703",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jjj2y6qsj5q20fj4rr1kbx7cn233myv6yk5l2j23x41nryandd2",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
+  },
+  "frameworks/opt/car/services": {
+    "dateTime": 1625188142,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bfa562c993efd28a4258a3154c1039f26c33f79d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "199qvczry0qcqzbdhfbjmfx2waz22g0hxm5kb8m11av418r0f9nm",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
+  },
+  "frameworks/opt/car/setupwizard": {
+    "dateTime": 1623805622,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35415c04c89776ba0112dccc473c9b83e860f30b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y0wyd226asm425nqbjli4m37q2v03g68p4l3dngb47ff7pp1pbl",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
+  },
+  "frameworks/opt/chips": {
+    "dateTime": 1619140284,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a80b111acc1601e604962bcdbbcca947fe503d59",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z3xilnl0krfs9d6dq9yb1gqx4hgvrdqsbw4n04m81gnh4kqg4q8",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
+  },
+  "frameworks/opt/colorpicker": {
+    "dateTime": 1619233602,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5dadbe0eadf1d1a033a6fa02badf6e6a74c5caa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vvn2sc29sc2yhvk5lz0gcdfb12321w4bcy24xkqvsnfsyddc877",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
+  },
+  "frameworks/opt/localepicker": {
+    "dateTime": 1619305596,
+    "groups": [],
+    "rev": "f766a09267faf76d4826567a3cdbed91e2c1d19a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r125r6xswixm6b6d68bzc489h6xhb7s0bjgs8fnay4vbsq4419s",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/localepicker"
+  },
+  "frameworks/opt/net/ethernet": {
+    "dateTime": 1624410403,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1d2d01a66c62e219875013505567d0aa91568c06",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1w5v0hr8a7qwrnf8f63fb6lnw19hggzjp7a1wrpfg1l539jaxv8k",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
+  },
+  "frameworks/opt/net/ims": {
+    "dateTime": 1626491233,
+    "groups": [
+      "frameworks_ims",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c5b187387ccbacfd71419d72a2defeaaf330ff68",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kr5h0khwphxr2f5nk8n1xgla4j1sk4h4nrrrxnp7n8cpwylfkqz",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
+  },
+  "frameworks/opt/net/voip": {
+    "dateTime": 1622682413,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "3517dc548ab21322d6e9870499261a73b4643edf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y3mffpp81hgzkp9qlwl49s82b5zlb2vbznxc3x5hp5kv2p6i7bi",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/voip"
+  },
+  "frameworks/opt/net/wifi": {
+    "dateTime": 1628910402,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "761a7d9683ec6014748f2b61c0b7015ff5b7b96f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1714q942yr3mfpfzwb3dzcp3zgrm67cibnx0887db7zcfjbzcknr",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/wifi"
+  },
+  "frameworks/opt/photoviewer": {
+    "dateTime": 1625015232,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "95460e522073845948bbaa380bbe23b2ae987aa2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rr6vxkks9g88zgrh9xzqpk3cgr4v5xpdb92dzxspq96il8l5nfl",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
+  },
+  "frameworks/opt/setupwizard": {
+    "dateTime": 1618535199,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "aac4390fcfe45e46b0b9b61c80ef985c143aaaca",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sdvs3n3nxd0dflqyjqqhf0g1drznwqrkbd4qv5za5n0g9dqg5x1",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
+  },
+  "frameworks/opt/telephony": {
+    "dateTime": 1632178056,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd1ea7056b4b78f50d6279d0444994690275acd4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03yfgl77apdnjidz3n2q22q2608lrj22jq026q006ija4z7y1kss",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/telephony"
+  },
+  "frameworks/opt/timezonepicker": {
+    "dateTime": 1626491236,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7f23711e0cc20810c317188fb99b27af4595e6a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pgbn75f41vwm94cdkaghhxm5dwizgsxm1a8l33s6sfva5f8vsny",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/timezonepicker"
+  },
+  "frameworks/opt/tv/tvsystem": {
+    "dateTime": 1620263234,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e184d672adc2ff541057764951859b8f86862305",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1008lz757hs6yjl71xcblv8lny21xlkvsh70sbqnv7akbn4pk3m0",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/tv/tvsystem"
+  },
+  "frameworks/opt/vcard": {
+    "dateTime": 1613531879,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "79b148bc9a1cb74184fa4bd9d94b93221f565e40",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ahqdbqw285rpk7cnsjq0fzb60jmpf5a5z32vz52apxlg68k5l1g",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
+  },
+  "frameworks/proto_logging": {
+    "dateTime": 1627096016,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "88ff7b14e6e145a77b3a147570b19502443213d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05nvs6wn2jch1y6anv4bvpsmyv0sxl2jjsmlrzhymil0bfadrp12",
+    "url": "https://android.googlesource.com/platform/frameworks/proto_logging"
+  },
+  "frameworks/rs": {
+    "dateTime": 1620263235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04a57e6a7bd766da7e2d08f27f47607b2ccf95fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gybw0hsp2p5mm7g2v737kg0ca5nys2f0333p9ma19sz5dyww3ma",
+    "url": "https://android.googlesource.com/platform/frameworks/rs"
+  },
+  "frameworks/wilhelm": {
+    "dateTime": 1623114395,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5f56ff0ce7a19343c58a99a3e023d7a2ff883bac",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nf5sx9zjs2ybcp4fqwzphgan379l83fml58dhs5x4f24rj80bxz",
+    "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
+  },
+  "hardware/broadcom/libbt": {
+    "dateTime": 1615943190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1f3007fa4d2f9b155b31085c2b275d119eaab80f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12945i09sz39ygg91szzabmw7kmhasn9b18sb2v8fkxxzqcy7nih",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/libbt"
+  },
+  "hardware/broadcom/wlan": {
+    "dateTime": 1628816816,
+    "groups": [
+      "broadcom_wlan",
+      "pdk"
+    ],
+    "rev": "a7a2503b14ec090c818e4bc7bc6fa6d5d543e6b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0js038a7cjyxkqv6kr6q4bpn23zjzipcjgxg5bwd51c4glxjww6w",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
+  },
+  "hardware/google/apf": {
+    "dateTime": 1613866010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "badf3f7a4904b05c2cf61798d93c7ed3bb9b9b66",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "144hxkgnbh4jvm5a830mjwsj5zcp4z0g61731r9vj9kx8kaxqxrr",
+    "url": "https://android.googlesource.com/platform/hardware/google/apf"
+  },
+  "hardware/google/av": {
+    "dateTime": 1624583232,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4cfc640e108d2c1771e8724cfc0bb0ccd24f7ad9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d3h8g5fbvqyxj8v7q1b2y049gi17wq8dd32yv2671f5rv5a668j",
+    "url": "https://android.googlesource.com/platform/hardware/google/av"
+  },
+  "hardware/google/camera": {
+    "dateTime": 1627700807,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52d535b0e8f7e95f5073d5cd2db3415f34cfb546",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fnbf8ahb9rvaarrlvrgjh7yf4awbh586gka3n5pgx034856kzs1",
+    "url": "https://android.googlesource.com/platform/hardware/google/camera"
+  },
+  "hardware/google/easel": {
+    "dateTime": 1612577205,
+    "groups": [
+      "easel",
+      "pdk"
+    ],
+    "rev": "86b861f7a59f26137893fed35e31bbb97bd08cb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0a8hgw2y5z36vqn9ifwsci7bn6qznz1kjzvswhzif2cag7249nvh",
+    "url": "https://android.googlesource.com/platform/hardware/google/easel"
+  },
+  "hardware/google/gchips": {
+    "dateTime": 1632713984,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "9c78a419879397cd721e395491cb65f70a7b5d92",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mzg8mfv1hzi82magc2p12zfwhwg48yv5mmjj3n8xshsiakah4zb",
+    "url": "https://android.googlesource.com/platform/hardware/google/gchips"
+  },
+  "hardware/google/graphics/common": {
+    "dateTime": 1632464572,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "abf7a3c2aee1adf628340d900f724b0711507a86",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18z54c53xrjf92h80cv2s3a6v2f56h0xcm2gma1bm1y51a5afi2i",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/common"
+  },
+  "hardware/google/graphics/gs101": {
+    "dateTime": 1628730412,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "6a7718c39d121c6f5f02cecd8b0d48741f30eca4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pywy3cap4sj2wmlf0yicm9ag79rv5vksnhqd9y8265mwz1gkabx",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/gs101"
+  },
+  "hardware/google/interfaces": {
+    "dateTime": 1627096021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "caeedf8f35a8be29e12682e4e9c3429fa15e6b11",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0da22b907fa4qg6ldjyr24bj09ckaglg4pa2r9ycjc0frlnb6xwk",
+    "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
+  },
+  "hardware/google/pixel": {
+    "dateTime": 1630375532,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "ddadb88df1a1bd91b92bca14a41a58baae8d37b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nyvsb7lppgp0n3k1v04vpld30n30hm5ibz7kf7hqvnzj3ihixqf",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel"
+  },
+  "hardware/google/pixel-sepolicy": {
+    "dateTime": 1629441557,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "ca95bceee2b02d43797e3fe6d575dc23a76f0ff3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0dnmq2hfngyjv80pnkyizfmh1fknpz6rik0p7rmxw05i0i040cwq",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel-sepolicy"
+  },
+  "hardware/interfaces": {
+    "dateTime": 1628910414,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e646bb036a32e65ef87b7ae4b0d428d7dd8f6eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15zwgamfjq5z07r34amlzbzrbszvvh4rgs03j1vpfljvfbfgaqnz",
+    "url": "https://android.googlesource.com/platform/hardware/interfaces"
+  },
+  "hardware/invensense": {
+    "dateTime": 1613866016,
+    "groups": [
+      "invensense",
+      "pdk"
+    ],
+    "rev": "ab74f96352536638bc5a5ce9401a569a06103e34",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12sqj3i0avyqpl6nqi8flaskfqlsfvvxzllskkfa67n9cknnv2p0",
+    "url": "https://android.googlesource.com/platform/hardware/invensense"
+  },
+  "hardware/knowles/athletico/sound_trigger_hal": {
+    "dateTime": 1614910008,
+    "groups": [
+      "coral",
+      "generic_fs"
+    ],
+    "rev": "32b27a0fa990a6eb63e8d41be1ee12f2d8076ce9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zh4cb9rggg5in2ha4sil7qn28m97iwldwn7d07nz6xyqiwxd4i8",
+    "url": "https://android.googlesource.com/platform/hardware/knowles/athletico/sound_trigger_hal"
+  },
+  "hardware/libhardware": {
+    "dateTime": 1625533599,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b56cecb99420b77d9f26ddd71cd7e4befe8c6307",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14qdi7lc6a0327zw8fw81zdz33xk9j1pkqq6gkmpzh5wn3ngvwii",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware"
+  },
+  "hardware/libhardware_legacy": {
+    "dateTime": 1618628830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fb055e73f053a14e2eaea96974609f154d23673",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v6v220b8gmjz9qnpq83wjwd6jircnnlkr4grnj14d24bxy3b1ar",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware_legacy"
+  },
+  "hardware/nxp/nfc": {
+    "dateTime": 1632177823,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a9e5312a427968fb9aeaef6661560522c9c8a5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0234v6a59lc8xwwywpwzz864jqjj4bd51j4dzcyq1s7nx4nnp0nj",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/nfc"
+  },
+  "hardware/nxp/secure_element": {
+    "dateTime": 1621991242,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cef870590fc7f32babd0b248ce2eb186ce158719",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "063k3nh3vp9nffvq2gl3zirn2wx9hna8z67fkcdj30f9bm6vglcq",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
+  },
+  "hardware/qcom/audio": {
+    "dateTime": 1619658423,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "964adb89718325d46f8218b953daaca3a11e2430",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hikyx0hvmycblqpapviqbjkf890b6cn4yqpiyrs4w4isbf8w37j",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/audio"
+  },
+  "hardware/qcom/bootctrl": {
+    "dateTime": 1613866018,
+    "groups": [
+      "pdk-qcom"
+    ],
+    "rev": "1ad2a4b7a483f3baa42109bc1d997081d4c9754f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04dv3a0zj03af7g4c19kiif4v1gff0fby467kh3ji440y4z00r31",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bootctrl"
+  },
+  "hardware/qcom/bt": {
+    "dateTime": 1612577213,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "f2eeff704f55b19f42c32e2d04c8b56905a65dca",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0a6h3jcprciwxjq86nfiiij8f7475mah4qgxgsfdd2b54cy37jbc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bt"
+  },
+  "hardware/qcom/camera": {
+    "dateTime": 1613866019,
+    "groups": [
+      "pdk-qcom",
+      "qcom_camera"
+    ],
+    "rev": "6d0d201c1974b19b44134e858e04b14414892f60",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p2932v9hsmv6i729zvzq0fypxcdh7xdhfyiz57pspm3xpv7f9yk",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/camera"
+  },
+  "hardware/qcom/data/ipacfg-mgr": {
+    "dateTime": 1613866019,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "b6be2877299be49088c438df3fd0380b632cdd1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11zhb0diqxlz9vsxzbvxn8pv6amxrclvqybnr5acbs8awlc6h6xg",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/data/ipacfg-mgr"
+  },
+  "hardware/qcom/display": {
+    "dateTime": 1613866020,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "91382e5b09ba735849af6a18373c0bffcca4f689",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1w8fr68drhj6wjqvla801wianxb71ybpxwfia4v7mjrf7krs09a2",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/display"
+  },
+  "hardware/qcom/gps": {
+    "dateTime": 1613866020,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_gps"
+    ],
+    "rev": "ee906ab6a46020a6b0bc4e69bb8e9d7261888750",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0r99iirahalmj8w9v93cqi9lhandavj88jqwlcgd01czlrynwm9x",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/gps"
+  },
+  "hardware/qcom/keymaster": {
+    "dateTime": 1612656400,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_keymaster"
+    ],
+    "rev": "849a2715881aa0b769a6b03afdf7adf5a9d645e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09882azkwai7h3xdr0krqv4d5k63qdyvpwzcw6d16wljbfkf525r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/keymaster"
+  },
+  "hardware/qcom/media": {
+    "dateTime": 1613866022,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "7b8daa7e1144210995de9e683a0c313e02d2bb8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1djq7k9gi7d359cdif0rysfprcfs16sjmfjqkj88a6px9sl0mdy8",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/media"
+  },
+  "hardware/qcom/msm8960": {
+    "dateTime": 1592363746,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8960"
+    ],
+    "rev": "5104c4f71a51e4745da0a5322730654999ef9853",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13ss8wgnd4306024174vsfv6ka2sf45jzx7d4b8z5ywcpqiyczwm",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8960"
+  },
+  "hardware/qcom/msm8994": {
+    "dateTime": 1592363679,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8994"
+    ],
+    "rev": "5a57581afc654405cd7c393a451058589cc64be3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15zxcb9dx1862fvasyn11iav765a3522my4mxby5iymjax8sir99",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8994"
+  },
+  "hardware/qcom/msm8996": {
+    "dateTime": 1592363678,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8996"
+    ],
+    "rev": "c9908f7c2f0da6a2b027251f49a4e39dfdfcec73",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0g381r0mv2rv0yzq0qw2m65z6a6wx2wsc14xln7q9pphn7x7kfyl",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8996"
+  },
+  "hardware/qcom/msm8x09": {
+    "dateTime": 1588820947,
+    "groups": [
+      "qcom_msm8x09"
+    ],
+    "rev": "2366412242709f124daaa2c19c0ec3d4e08c78ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17hq55hsfyzknrjfmw877y5cnm4mgxi7bdj0fpb920gcn6klfdrs",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x09"
+  },
+  "hardware/qcom/msm8x26": {
+    "dateTime": 1592363301,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x26"
+    ],
+    "rev": "60ceb23ede860ca8ba648d6d82fe869e2384b2ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0kxbm2sk5lxzydh2f8jv1z6j3qpjxrb2b2vr3q71mfwms76z7zlc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x26"
+  },
+  "hardware/qcom/msm8x27": {
+    "dateTime": 1592363301,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x27"
+    ],
+    "rev": "731db3415d35e19d5ad5c4ee6293891cd35f4c14",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bly3vx1ykfm251fz9c86znqzy9f8rlmgijaczzz1hk78mrk5sy7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x27"
+  },
+  "hardware/qcom/msm8x84": {
+    "dateTime": 1592363006,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x84"
+    ],
+    "rev": "80098b6c00e1b2eb80fa5bf2984748887c4da867",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ds8p9sr9r3m9lncav7kjzma9m1v6abapddjx6xjncn9ghv3ga08",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x84"
+  },
+  "hardware/qcom/power": {
+    "dateTime": 1613866025,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "e9328135c04548da7267d9c7fb20de0180302a37",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hgjhbm8bj66nm29xgmg9xb32y12kz4jn8bm4fpflxn1cz4gb38g",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/power"
+  },
+  "hardware/qcom/sdm845/bt": {
+    "dateTime": 1613866029,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "15cbea3212caaf41efdbe634b42246f0d942455e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16wxyxlvywkqpvlxlch8czcdjchnqnza5z8qhb1qgwv0kylrh1pp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
+  },
+  "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "dateTime": 1616029613,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845",
+      "vendor"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "4a5ce4eebb506210f734934d70f355c448cb1bce",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ymwzhq5n5cawc6cwspz5xbdc1vzxnxrp7nslmf9kc7mvln56hr4",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sdm845/display": {
+    "dateTime": 1621904866,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "02e23bcc98f51b1e10ce4a163054783f29bea6f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hh37liap88gw5rl1yn15mpx3b96iw8qk7agsvrrxszyxvbksii9",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/display"
+  },
+  "hardware/qcom/sdm845/gps": {
+    "dateTime": 1624496829,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "aebc156ca83ed71e542ef7dd5191a6a7c4625886",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15ibil263invfsc8p2889lb92370zxi27gkgx14b8y0jnpf4jx14",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
+  },
+  "hardware/qcom/sdm845/media": {
+    "dateTime": 1613866031,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "3e903295efc9cd3d5dca2e1edf90fa623636f20c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10csk645fbbkcszv3lb835h2v1il4x6dihadxg23g7y2cxfi6nvj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/media"
+  },
+  "hardware/qcom/sdm845/thermal": {
+    "dateTime": 1613866031,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "333a993b3392e2092f941c9ae4d54205c917abf6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08jfmac2ac6zgfxg8hgvxmv70xk5mlz15vqrxy5xcfsg2f4q1c8r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
+  },
+  "hardware/qcom/sdm845/vr": {
+    "dateTime": 1588734325,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "c1f4470d564d85c3bd269e55d60208db24c95907",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06fbwha2qkigss5r7r5vmgnr3c64cxy3njdp2qlbsxgm0c07xy9q",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
+  },
+  "hardware/qcom/sm7150/gps": {
+    "dateTime": 1617152809,
+    "groups": [
+      "qcom_sm7150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "1dda5d25e9b888a7f16c220f55cd43030bcd0367",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ilgf2rdxniq5b63an8asrbdir2f82yj05qcq8pg51gmkm2550nh",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7150/gps"
+  },
+  "hardware/qcom/sm7250/display": {
+    "dateTime": 1624496831,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "9010ced78cfb8d7a3ace9dc840a07af91a4f3aff",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vha4cs3p8zy3b8m1di92wgypi8blsgl8a8aw997j9p4rg9pvm29",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/display"
+  },
+  "hardware/qcom/sm7250/gps": {
+    "dateTime": 1627700831,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7250/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7250/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "f6b5d2ad3bfb8d2be062ff939265657639a99040",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rjf94w442vpb4v8ihb3f1d4n7rcph8whdmlibpwhdwcgks1dwm5",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/gps"
+  },
+  "hardware/qcom/sm7250/media": {
+    "dateTime": 1624496832,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "52be4415b6fa40286e127e67932a0f1456e887d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mxv8v1fnxr4gmjc92l16zmzxbiyppppszmjyjc61rkj3z92vdk7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/media"
+  },
+  "hardware/qcom/sm8150/data/ipacfg-mgr": {
+    "dateTime": 1624583258,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "78c128ebcd45e1f80a834ece35912d7bb1e60fe6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nl5wgfh2fnwh6ypyb7c4fga6q434b1nzfl4ha9l0qm24b5zw6vz",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sm8150/display": {
+    "dateTime": 1626138540,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "0886c0041391b520983c6252fbd63b1a2a395cfa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11cf1n074nmgbl26w90h5g37yjivykmcn9likf9gy26qwg6ykwi1",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/display"
+  },
+  "hardware/qcom/sm8150/gps": {
+    "dateTime": 1627700833,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "5ec33a0d84d066e0a857ac79a6993bf5a5545f12",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d1r0yfdlx6af5yv17n8550mk48xksgw60ifpx4j4wg4ns788ic3",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
+  },
+  "hardware/qcom/sm8150/media": {
+    "dateTime": 1624676831,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "892734e0c958ebc9919d1e30020e691b4cd6ad4d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07ghzjg7k8jydqg46w8s5w3ngjx0y533xyx8aigji399f1jdj9fd",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/media"
+  },
+  "hardware/qcom/sm8150/thermal": {
+    "dateTime": 1613866035,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "3d5af755f0495683a5faa0dcb4163d6c924f53a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "068aa9jpgn5b8gdy62jz74hhik1dh4yjgliaavfhvqmg1mbgn7d5",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
+  },
+  "hardware/qcom/sm8150/vr": {
+    "dateTime": 1612577230,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "ce5d8ad5ba605968a92ee406d2c6881a357ef415",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k4dfzb7l3pk0zdxzad6y20kckyac5dl5i26b6rg03ip940ij7dj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
+  },
+  "hardware/qcom/sm8150p/gps": {
+    "dateTime": 1617152813,
+    "groups": [
+      "qcom_sm8150p"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150p/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150p/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "4699856b972810b2ab52c3284ceab494446ee72d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m43j0m0cdjn7xn81n1a9h9v2b3846vixqffamajb8qrfp25yvzr",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150p/gps"
+  },
+  "hardware/qcom/wlan": {
+    "dateTime": 1628212035,
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "1c1652091543a03beed7778e4ed0e8e6e9a88f0b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01kjgaf69v97ai2rcdaj6xz8gzc5b2nm4psxmsq282zhmaaasrhc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/wlan"
+  },
+  "hardware/ril": {
+    "dateTime": 1622768841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1d95a9208e4884e98e12eb0d04a67de3ae8f613",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13r4911z64whzp7q6sm9153xqj9frzmyq95q6dgfx2z6826gxcxn",
+    "url": "https://android.googlesource.com/platform/hardware/ril"
+  },
+  "hardware/samsung/nfc": {
+    "dateTime": 1619572025,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bcfc77d0079db920053ce1ac4f40671e0146ae2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mcsnjjngc7v1rb0pdf9fkjz5ww7smpdyxvll32yayx27nfmnsdq",
+    "url": "https://android.googlesource.com/platform/hardware/samsung/nfc"
+  },
+  "hardware/st/nfc": {
+    "dateTime": 1628212035,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e83b6b5cc8663ef311c1a0a87c084dbcc1274d90",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1r021x5w208zl95ldgja0ziyjmf7yad6pp7yq3rz9nn1a0pi8phf",
+    "url": "https://android.googlesource.com/platform/hardware/st/nfc"
+  },
+  "hardware/st/secure_element": {
+    "dateTime": 1619053647,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f49f0552ccadf7bdfecfe82b253298cf8a0b8c0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "043ca4c21n7jrrckdd2b6j9p1prg4y08k8giw7r90q8kk2bf4cwl",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
+  },
+  "hardware/st/secure_element2": {
+    "dateTime": 1619572024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94ccedbac7e5f9b5e2f62ee1e4287710ea3ec49d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "183k0fmav5ndrkxkl7bnkm5mqyq0ddjjw6iilnl5y8122cg8phqn",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element2"
+  },
+  "hardware/ti/am57x": {
+    "dateTime": 1613866039,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76fe168ab350fc9a558fbdaedc17a9eb3ded8399",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gqn5lsyf7s420cdiga57w2c6g03zj048i5qq9r4904abcn9w1bm",
+    "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
+  },
+  "kernel/configs": {
+    "dateTime": 1628910442,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "77d46cbcc2b0c85ff8a5af966f85bdf908c688d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fk0441588cbivnqxzdzxipmq31lidh1j6i6mvy60ply57yplxi2",
+    "url": "https://android.googlesource.com/kernel/configs"
+  },
+  "kernel/prebuilts/4.19/arm64": {
+    "dateTime": 1623978456,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5505ed99ca27bcf9b6eff32222e524e529cd5fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ay1q3y68kymibsahxdv2kyii53gr00mrw1smfl2cpzbn5fk79wk",
+    "url": "https://android.googlesource.com/kernel/prebuilts/4.19/arm64"
+  },
+  "kernel/prebuilts/5.10/arm64": {
+    "dateTime": 1628557658,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b2193bcaf2e5beccf036c885e925f0216f13593",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16gcxkiqk0qwfxqnj9bia1qz99yk1mnhd1j4l0ai55qbw9bykjwh",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/arm64"
+  },
+  "kernel/prebuilts/5.10/x86_64": {
+    "dateTime": 1628557659,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b0cfda6a653a2f0f4447f154e36ed130dc46dd2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0w52f1q85z3lj83dry416g44xsj1j980w1pp78jq15xs9z1lrf8d",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/x86-64"
+  },
+  "kernel/prebuilts/5.4/arm64": {
+    "dateTime": 1627002437,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "82ef21d21bee6352cb4be59164ba5ae91bb229b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jasy96bh7g748c088ckk8a26nn4kgds5imwz5n6qkp8zhbqr02h",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/arm64"
+  },
+  "kernel/prebuilts/5.4/x86_64": {
+    "dateTime": 1627002438,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9caa4491724d10fb323a4b4151a4084f5b54cbad",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1alqypr9wjjd159c1vafrfwwh6yisq3i5avf239kjdhqb2v13ma8",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/arm64": {
+    "dateTime": 1612209682,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c6859ba543e7cc7fad69ef600a4f5d57faf29f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/x86-64": {
+    "dateTime": 1612209835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa663b1e3fbe4fac971dac74d529419bbf4544d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/arm64": {
+    "dateTime": 1628557660,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "97975bd5ee0ed76eb0756d88171198813aba8cab",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08bdxj5j0cwppn3w1fivzlcj8irnis1h8a61046rfw47fgk3slg4",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/x86-64": {
+    "dateTime": 1628557660,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69522eb1d17aa09806759b9b5bcc365e2ccd5751",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0dshr532fns65s891bmvvzwjgh29vgcgnly09in2qh1pks83qzqc",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/arm64": {
+    "dateTime": 1627002441,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bef98d1f51f7d8714e17e886128deac49c885407",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "157q3qksh3xp1h2y0xf9zny0hvcjaljr2qxa175sdkh9m3mj8jhh",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/x86-64": {
+    "dateTime": 1627002442,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50e504714d3f7ce4927482019de46b11c48cf0ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mds1n9ysx5q0hqlgkd3jr0admbp2l6s4nlzgb8c77dcn0pczjh8",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/arm64": {
+    "dateTime": 1612210495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bfe05a177f55ff9204205ea5e81ee1ce11b52b05",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/x86-64": {
+    "dateTime": 1612210658,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c579f17b149db718f80edef939e683dd86c0c5c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/x86-64"
+  },
+  "kernel/prebuilts/mainline/arm64": {
+    "dateTime": 1623287263,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15f05deaeda29070f206e2a28638a61018047993",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0pw66qkkcil7wmfamvikdjsdmsr4vysb4f0aby02ygix2kdwfx6p",
+    "url": "https://android.googlesource.com/kernel/prebuilts/mainline/arm64"
+  },
+  "kernel/tests": {
+    "dateTime": 1624496848,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "4ce2d89ccf8782acb77e7d6945dfe5e5ec565645",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xibcqrq89p12cng3qsg5hcc7lf2mdz90g5cbipz7rxwqpid2qc8",
+    "url": "https://android.googlesource.com/kernel/tests"
+  },
+  "libcore": {
+    "dateTime": 1630633815,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e27b4a2f22d06165a7e7d4da7d12b29486640200",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1k7xbp5nkayyf3ksynanzh1hi8k3dbp339hkvpyy8x3fz7rd04f4",
+    "url": "https://android.googlesource.com/platform/libcore"
+  },
+  "libnativehelper": {
+    "dateTime": 1625706624,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16588545bfeb7c4f54f800ae5e9f227d6f9ef36a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1509vfazmfy60ny84mljzf1iw0m5hswg922z4wm8ac79gw5wsrf2",
+    "url": "https://android.googlesource.com/platform/libnativehelper"
+  },
+  "packages/apps/BasicSmsReceiver": {
+    "dateTime": 1628910451,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "13209febafc98043ef7e1a96c495558c3f550404",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13a8aj0lxiz3xw69iq5mf3kyc99v400x64gk9x2pgb6sqwdb8mn9",
+    "url": "https://android.googlesource.com/platform/packages/apps/BasicSmsReceiver"
+  },
+  "packages/apps/Bluetooth": {
+    "dateTime": 1633492570,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "47c034d52eb5d1a887e65c1c0721782059b5d916",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "069wavbljj9dbacgyiavaqgkcdizi94f38xjghsrzjm3awa0gdh2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Bluetooth"
+  },
+  "packages/apps/Browser2": {
+    "dateTime": 1617066446,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e7ec58d95875f5717cd46f548ff479aa5b5b5190",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1h9fvxivq1vg0mcwjvi4bzz37l8qimznybpljqin45smddavryd3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Browser2"
+  },
+  "packages/apps/Calendar": {
+    "dateTime": 1619053659,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f95d595022e542f847046449c4a4eccf5a48f1f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1g184s6psnhcqbdmfjps5q0ynis04z2nclmha7jk3r60filxl22v",
+    "url": "https://android.googlesource.com/platform/packages/apps/Calendar"
+  },
+  "packages/apps/Camera2": {
+    "dateTime": 1619744900,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5adef05d4878e991220aed7c5d706141068bb9c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vxvf0jx742y1ygdvlgxx9mzr7wnd5hk7n61vlni8qphnyjzgwqs",
+    "url": "https://android.googlesource.com/platform/packages/apps/Camera2"
+  },
+  "packages/apps/Car/Calendar": {
+    "dateTime": 1623287270,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "122443f7186c2a2bf8360ea09f7ed74cf7811758",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14s3b8lr875dzylc9805a577mqws9396vh625py5cyk40fd9kmha",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Calendar"
+  },
+  "packages/apps/Car/Cluster": {
+    "dateTime": 1624748846,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c33365c06cb25381a9276884b251c79ba3d38da2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jmpvmk09bca9x4kcnaxxbskqdphv8fxwf1cjhw19c8qda8dwmb8",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
+  },
+  "packages/apps/Car/DebuggingRestrictionController": {
+    "dateTime": 1628039250,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9fb3bdd7ea6b850d99d8a7acc7dc75a34777b334",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hl1gyk1x3if9vbbd57qi69xrkzlbazfd71cvna9my33aazlz22n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/DebuggingRestrictionController"
+  },
+  "packages/apps/Car/Dialer": {
+    "dateTime": 1628377641,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d145c84fab2ebaab0df03797a94976c2f81377fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1vbchx5v6mipf06pkiz0djbgxqn9gh26rva2xy31nl495fp1k4js",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
+  },
+  "packages/apps/Car/Hvac": {
+    "dateTime": 1612577248,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c6026d156b68dc9335ada8f64dab29bc2bb564ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1d2hqs0qqjihdjsqcpa1sg1k54rzdnzgj1y045mmxjp3sywd4lny",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
+  },
+  "packages/apps/Car/LatinIME": {
+    "dateTime": 1613866053,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "914ea15173c372a935e624cfde9563f34f139fe3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0386ikmn57maxfr4brily6klk0996d93yw6fahk0h1vlh1bhqgma",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
+  },
+  "packages/apps/Car/Launcher": {
+    "dateTime": 1625188215,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c28a78ebabd3391d79ed16c29099617a9bdfbe44",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14iczkp42lqwv8rn4nc879rnbbwpbxq9lb5dwksj2plw9l6nfx75",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
+  },
+  "packages/apps/Car/LinkViewer": {
+    "dateTime": 1619140341,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8e1f0ce31338b79ba81109456b5d6439e1798664",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z34jrm6jwb5wpvia998h5izbmx7s80k3vgk43kmizkpfkd99n9p",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
+  },
+  "packages/apps/Car/LocalMediaPlayer": {
+    "dateTime": 1625015288,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a37ce43d8715f643ba8eb0c03b631aa62cbe4a61",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1q5kbq8p08vscikaqjhkx2dq4cv7i7q3x4ga9fvjfgjnpvvwcgla",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
+  },
+  "packages/apps/Car/Media": {
+    "dateTime": 1625101698,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d90991980bb8d64644373aa80da974cb6b541c7f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "165khjph49rzbg8f20rz5j1wz56vyx6i4ikg7kinlh32qy005sq5",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
+  },
+  "packages/apps/Car/Messenger": {
+    "dateTime": 1625353830,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "529e28db958e46153e3144e4b187f9440f09a4f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gfrnnp74byx7rcxx8sx383vbpngmd99bjswkdv6rf6v71pxghs5",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
+  },
+  "packages/apps/Car/Notification": {
+    "dateTime": 1628910459,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9557be335f09d72b2008a4bc2a1e37a001ef07a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0i073s0mkysbga73lc32d3vgcxy4z1my4zb96a1adrlr2d8pcblp",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
+  },
+  "packages/apps/Car/Provision": {
+    "dateTime": 1614823661,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8bd39ca0c46981a1ff61d4fbf2230c2bf9d4cbcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hfam8x8qx9ggli07kgwinf6l1lllb7cv0i8g1k7ff0fahm7frrk",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Provision"
+  },
+  "packages/apps/Car/Radio": {
+    "dateTime": 1619140344,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bdcbccba505100b3cb88f216cdae3d6abe95f506",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1cnswjixyvfvv4hgsvdwb3hga5pzr2nljkx8rxqwjdpa0c8ny8dv",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
+  },
+  "packages/apps/Car/RotaryController": {
+    "dateTime": 1624496858,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "46ea6fbde81814cf681820d6b636be251868fc00",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p4if21xgcj2if6ap4h67scxgy9rh42my4s1n82s9dqclyan7npb",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/RotaryController"
+  },
+  "packages/apps/Car/Settings": {
+    "dateTime": 1628910461,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3fbe257be7b59198c5e6ae4982bc986365802625",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zs0qxa4c956fxmws0vhxh82sw4j6iyzx7brxlxx47g6s2d164fr",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Settings"
+  },
+  "packages/apps/Car/SettingsIntelligence": {
+    "dateTime": 1623978475,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ffba1500e5095b1cc81e93914b1577fb6a1bf604",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12hhrinxbnllsqq8xm1c1glip9rccm28axw6h7pmqdr71z4nd7wr",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SettingsIntelligence"
+  },
+  "packages/apps/Car/SystemUI": {
+    "dateTime": 1627700850,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d7a5627527b26b53ae81257f0cf3978e064623cf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xzck63f4y22zxx4mw6yd0h2032rcwwzvc7j4iy16zp08av7fg8p",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUI"
+  },
+  "packages/apps/Car/SystemUpdater": {
+    "dateTime": 1625015291,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c4cb6a9756a9aa7e8038f9892027c8954214d1aa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0c5i2y5p3y5gmbdi4fl3k6nrifr9kp1g15115i92fg3vh78f4g0x",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
+  },
+  "packages/apps/Car/libs": {
+    "dateTime": 1628910462,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0e5ec2783f092a01b6cf52a2286b77c3dd6930ad",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hnvm49g5fbbzayl8aklw89hdd4cbv9w1k2fw6q4f5bj80hbw2fj",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
+  },
+  "packages/apps/Car/tests": {
+    "dateTime": 1625015292,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8d6ef4df7c404dbbd444adc5f95ed9e5df3ad45f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03cwfjb13np93vfvpidvbwrx57d41hb673ddrwh9rnqk1h1sj0z5",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
+  },
+  "packages/apps/CarrierConfig": {
+    "dateTime": 1628126524,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "83c2250efc3385265bcca08a512d3fb4b8638a53",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11880c9kx432lqdr26yrajv5kfxy4ngrn5m8vp81qmrxaz5c72rp",
+    "url": "https://android.googlesource.com/platform/packages/apps/CarrierConfig"
+  },
+  "packages/apps/CellBroadcastReceiver": {
+    "dateTime": 1628910464,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9fedcc9c42c40f293bef5b911b7eecead56d8c7e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15dkbzpxlamnz9njafsrjvqrryysyb2xhipqfpjmyxxgyprw7la2",
+    "url": "https://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver"
+  },
+  "packages/apps/CertInstaller": {
+    "dateTime": 1628910464,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4db0ff16ed7f0d115f23d29d261655e8b8ccf33f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0a52nxxm6l25xp4435nlw3aq8nvd3p2hzhlddwcxgw5vnffl5x4x",
+    "url": "https://android.googlesource.com/platform/packages/apps/CertInstaller"
+  },
+  "packages/apps/Contacts": {
+    "dateTime": 1632177832,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "01e1f9403c3dc259f5f387ea5c601b782e2a6796",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14z4xr31wm57i058hcmv8lbk9ffsfw9whlybzbzzxdkbb29gq0lr",
+    "url": "https://android.googlesource.com/platform/packages/apps/Contacts"
+  },
+  "packages/apps/DeskClock": {
+    "dateTime": 1614996435,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c0ba9f3c0692c421e3dd6039291af997a445e365",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v7bkqlsi8q3djjbs6h449p3nw9mg0c120y6bj37nkmyci4lw9nm",
+    "url": "https://android.googlesource.com/platform/packages/apps/DeskClock"
+  },
+  "packages/apps/DevCamera": {
+    "dateTime": 1618535261,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93acc34ccdb955bf31179904928b6f6dbee5a4a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10vv74hndkdq9281dxsv8jk8frfjjqkqw2h48wc63c762mvvfy5f",
+    "url": "https://android.googlesource.com/platform/packages/apps/DevCamera"
+  },
+  "packages/apps/Dialer": {
+    "dateTime": 1619305664,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b8a122fc6a0498431398759bb19350d53d711eef",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jl84bzvf9s45m9api93byy7hl7n5hwv23xknqj4yv3hhz8xwqps",
+    "url": "https://android.googlesource.com/platform/packages/apps/Dialer"
+  },
+  "packages/apps/DocumentsUI": {
+    "dateTime": 1628910466,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c3923379dcd49723a8bbfd4e102defef459a4306",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bhkvhgx4i6wkif0pfsc9xhlx4knk6j01h46bcf8rfarh8afqgwz",
+    "url": "https://android.googlesource.com/platform/packages/apps/DocumentsUI"
+  },
+  "packages/apps/EmergencyInfo": {
+    "dateTime": 1627700864,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c733ed97034e0a45d232f1e139894f32945762d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xq2xxp84cq425rrxkm79wvla8z1rmfrynpb4qxrld1q35iyvz5w",
+    "url": "https://android.googlesource.com/platform/packages/apps/EmergencyInfo"
+  },
+  "packages/apps/Gallery": {
+    "dateTime": 1613866064,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2e8bf9fbade092fba023df810a08f06e1706ab4d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1jvm1nsp49a8bdzrykm2ywi5d8kp5s79ynxsaazr56xh88m63swx",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery"
+  },
+  "packages/apps/Gallery2": {
+    "dateTime": 1613866064,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7786dab18c9a775845c9fc2a2bc00aa0d7b00d67",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0867dc7j5diqyivnd9j6s8c4iwjgml5r47s364s8c8z7jz2haicf",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery2"
+  },
+  "packages/apps/HTMLViewer": {
+    "dateTime": 1620263298,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "83e7ea1b60ea8ab0e90760c741ac9f94ae00d571",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p8kx6jf10ga48l7sbbn731yp8rfy9z2l2n5kvxwwc7vflbybi90",
+    "url": "https://android.googlesource.com/platform/packages/apps/HTMLViewer"
+  },
+  "packages/apps/ImsServiceEntitlement": {
+    "dateTime": 1625281671,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b54ceda5614296ca05be421906ec5f52a3cf864f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1vj7ws4vgrl8fs7ssdqk8k4aq910kaas3ny8apyq40zxnpwafp5z",
+    "url": "https://android.googlesource.com/platform/packages/apps/ImsServiceEntitlement"
+  },
+  "packages/apps/KeyChain": {
+    "dateTime": 1624583292,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "dcd61e01f1e3da3e1fa4350834243d6a61fc84a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1h5f4yg0n2y6slk0z7nr6qi9pqzl2ch3i6halnf08pwkvfcy86y7",
+    "url": "https://android.googlesource.com/platform/packages/apps/KeyChain"
+  },
+  "packages/apps/Launcher3": {
+    "dateTime": 1632178056,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c2e7dac081fd371df6eb560bd301d500efd24339",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l9d2gsa8lwg75m2mfwwqc9a84yz0wyd604jk0i3hyaq7q28j6kk",
+    "url": "https://android.googlesource.com/platform/packages/apps/Launcher3"
+  },
+  "packages/apps/LegacyCamera": {
+    "dateTime": 1613866067,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a7e00568f069c6393d3339ed0d857c181ab02b06",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xlgpy1lpcixp767g81kahhzid6g81qa4ghzk0q97jpqb9dp7fsy",
+    "url": "https://android.googlesource.com/platform/packages/apps/LegacyCamera"
+  },
+  "packages/apps/ManagedProvisioning": {
+    "dateTime": 1632177815,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "df6706775a19b362a0271b5f4e9e76350a10b4a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v60ia0z38ym712ink8aa3pr7szgkn464glnhzw06v7rvdk4nqiv",
+    "url": "https://android.googlesource.com/platform/packages/apps/ManagedProvisioning"
+  },
+  "packages/apps/Messaging": {
+    "dateTime": 1620868078,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6784f2427660f76da076bbe2084cb656645305c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rw5c8w8ilgayhlryg652dv2k0n9i4f16qx09hhw6phzcxffqxhq",
+    "url": "https://android.googlesource.com/platform/packages/apps/Messaging"
+  },
+  "packages/apps/Music": {
+    "dateTime": 1613866068,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2f0c6feff033844f2c9dfeb8a854369d10c68ec6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0as5xx38vj9lhkqx0vwd76sdn53cd3f3p2igb48lbx31d037q4c3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Music"
+  },
+  "packages/apps/MusicFX": {
+    "dateTime": 1617152848,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "49c7f161516586dcc0eeb8b032571418e0ad431d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "17nh688q66vp9c3sqk049z2685s1srmmlc7qvnzvwgmramqzvf73",
+    "url": "https://android.googlesource.com/platform/packages/apps/MusicFX"
+  },
+  "packages/apps/Nfc": {
+    "dateTime": 1628910472,
+    "groups": [
+      "apps_nfc",
+      "pdk-fs"
+    ],
+    "rev": "025b06f4ec7fb1305cc7e22f8bfcbd2035ffa742",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pvwayspc7dl8xfgz2sv23ykyv3xix01dq2xprf65ssn3xv0czc3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Nfc"
+  },
+  "packages/apps/OnDeviceAppPrediction": {
+    "dateTime": 1613952449,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f3b04059a3614fd79fc8bc24aae39b8983757ccf",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1fkf6vkd884q62xl21kayi6113ggay9yla8v89nq1dyp2k5w3dna",
+    "url": "https://android.googlesource.com/platform/packages/apps/OnDeviceAppPrediction"
+  },
+  "packages/apps/OneTimeInitializer": {
+    "dateTime": 1612577266,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e62b4c04ff6cc4a116485aa86a9fb3c3961b43a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p5xhhljcd2bcpb57b22h65rgsv6k11l3xdi0bc4jaim9p12sikp",
+    "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
+  },
+  "packages/apps/PhoneCommon": {
+    "dateTime": 1628305699,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e6b2fea96c2ac40395e3818517298956ad212161",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15pca0a2wfzigr9jxw12m8mq9vjm36a00am5lm252q33b60hnkbg",
+    "url": "https://android.googlesource.com/platform/packages/apps/PhoneCommon"
+  },
+  "packages/apps/Protips": {
+    "dateTime": 1613952450,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b1bcbe05dd3ac74642e6517b02837a65ffc2dba6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0krih7himlvr4i051i1ccrr46pvz34nl7zabxq37i5902fg7ifn6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Protips"
+  },
+  "packages/apps/Provision": {
+    "dateTime": 1613866071,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8e4fffd410f833201a1c94c117637ee813427f63",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1b52p9b9i19cg8pip9ykfj5finlvxxv9ikwjfjpk022pzg0p0zz2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Provision"
+  },
+  "packages/apps/QuickAccessWallet": {
+    "dateTime": 1619140360,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "65c09a3ab4072af9156eeb1ee21ea72c2a6c1e83",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l01m9dgs7xvjk1jcakmxgysh0phkcnplanvcqz4z426h029y9aj",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickAccessWallet"
+  },
+  "packages/apps/QuickSearchBox": {
+    "dateTime": 1619233678,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4a9f250e8be0883e828d66b0db59ba009b6ee955",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kpl2vqdg25vbqbl1bd16rqfiyx5s4jxx2pcf4mfdj8xlwpigcmq",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickSearchBox"
+  },
+  "packages/apps/RemoteProvisioner": {
+    "dateTime": 1628557694,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3b09f9faf67657c5e7ff39e86cb2db7e43019532",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1z5khrz27380n6rrjm290nj8cv36ngamj52zbzffy26xi7haxcwq",
+    "url": "https://android.googlesource.com/platform/packages/apps/RemoteProvisioner"
+  },
+  "packages/apps/SafetyRegulatoryInfo": {
+    "dateTime": 1622768879,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "571724ff3cc657db6be72fb5c1a4cab88882f5e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09xfmkg2hbs9zrfjimvw7jl3ah7015gqwd2nqk1gjhrhmqr5mayv",
+    "url": "https://android.googlesource.com/platform/packages/apps/SafetyRegulatoryInfo"
+  },
+  "packages/apps/SampleLocationAttribution": {
+    "dateTime": 1620177029,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9595378820526157f9eefc44349178059847ce6b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rl5fafh4w2ly59yby031ag1h5b1i7fp01i89qlsc85x5c4k3ash",
+    "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
+  },
+  "packages/apps/SecureElement": {
+    "dateTime": 1620177029,
+    "groups": [
+      "apps_se",
+      "pdk-fs"
+    ],
+    "rev": "8e327e7436e5427d8ff37c4935f1f601533c4e6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0csvapdfp737y40sywzxbk87bx20dn3j7ppalz6wigc25r2a5wz8",
+    "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
+  },
+  "packages/apps/Settings": {
+    "dateTime": 1632177809,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "21125998c804560aa55d6f81cc2ca7807323f3e0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kf3xvcqri6ag1rflic0q3885p9mdlznkr6v36vd78irrz4skav6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Settings"
+  },
+  "packages/apps/SettingsIntelligence": {
+    "dateTime": 1614910075,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "dd8fa9fa1fe6eb9b36625dac9a69e4ba8481b729",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0l0yv5d5azgp0iax13dbzqxfkbjgwf0yr0pmiamhi6fjyqbzmh0b",
+    "url": "https://android.googlesource.com/platform/packages/apps/SettingsIntelligence"
+  },
+  "packages/apps/SpareParts": {
+    "dateTime": 1612577271,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "815a7b9766ff507a815cf725e3aa5a0d8a72c7d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1maawjwjr5mcyh62h02fv6g0jhchfw653y89mmjr1wc9xf13ywvn",
+    "url": "https://android.googlesource.com/platform/packages/apps/SpareParts"
+  },
+  "packages/apps/Stk": {
+    "dateTime": 1630375535,
+    "groups": [
+      "apps_stk",
+      "pdk-fs"
+    ],
+    "rev": "fbe121b6960dfd9e5ef6f295ac5e1777d04cec63",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f8p9clhch862ml054cqfmxkns8xmq7gj45glc94sjyannv5i1iy",
+    "url": "https://android.googlesource.com/platform/packages/apps/Stk"
+  },
+  "packages/apps/StorageManager": {
+    "dateTime": 1628730483,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2c582727fca25de270a326c10f75a48cb150001c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hclidnj1j9ddv64m4pia7zxahmz5pxaias1paiivza934d92i41",
+    "url": "https://android.googlesource.com/platform/packages/apps/StorageManager"
+  },
+  "packages/apps/TV": {
+    "dateTime": 1620695307,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "77b6de844f5cc429dddfbf63591c54376adaa8c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0qx3r6m8crigjdxyhxbbfvmrs6r9yjjsjkz5i6aclg2l02hmrqq8",
+    "url": "https://android.googlesource.com/platform/packages/apps/TV"
+  },
+  "packages/apps/Tag": {
+    "dateTime": 1628644082,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c2ee4865a0100193af53d36afb15ec5c21287ac9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mbdfb70sxdsiyyc2pk5nam4d93av6b8j4qxmr8bwbirmzni42b1",
+    "url": "https://android.googlesource.com/platform/packages/apps/Tag"
+  },
+  "packages/apps/Test/connectivity": {
+    "dateTime": 1613866077,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6bf0365b3197778597ca37bade70cb014f5df2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10mb5gqc3lyi02r4i68yqhqxiwik1xdi87ik9s6lr9b04clf1fax",
+    "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
+  },
+  "packages/apps/ThemePicker": {
+    "dateTime": 1628212080,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "390d6f41b2e6aaa85cfc72079f3d8635b3e47e0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zq3pzcvrj430r72cncjnj23sqq3asaa08kv15w8b6jxmpzdm7iy",
+    "url": "https://android.googlesource.com/platform/packages/apps/ThemePicker"
+  },
+  "packages/apps/TimeZoneData": {
+    "dateTime": 1619053687,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6676bd0129ebfba9bbe0e19d7d910b2061c53777",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07ap27ilgs63idvgw1lyzy64djz657ad4wz273y0pibgh3nm5fj9",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneData"
+  },
+  "packages/apps/TimeZoneUpdater": {
+    "dateTime": 1622768885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48619574f2f5037d1de88e120a7d231bf3b7ec3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12ir26ysn4n8q1mvyhxp0lmry7k51zam3n2pcdkg3v3g1s344g80",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneUpdater"
+  },
+  "packages/apps/Traceur": {
+    "dateTime": 1628644085,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "537107be190ae2559e6f607465964aef2dafef96",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bhsiwkcc5hp4phf262h2q4phq9vxifn2fs4nh2zrpcsvxl5lws4",
+    "url": "https://android.googlesource.com/platform/packages/apps/Traceur"
+  },
+  "packages/apps/TvSettings": {
+    "dateTime": 1628910484,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3890f92fa4dbaf7442f989a7cfd8fcb79e836eb7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j8rd17c2h8yi4q2z196av0100gjvjqh9abfbwxb5ix51k15az0y",
+    "url": "https://android.googlesource.com/platform/packages/apps/TvSettings"
+  },
+  "packages/apps/UniversalMediaPlayer": {
+    "dateTime": 1613952460,
+    "groups": [],
+    "rev": "0417344820f194edbf9c463d3d0567d28ea212a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bzyk8zck067snc55bknnd4rsmsqkx3y41yg5w9lm410a7vr7bgz",
+    "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
+  },
+  "packages/apps/WallpaperPicker": {
+    "dateTime": 1612577276,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8d79f2738063527e5c36584074085d9bef5bac07",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1amwx8m2ckvx5clggdsnwas0ix9qnam2z9sfdwy9wys6rb9mf2qp",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker"
+  },
+  "packages/apps/WallpaperPicker2": {
+    "dateTime": 1629258482,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3863c6a86eefa998d2e84526e1f5a4d38f2307c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0d0phgwpczyk48b5b22wrbg5987xcjf4rq196n9rfvdgk270fv5v",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker2"
+  },
+  "packages/inputmethods/LatinIME": {
+    "dateTime": 1624072119,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8d797180ae961f2a73010b9657e5a052776ed4ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06irq7fz55icip6g5km52ds3nc1az8vhg5ra32szsq5qxg788scl",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LatinIME"
+  },
+  "packages/inputmethods/LeanbackIME": {
+    "dateTime": 1612577278,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b97bd70f1fc118a90d8e307c9f7cd1f2f8343c09",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "19wfvg8izsyvb2fwy1gl21vfk7v9c1icbpw542pqcjdyc6dyb672",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
+  },
+  "packages/modules/ArtPrebuilt": {
+    "dateTime": 1625533674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc413a28bf4e9b6b6dac87c4a4d4becb49c45911",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0i9lnw0byhqxwz242kbr5dhi8dg91grhkycp9jp5icdpza28l66b",
+    "url": "https://android.googlesource.com/platform/packages/modules/ArtPrebuilt"
+  },
+  "packages/modules/BootPrebuilt/5.10/arm64": {
+    "dateTime": 1610237331,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b8aae83faef817184b941dd483a358c8e5cda89",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1n7apxd43m3i2sqgjcp80garn9zznfcsq67gnm0nywp0bbi7wd58",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.10/arm64"
+  },
+  "packages/modules/BootPrebuilt/5.4/arm64": {
+    "dateTime": 1613866083,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "990dbc6af4d8fc5edd54d0c584c5fedd131b732a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13gs7i4dcwmjwld93q0w47ar1gcah0kaqbkxacwlc404axfzqg72",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.4/arm64"
+  },
+  "packages/modules/CaptivePortalLogin": {
+    "dateTime": 1627520888,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0d6d254912273a62683d48dfc6462095f63d5027",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0iaqzwpmhgmyx0zj35h2qm2snwl04v77nw3g2nb6rm72sk0afps0",
+    "url": "https://android.googlesource.com/platform/packages/modules/CaptivePortalLogin"
+  },
+  "packages/modules/CellBroadcastService": {
+    "dateTime": 1628910490,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3e39215b95272f35ec2b2bc38dd8a40faa5e92f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1288r3qmmbhlhlr8nzf509v2ayldz785zlx3pl7y6q41kmcws7a6",
+    "url": "https://android.googlesource.com/platform/packages/modules/CellBroadcastService"
+  },
+  "packages/modules/Connectivity": {
+    "dateTime": 1628910491,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1d8ca5e6126b0c0cfc51b1c97fd51fa13df70848",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0p2ms11ppymzpixj542jf66n9qag1vjk25hlznanr9d0cgnmjba9",
+    "url": "https://android.googlesource.com/platform/packages/modules/Connectivity"
+  },
+  "packages/modules/Cronet": {
+    "dateTime": 1625281693,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "eb5a69c05483e2b4d1cb3e473b2b0548ae039791",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Cronet"
+  },
+  "packages/modules/DnsResolver": {
+    "dateTime": 1628305718,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b871cfb0c09aec1a93893dff7b01777d43b6ede6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ckllgahhki8dcx3md37x6jcyjm5maxmh98l43d107h14h1bva10",
+    "url": "https://android.googlesource.com/platform/packages/modules/DnsResolver"
+  },
+  "packages/modules/ExtServices": {
+    "dateTime": 1628557713,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f5c300e197779816c69211f6ea503d262d71d4ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "112sxv4lymh9sx4n1ai9hcxd56wpjc9fbll1ih6bvx2421y65ar6",
+    "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
+  },
+  "packages/modules/GeoTZ": {
+    "dateTime": 1624324281,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4f3bc163c6dc1588af53caceb73e89631a0e4899",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xw9s4x82r3aa98wcr5cbmclcw2cmmc22palh14ylsypcvpb4zip",
+    "url": "https://android.googlesource.com/platform/packages/modules/GeoTZ"
+  },
+  "packages/modules/Gki": {
+    "dateTime": 1624324281,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "494033fec1b6c1081205c07218fdecb68745f56e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1snci4l616cvznfbgw3xvmkvsa3i95q1v3fp882327wmv65nrqww",
+    "url": "https://android.googlesource.com/platform/packages/modules/Gki"
+  },
+  "packages/modules/IPsec": {
+    "dateTime": 1628910493,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e08ffebe482e757f52324623c288ae2f185cede",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v2qw6hjafasjn9vby9wac9kp204nfn0y3j0abhz2i591jnbzkdl",
+    "url": "https://android.googlesource.com/platform/packages/modules/IPsec"
+  },
+  "packages/modules/ModuleMetadata": {
+    "dateTime": 1622164130,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d43c8f898223d499041070cf3c4f59f17f4c6a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wl1mb6fmnym4yyi1w4fc0zni7awb50mh9w91a6plp5j1rmy3x87",
+    "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
+  },
+  "packages/modules/NetworkPermissionConfig": {
+    "dateTime": 1614132511,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ae1bf6a9553bb7b5379a9f7b995784fbd433e59f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nz2xs3rmpvbfwka7lxr87chqpchq57cc8r25qfgymbhnkkg61pl",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
+  },
+  "packages/modules/NetworkStack": {
+    "dateTime": 1627772884,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5454d292d64afb43a74c3c4369745f93e7c74e27",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gyjjmjhghgpbw373f3z18q4fb17y5i0gckp1xvh8bwj52yqhppl",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkStack"
+  },
+  "packages/modules/NeuralNetworks": {
+    "dateTime": 1627952881,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f623e6be8ef250fbd6b775223b5ef1d59c013546",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mb2cmq4xdwjjny1kwgb7bv9jgfy2a6ky3gnbbjm01n1pwx63zxi",
+    "url": "https://android.googlesource.com/platform/packages/modules/NeuralNetworks"
+  },
+  "packages/modules/Permission": {
+    "dateTime": 1629162491,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "32fe1cde0566f67aac7143e6cfe3cfbf91e93af9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0iqdcr4lnvigvbz8hpm0ik49icyzz9klxa0f9b4lnk5jv9pjvfzx",
+    "url": "https://android.googlesource.com/platform/packages/modules/Permission"
+  },
+  "packages/modules/RuntimeI18n": {
+    "dateTime": 1623892110,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4221773d72eef679db5118cdfefbac8446d75e11",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "016clxna7xjxwy42chxfdcp48ny0j3g4nyxg57zvqglgrlx8cqp2",
+    "url": "https://android.googlesource.com/platform/packages/modules/RuntimeI18n"
+  },
+  "packages/modules/Scheduling": {
+    "dateTime": 1627096106,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ded59409b1a66506467354ff13524eca0bfbc1a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hl2d5b5nybidak1pwiw26sm08il2nb5jflj419f765p3g9r5byf",
+    "url": "https://android.googlesource.com/platform/packages/modules/Scheduling"
+  },
+  "packages/modules/SdkExtensions": {
+    "dateTime": 1628305722,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "67f602c471e78c9d1d7595b56fb1d9b2f26d20af",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1m4pl0v7f56g74ym76qrq198g6pnd93w8zh05bynvyvarwbajphd",
+    "url": "https://android.googlesource.com/platform/packages/modules/SdkExtensions"
+  },
+  "packages/modules/StatsD": {
+    "dateTime": 1627700896,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f45564224bedb4e6b407497b636d81acf0edc0ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nprm88fh2mzdqim7008r472jxk1p5wcz0aai9b8r3i8diiapq5y",
+    "url": "https://android.googlesource.com/platform/packages/modules/StatsD"
+  },
+  "packages/modules/TestModule": {
+    "dateTime": 1539195664,
+    "groups": [],
+    "rev": "a2070f870f7dbd11d0e4d88b995ca338505151fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
+  },
+  "packages/modules/Virtualization": {
+    "dateTime": 1625706690,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6cc4e3bb986e4fa4d71799df7266cc8e5b569e7c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1i7h4ppc6clrz7q992fmq7wsw7pznpai9kinwb2w87b0m3yzplk5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Virtualization"
+  },
+  "packages/modules/Wifi": {
+    "dateTime": 1629162494,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "fcefcd64c1c38f278c8e2dfe0a3fda6645f7d7b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gspapvhw5ig1875kxvxnmjz7qm1l5r4js1ggskrwhr971wj0sq6",
+    "url": "https://android.googlesource.com/platform/packages/modules/Wifi"
+  },
+  "packages/modules/adb": {
+    "dateTime": 1628644089,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f13742f67931902c9d97e804c8b76edbd34a5df6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10819wff878fisyz5cjh305svrrfi3i896vhv2cx1y4w3cy7hrkj",
+    "url": "https://android.googlesource.com/platform/packages/modules/adb"
+  },
+  "packages/modules/common": {
+    "dateTime": 1629340750,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "26f3780eefb4f3033c41850859342e1077d780ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ljzhs7788xbwbl3h1n5fdbwkcpvdbgfp8f9b3f811nncxl98xd0",
+    "url": "https://android.googlesource.com/platform/packages/modules/common"
+  },
+  "packages/modules/vndk": {
+    "dateTime": 1623805721,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b95db9643d6a5a008c24b38cc6207b1ad9c97a6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01y5wlkqvj6qcplkjmwazmz8q964k9x32kx8v85kq7w5vgnlc33b",
+    "url": "https://android.googlesource.com/platform/packages/modules/vndk"
+  },
+  "packages/providers/BlockedNumberProvider": {
+    "dateTime": 1624496899,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "63a94c50b7ca36f8bc1acb90bcb80b5fa28ccb93",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xljiic1hbdkzcpzxmhi1s19h90fdb9yzx6yai6iqbws6zyi5wj8",
+    "url": "https://android.googlesource.com/platform/packages/providers/BlockedNumberProvider"
+  },
+  "packages/providers/BookmarkProvider": {
+    "dateTime": 1613952474,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "df6ad70fcca13dcc349739c3e4782299d537ed78",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06p1pl2iq980hibsdal7jq7qnmvsr3w4zw88jvr53ifgjvaj7jyy",
+    "url": "https://android.googlesource.com/platform/packages/providers/BookmarkProvider"
+  },
+  "packages/providers/CalendarProvider": {
+    "dateTime": 1627348122,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "563174c4d56b1400f407c1bf2b07be15ee91ab7d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10g01wxvmkylh7r7kjq2analk29zfs2xqaql75h0rw5bnvxkmfdc",
+    "url": "https://android.googlesource.com/platform/packages/providers/CalendarProvider"
+  },
+  "packages/providers/CallLogProvider": {
+    "dateTime": 1620695324,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "84ff38d98db1e78de13f3d5b2f123f82751e948a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0qxaag2rzr45ixnnmzl88xhssvvlaz6mijizj75jkrdslj61q2ha",
+    "url": "https://android.googlesource.com/platform/packages/providers/CallLogProvider"
+  },
+  "packages/providers/ContactsProvider": {
+    "dateTime": 1628982491,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "79d1605f940fc047f8758b9ba08bb2b6fa159549",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0667sccdvjsg9pwb3d3iz747nrlcyngbkzjdar01d1hrwsd06pik",
+    "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
+  },
+  "packages/providers/DownloadProvider": {
+    "dateTime": 1629441562,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cae6ffce4a1152d8f464def46449a143ceac4984",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "076kwgx6s5110ya4wx83rjbnrfcnhhrdcx0cznzav5skj5kakq7y",
+    "url": "https://android.googlesource.com/platform/packages/providers/DownloadProvider"
+  },
+  "packages/providers/MediaProvider": {
+    "dateTime": 1632177824,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "be14ac6097cf5feb45b13af6d3b5efa060b4e53e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "06f69al8xn7ic1xsq5yxg5hl5yxbx4w3511zjy1y7ckn77n5v72s",
+    "url": "https://android.googlesource.com/platform/packages/providers/MediaProvider"
+  },
+  "packages/providers/PartnerBookmarksProvider": {
+    "dateTime": 1613952476,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ad21bf756e089bfade643e6cbd4f836b3d5f52e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12s14vcmpypbk2h116n3spvqg4akj6xizjrw7vilab7ln8wp89i5",
+    "url": "https://android.googlesource.com/platform/packages/providers/PartnerBookmarksProvider"
+  },
+  "packages/providers/TelephonyProvider": {
+    "dateTime": 1628126566,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cbd6e96bd37cbae5f071d9ee2891520b72a5718a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "137glp2nz7m0g0mc039m6mnxzny9q962z3349yavw9sidakmq8mv",
+    "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider"
+  },
+  "packages/providers/TvProvider": {
+    "dateTime": 1627168097,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bedad079bf35175a4fa9454cd5ff38bb21a69db2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12whrzjsn4qcqmrqzw61y2ya6mzjl0r3z1k414w05b68bai4cdg9",
+    "url": "https://android.googlesource.com/platform/packages/providers/TvProvider"
+  },
+  "packages/providers/UserDictionaryProvider": {
+    "dateTime": 1624496904,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d190a86b22d23530ef007cac1e87dc7eaf611e39",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nkkxj3mm39lp6ga1icachqykkcarfslxi3jngxj8v1rriqa710w",
+    "url": "https://android.googlesource.com/platform/packages/providers/UserDictionaryProvider"
+  },
+  "packages/screensavers/Basic": {
+    "dateTime": 1622596114,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9ab84df746486902ae98c308222ff7d5a96b564c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03wkn8gl92cdcqkykb1m5kpmmzmc46hlinz4gyprpacn8wgr6zqx",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/Basic"
+  },
+  "packages/screensavers/PhotoTable": {
+    "dateTime": 1628910506,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "685b8211ee33844ffd4954ce36a365b61cd739bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0rq44l1hkgcn7wxk6gs0nmhljnkz556wk60mc2xqxapcan6jyi85",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/PhotoTable"
+  },
+  "packages/services/AlternativeNetworkAccess": {
+    "dateTime": 1618024112,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "93a49ca9ddadc3ed1ebcb509a27316a7ee5aa2f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09kr3cq670ry69jm9wps9kl4h5b89d1v4k9fszrkr2cnz522j3n7",
+    "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
+  },
+  "packages/services/BuiltInPrintService": {
+    "dateTime": 1628377695,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c60dbf5478c3026c27b672730d2fd775bf7a4f76",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10zwsrfnwcc0zcxjpiwp9i66qx7jb8k3rs14m6kgdl6xnfrq85aa",
+    "url": "https://android.googlesource.com/platform/packages/services/BuiltInPrintService"
+  },
+  "packages/services/Car": {
+    "dateTime": 1628982497,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e176b5c13eb74ce1b34689e7cd5672f93784bba6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zims78g6sfy2f3ydw2ivk5fr94pjwg20v23zgqhy1r50aagwgyq",
+    "url": "https://android.googlesource.com/platform/packages/services/Car"
+  },
+  "packages/services/Iwlan": {
+    "dateTime": 1628816919,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f59a4e474d4758957fe046eb22dec335da791109",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1l7f39npsjsy6rgaypz8c33y29y8b500m7ssrp1w0b3injj5ddy1",
+    "url": "https://android.googlesource.com/platform/packages/services/Iwlan"
+  },
+  "packages/services/Mms": {
+    "dateTime": 1620177059,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "329631227d394ec51a25cf32d29852bd0b555a0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "192dhws43zp66czpx42kciwggd1p21mp34if3hkkcv8gqb5vkxsg",
+    "url": "https://android.googlesource.com/platform/packages/services/Mms"
+  },
+  "packages/services/Mtp": {
+    "dateTime": 1624496907,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "341ce8e6e0d152c84611383756223b3d391f3e08",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0581pybyfy4npszpycjkkphir38nvj6b16zfl4ciz8fxg6dcwgqz",
+    "url": "https://android.googlesource.com/platform/packages/services/Mtp"
+  },
+  "packages/services/Telecomm": {
+    "dateTime": 1630289513,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "248efa7baa08dd72f6b244b107f94ae58d1d0269",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j9f3jw2g96vnnxs0rw06sr32af603hh2kdgwkg20dnqda0zmhgc",
+    "url": "https://android.googlesource.com/platform/packages/services/Telecomm"
+  },
+  "packages/services/Telephony": {
+    "dateTime": 1628910510,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4555a33a625803cec3da648a9247d78bf7b38973",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0viv6ilpx9pb3zkrmrz7ddr381l4n8gz6z2n4pc8cgrr1lyma8jp",
+    "url": "https://android.googlesource.com/platform/packages/services/Telephony"
+  },
+  "packages/wallpapers/ImageWallpaper": {
+    "dateTime": 1571790197,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "de30d28d8ab40ff2aaea29e2eed4bfa17c7dc7b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/ImageWallpaper"
+  },
+  "packages/wallpapers/LivePicker": {
+    "dateTime": 1627168103,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2f0201bcc0964c62e0ca07721208cc112828d76a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ji2igf0a95gf2fdvb9nci5rzky259bzvfn920saj04yxsmb8mg0",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/LivePicker"
+  },
+  "pdk": {
+    "dateTime": 1619053714,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "759faacfbf2ce05e3557ebe0fd5d28002da7ac94",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zxgc4qgxsz4vn8qyzmp8m4zqy98fcsgjsn6abhlagp3ihjh27hv",
+    "url": "https://android.googlesource.com/platform/pdk"
+  },
+  "platform_testing": {
+    "dateTime": 1628982501,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "03df9152c687e7e9f594b881d08256dd8ca8456a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1xj1n3a4zrharn7qv3knzmv0712f04x69b0zmzhrm5zsj9xwiz6j",
+    "url": "https://android.googlesource.com/platform/platform_testing"
+  },
+  "prebuilts/abi-dumps/ndk": {
+    "dateTime": 1623805733,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ff8e917399bae065bd87513376dfc3193f3b5df7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1422gwmj2f08z664xdzvjzi0q03v2irhxl7cl25yjxvr26gpgb7p",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
+  },
+  "prebuilts/abi-dumps/platform": {
+    "dateTime": 1624929180,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "10b72114f9706e6b67a107425e3ca10be7cfe9f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0256schrmrnmjnip9r6na9hhci6cqydgy3syx3qafpg9mavzy5lz",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/platform"
+  },
+  "prebuilts/abi-dumps/vndk": {
+    "dateTime": 1627002509,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7e93f2a1a070d4584ed5c422f885315fd7206f17",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1lss4fhd3g2323xl7v0jlfy69pg6x6fagpmvi0i06pjjgypq5nii",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
+  },
+  "prebuilts/android-emulator": {
+    "dateTime": 1627700911,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4f158c3e564553b0375c4f2519df7454416104a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0i3xzldhlphn291adwp8mqxr6bkah52cdpzvzwkjdqna2fpr6hb5",
+    "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
+  },
+  "prebuilts/asuite": {
+    "dateTime": 1628126576,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d965906e93d7216659b145c9aaaf9df652be7434",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "012s3a4fb2gsd7rwn8vzf3b7k38zk1kl6i80r2d4cys5a9vmadxy",
+    "url": "https://android.googlesource.com/platform/prebuilts/asuite"
+  },
+  "prebuilts/bazel/darwin-x86_64": {
+    "dateTime": 1615601292,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "2b70ec169406545c31d4b7102f9c0b2539cb8395",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wcwyr0n9m0v9mfyjb8f3ljck0w3payq39iv33f2w7n0kihqalgk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/darwin-x86_64"
+  },
+  "prebuilts/bazel/linux-x86_64": {
+    "dateTime": 1615601292,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "d93b2573d955bb740a352fee365f5762b175d12c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mf45cyj47xqfpxp3cvdibwbxjswb2n10gpdydvyb5aynpwg492g",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/linux-x86_64"
+  },
+  "prebuilts/build-tools": {
+    "dateTime": 1621386527,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67abe25effd5daa101846276a185d65b3f23728d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wph12829w8mj7ddrp9ml33igyg8qvw13hvjsv0jcl708pqnbnzf",
+    "url": "https://android.googlesource.com/platform/prebuilts/build-tools"
+  },
+  "prebuilts/bundletool": {
+    "dateTime": 1613866111,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd3cbae65b7d44de63631ffad29f031a2d5d713f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1kg4bhhflbbzp2gkdf1q8yicsnfnm44z4yfh8y2wwzvlgxy87wmk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
+  },
+  "prebuilts/checkcolor": {
+    "dateTime": 1586495846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c1e685b00cf09f1c724023be97be0954ff9edcc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zaw6nl6k2l1d9g7rz45vybgi6yjmbxzfzz7kwrsgaymc27b060r",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
+  },
+  "prebuilts/checkstyle": {
+    "dateTime": 1619233716,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e30f9544745f85d0990fff644328525f20381ba8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j0apf2ddqkxi2v3qqsbjbk9w5b6i7frjfyashymzcwvaz474p50",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
+  },
+  "prebuilts/clang-tools": {
+    "dateTime": 1613866113,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0fc29e79fad4981a8e7557d7b88e2c718662ce2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18l1ppiv14asv6bv2ivshdwmcgx6r100jjyrxjzl5hpi8zwm6wlm",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
+  },
+  "prebuilts/clang/host/darwin-x86": {
+    "dateTime": 1624676912,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "5148f9b446d2d57917f906208a7aa8477a17569d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ks4mbdskbwr2r8mxk3ymx68709ccm96j06hgq2wvmc4bb9ajyx0",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
+  },
+  "prebuilts/clang/host/linux-x86": {
+    "dateTime": 1624676912,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30ee97c86a2004c6053a2bf5138a3ae5ea4e45fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0a8dbqq3qlsvsdrgymjk636rlv8zspfmqzrddx9nsysvkw5wmgsd",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
+  },
+  "prebuilts/cmdline-tools": {
+    "dateTime": 1617930512,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1b6515fdf91bf24ad0d8d4266c0b3c9afb720448",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1h7r0mi51dgsgz61d3gmh0364zw8a3fgrg46fv26vwg2vj4dcp5q",
+    "url": "https://android.googlesource.com/platform/prebuilts/cmdline-tools"
+  },
+  "prebuilts/devtools": {
+    "dateTime": 1561663933,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "351536464b402284edb5adf4d20f9bfeff428f81",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1yr6acnwdmwygnvd1kljs27pnhwywgm8gv7qp1m6ir23axwydx0s",
+    "url": "https://android.googlesource.com/platform/prebuilts/devtools"
+  },
+  "prebuilts/fuchsia_sdk": {
+    "dateTime": 1605025047,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "dd503f72b5928dae74d084fc2c56f5a5a00daa23",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0j1rnznlk5z0c985xb1fl8mxk52kwjl0c0vask9hka2bqwxcj7xw",
+    "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
+  },
+  "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586495849,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "f80a7fd9407cda83d3fcffa27f5de194e1f6f436",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0svy6bm57kq0zkcmc1747x46b77jh4l0rbs8415ka50kvmhwph7s",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586495846,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "dd3fcaf4adc0f37a888bd0868b33eb2209fdd6a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wv4rh1y00w0mjp535arw85psjfbzc3gplczzdhpanr1g4im5vlp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "dateTime": 1578436765,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "674138bd3e5106876b4f5bebc9ee8ff515a76da2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
+  },
+  "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586495849,
+    "groups": [
+      "darwin",
+      "pdk",
+      "x86"
+    ],
+    "rev": "a792f659e5839b4bd8d1a10f43aec0704931cafb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1526g7ybbd0l31bvqdpbarscjsnp1rajfnb9bwyjy8wq1p4q1pcp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586495849,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "0877657b6184c2774f9670ece4a001e4517e4a46",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ag3hyvwi9sr0z95v09iwnx6n8wccxsga8z0gwgm286i0q5m4971",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586496947,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "7a4e31d6bc7cb59eabef278b386cd92f2edf53f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1am7mjlf4vsybkzgvhhiak6j00awykncg0137wqagshyz5b0sp2h",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
+    "dateTime": 1618628934,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "15eefea9049c4b489f280aeb0db2c0c545f51d6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bccbfl7imas5i47cnj5ms3lvsqkhp4nx37nbips3ia7d6fskjcs",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "dateTime": 1612577314,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "06a5e39805202b311ebbb3cbf182004ef604f11c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1a0ls85jsic0xiyifqaxsp15s046j3a28p8c5mih8ya0hbw80x7l",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
+  },
+  "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586496949,
+    "groups": [
+      "linux",
+      "pdk",
+      "x86"
+    ],
+    "rev": "0082597222937505412bb9e5416843016e5d77fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0sbw4b8f21cmhxnx6ad5ia5jz1fhv7834m8xskaw4ik5dxrarm11",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gdb/darwin-x86": {
+    "dateTime": 1575581434,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "a92807858984963ec4886ebed554bf45d95cd152",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gs89dnw1xkpb94lism8s8arhlkyq52h7w1v530a3zdj656h7xrv",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
+  },
+  "prebuilts/gdb/linux-x86": {
+    "dateTime": 1575587382,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "997e3134ecd8d08ba60986e8a4e7abbaa5456633",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v8y9rdivi8ydrbcvxrkdlzc8snjpdjwgzra2s7qrjpd2qg4k4k2",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
+  },
+  "prebuilts/go/darwin-x86": {
+    "dateTime": 1614046119,
+    "groups": [
+      "darwin",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "de638c4a75692aa34b2a528e661f9aab5ddf34be",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16hxbnamn9cayw4fv940m22k6k3yz4m9nf3liy89z7bwl008s2yk",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
+  },
+  "prebuilts/go/linux-x86": {
+    "dateTime": 1614046119,
+    "groups": [
+      "linux",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "4cfb22d1b562731d20c3c1dff51bfe519d39ae85",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07dv2mwbxazin9kf32fv6s30ac28q4khswfavql8d78zcmacgw03",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
+  },
+  "prebuilts/gradle-plugin": {
+    "dateTime": 1618024133,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "afa506cae2c012855e610fad0dcd7b9d08c42a94",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1sap095xg08fz10f6rxhnnd0c5d2xlld1zphp41hbdga5fhsn8gb",
+    "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
+  },
+  "prebuilts/jdk/jdk11": {
+    "dateTime": 1615428493,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1796563e8ade1efb4eaf7e6a9b8dd8f47c3a7c4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03wsqba6nzghhrqsvsi33rfjh8hdzx98vjkx2as0l601l21cks8n",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk11"
+  },
+  "prebuilts/jdk/jdk8": {
+    "dateTime": 1551002778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a985ddd8b2f313d5b038382e5de8536de28482c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
+  },
+  "prebuilts/jdk/jdk9": {
+    "dateTime": 1600226012,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84a82e06784660318deb7c7538c0cd2f47a2140f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0f7b8cydz6j6pvgxln6g0dp62qz0g1768zszdiwswk8zcvzk80l0",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
+  },
+  "prebuilts/ktlint": {
+    "dateTime": 1586496947,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07bd56cacae0d0e388060e3d560e2b573a250d6a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11rsh1vvx4k2wyn6cmhq7s5inrg0nrvavvdcx3jpkrvdh3lr1laj",
+    "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
+  },
+  "prebuilts/manifest-merger": {
+    "dateTime": 1613866124,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f4591d02a60057efbb95676a516fb29d6713405",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0agc0j0mvr9fbi72x9dbf4dwsf9y8k4sniajzmdnkpyy5jlixd7d",
+    "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
+  },
+  "prebuilts/maven_repo/android": {
+    "dateTime": 1572476701,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "415987aa867e948064120b5f9e2a7bcd8c6545e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
+  },
+  "prebuilts/maven_repo/bumptech": {
+    "dateTime": 1613866125,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f6f278b493250f1a93cd908397d82d1b8993dbd7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03wzcxnixq9gfzciy09qjxw97d46zdhzihgx3g5lqv6403il1lf1",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
+  },
+  "prebuilts/misc": {
+    "dateTime": 1628910531,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c514515e1083e5a5296f3817cbbf401363e64f0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1l0kg1lc81hfd890k5pba2ipbb1sjm1g62nrb1899xmd2zd6hl9z",
+    "url": "https://android.googlesource.com/platform/prebuilts/misc"
+  },
+  "prebuilts/module_sdk/Connectivity": {
+    "dateTime": 1629441561,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f5a6f0e49f076bf524af2e8d41f3f73dfb77f84",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bj7j47djf85vvvm9z579jnmzv3vy023w6ppn5007wxdgmag9p6b",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Connectivity"
+  },
+  "prebuilts/module_sdk/IPsec": {
+    "dateTime": 1628212130,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84ebf2852b243ac15d2de663eea7a2695079e622",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01n3wr58dazwv7vnc3m0ndhsx1485na87q6nbk2kvlil0vwlj3v2",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/IPsec"
+  },
+  "prebuilts/module_sdk/Media": {
+    "dateTime": 1629162528,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64ba144730642bc39ac28f1c2463806cc147c328",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0fjxn8157kmafhizglaacknyi2ddalic2agi1plwmilm2s30p16x",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Media"
+  },
+  "prebuilts/module_sdk/MediaProvider": {
+    "dateTime": 1629162528,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe8e55d7ee1097c757106aa9968e7fe328e0574a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1irq06ri1n4zbq60n00mg4sk3qyx2rl8arhcwfyxk2gg5f3qlz3y",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/MediaProvider"
+  },
+  "prebuilts/module_sdk/Permission": {
+    "dateTime": 1629441561,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "577c0951e44d00c4e2d7895ead5ffb94a38e0e8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "182fvws2xiygaia6a5prlsj7fgz69y1aklrda6pwgzrc8yhg1adk",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Permission"
+  },
+  "prebuilts/module_sdk/Scheduling": {
+    "dateTime": 1628212131,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ea5b4222a3ca2397bee3b8ef8e23d7106748995",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1glfz1sd05562ckmrfd6zlfmjx66kw05kyc7mdjv59b8q0zh56gk",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Scheduling"
+  },
+  "prebuilts/module_sdk/SdkExtensions": {
+    "dateTime": 1628816946,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c18134b7ec8b1d1d3668825d7ad1c5c811059d4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qn42nrk7yw3hw00hs5w6762p7vgzdd687pvxw7xrz2cmmjz6z73",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/SdkExtensions"
+  },
+  "prebuilts/module_sdk/StatsD": {
+    "dateTime": 1628212132,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64b51064a85d074ff3f78184cc0d80d685276fd7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0qf4ksajb7a2xh57c45zyhj6qh6p6cdvd35c97gx3fw5g941g8n0",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/StatsD"
+  },
+  "prebuilts/module_sdk/Wifi": {
+    "dateTime": 1629441567,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "01cd46fcc8cd88818062e938dd851216cffa93e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0y132kanb3acg9kcqfb60ywng65jrjsxdcibn2mgrnqnqlsikql2",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Wifi"
+  },
+  "prebuilts/module_sdk/art": {
+    "dateTime": 1632178062,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a9759da327a15d1aa6c1026ed8ae606c95cdb44",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gzv5wjia3vaddsixp2xvh6h0wj4sb3n5bjlvyvwxk06nhznq15k",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/art"
+  },
+  "prebuilts/module_sdk/conscrypt": {
+    "dateTime": 1628212130,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71299934ca07c0a95d843fd1ad7c5f7769382e87",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bd17wm8h58mqa858jzx2i58ah6x3jb0ar97fmlc01qsmkjiw8bs",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/conscrypt"
+  },
+  "prebuilts/ndk": {
+    "dateTime": 1617419308,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e48ce52c1e5c0a9a432c2576a3cd5101a8d7087a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18g58y7abpi4kgc8zphv08yg89pcs6wazzm54v89lrbry6shhdp5",
+    "url": "https://android.googlesource.com/platform/prebuilts/ndk"
+  },
+  "prebuilts/python/darwin-x86/2.7.5": {
+    "dateTime": 1446753806,
+    "groups": [
+      "darwin",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c5d250b5f9d1a16b582d4eeb04fbbc3f570cfb40",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
+  },
+  "prebuilts/python/linux-x86/2.7.5": {
+    "dateTime": 1551111763,
+    "groups": [
+      "linux",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "09dcb017c44192e2bbea1ce962f118d627b198bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
+  },
+  "prebuilts/qemu-kernel": {
+    "dateTime": 1613866130,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4b00336c8af47be3a90ba004537deb844e49810",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "174ffmr45kn5qkzbfc8a9irk8p2ksxzj5rylbbisswhlk7419rpq",
+    "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
+  },
+  "prebuilts/r8": {
+    "dateTime": 1626138648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d5e959c50eb999e830048290dfd327ac8bc2b6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "052xbmqp69pbl3p9q05jpnnzj7mws57rscgblmp2h55hnm6ay8fg",
+    "url": "https://android.googlesource.com/platform/prebuilts/r8"
+  },
+  "prebuilts/remoteexecution-client": {
+    "dateTime": 1628039335,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "12ba95deb8eec7a048f19d458d9ee969a6e3408e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zn71mv5sy36gb2gcjan8swg5y10z6r9bd5a9pmgiwsj7js3kigq",
+    "url": "https://android.googlesource.com/platform/prebuilts/remoteexecution-client"
+  },
+  "prebuilts/runtime": {
+    "dateTime": 1624929256,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d02e168b8fe7d5a3fd5d16185191707256389f8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0yyl276b039qmbz3b7mqnl4h3mqk5ggv0yq07k2hli9v09w55dha",
+    "url": "https://android.googlesource.com/platform/prebuilts/runtime"
+  },
+  "prebuilts/rust": {
+    "dateTime": 1619658543,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "055e8ef55278ae66f3d7e349e4595f473465d24c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0k1vw6hallcd3fhl6scgq89qqpi198pxwd6vd4r1rlklpm4p2xyj",
+    "url": "https://android.googlesource.com/platform/prebuilts/rust"
+  },
+  "prebuilts/sdk": {
+    "dateTime": 1628910541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "192ce52da4ddd607fd0a94e492e83d383ace31de",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1139ri4kkbd9wnih9w78gswy5qavymwjr8ay04cj924axfs2z8s7",
+    "url": "https://android.googlesource.com/platform/prebuilts/sdk"
+  },
+  "prebuilts/tools": {
+    "dateTime": 1626743381,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "e7a42c896252915105cdcff8c9ccae17b0417d61",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gqaix187cmkrnk0ydd2hz5mph334zi164jlikhn19bkgw8g75yl",
+    "url": "https://android.googlesource.com/platform/prebuilts/tools"
+  },
+  "prebuilts/vndk/v28": {
+    "dateTime": 1614650910,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f58645e2ee907270ce59c467f6b3952362577711",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "18yxf5lk692292w99xijjyr545r928lyfxclkg1hpdvf5vk04a9g",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
+  },
+  "prebuilts/vndk/v29": {
+    "dateTime": 1614650910,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "483a96da386c0a2a8206aa60335344486cda1aa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0wl0lsbf5hr6kignm6fgb9mc0p7icyzz7yd8yl7h6ngqajdzh5lb",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v29"
+  },
+  "prebuilts/vndk/v30": {
+    "dateTime": 1614046132,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "718b774bdd00d971fc7ad5b24598403546a797b2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0c1ni4axai052b98pp6d6pyl0pshbz9sczcm6y0mlfhgvmlwk7wp",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
+  },
+  "sdk": {
+    "dateTime": 1613441309,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f46926856ba4ad2b70292a647a1a5b6919e55e54",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1x4v7n0i9pcz91q5ii4lpwrmqr9v0hpwjv86mcqjzjw22rzi5rxa",
+    "url": "https://android.googlesource.com/platform/sdk"
+  },
+  "system/apex": {
+    "dateTime": 1627607340,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "57edd3e500dd54d710b296f2aedd8915c20c256f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hilaxanwsiqaq95i7qsdrirx2nxlgpisxb8djfvf6vkc062n3yy",
+    "url": "https://android.googlesource.com/platform/system/apex"
+  },
+  "system/bpf": {
+    "dateTime": 1625620159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "036fb2548becdda3f7e19b9f4916a1250196b88a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qp4zl4hzq1xdm7j6qd44bx2fb821j746vyxz9296zi6nwqaj0hf",
+    "url": "https://android.googlesource.com/platform/system/bpf"
+  },
+  "system/bpfprogs": {
+    "dateTime": 1613866138,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d566af531134807de851f77763f22ebfd865d619",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "059l6k1y7jpjbkfamq83pjj8nzmghc5pqkz1p53pn556w1hr34jk",
+    "url": "https://android.googlesource.com/platform/system/bpfprogs"
+  },
+  "system/bt": {
+    "dateTime": 1632177837,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d99a1d0742d1d416d6257f97dfb5ff9354e1ea48",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1546hkcxpmr848j5hqfwn638wz143la4m5gnb3c8ay1cp4932143",
+    "url": "https://android.googlesource.com/platform/system/bt"
+  },
+  "system/ca-certificates": {
+    "dateTime": 1613866140,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee8b4f4c9bf4d4ba019ff810fdafb5a4d74b70f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1rz4x4mrsv112csx3bykgi78rrf1sc4g8p5yvma2yyrcn7j0vxq2",
+    "url": "https://android.googlesource.com/platform/system/ca-certificates"
+  },
+  "system/chre": {
+    "dateTime": 1627002541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "589367c94934b5c463401632ee6a58b60c35f78c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jp85n2gk49wsplrnz3gd8v6d31lsccq4zdhdzg77k329rd50vmr",
+    "url": "https://android.googlesource.com/platform/system/chre"
+  },
+  "system/connectivity/wificond": {
+    "dateTime": 1625101789,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f839f8721d8c1f7b7c7c5f2b83c718e9fece2c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "10qlm9h25sa97kpsbqh8dawdq8ilb2ympk77qjqx3bcp0x5aqirs",
+    "url": "https://android.googlesource.com/platform/system/connectivity/wificond"
+  },
+  "system/core": {
+    "dateTime": 1629340744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de6f237cfb14c95534d5fd7ebe062e4b59d1863c",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ylxrb1aagyfj9bqizcmq0ckk348n0rgfsx2apxhzy0nh1ypqg8d",
+    "url": "https://android.googlesource.com/platform/system/core"
+  },
+  "system/extras": {
+    "dateTime": 1628910547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2e740c0c1a016f50c024bef3645b9ef35be1559",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1nbb1gpdxpm2dhf52p59f284ss9b9vcb1qpax14p4s89s7cr1had",
+    "url": "https://android.googlesource.com/platform/system/extras"
+  },
+  "system/gatekeeper": {
+    "dateTime": 1613532014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "38ad22ec4f7c504e7707ff0236ae17ef788d59bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wxbr2nrgv2w9zwy8vf7pi4vnjcs6jrhg7p0psp36iqqpj46ncpc",
+    "url": "https://android.googlesource.com/platform/system/gatekeeper"
+  },
+  "system/gsid": {
+    "dateTime": 1625706749,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "45990a0f872b8712eebd37eaff9a7eb61576831e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13xicpg8wk1y021a3lxlq49vr51v2nicfwn3zavvz0xgs065ygzs",
+    "url": "https://android.googlesource.com/platform/system/gsid"
+  },
+  "system/hardware/interfaces": {
+    "dateTime": 1629340746,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "37ee20b11f0ee5c8b7a5b0d740b473b9af9cdd52",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1wazlzks5irs3lx3glj150xx284gm8611x58vn1hyv0qbp2hzj85",
+    "url": "https://android.googlesource.com/platform/system/hardware/interfaces"
+  },
+  "system/hwservicemanager": {
+    "dateTime": 1622862571,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a614474fa9dce8f26a8926cf1e38a34e8715b40f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03sg3s64q6iik4i0b8l57dz5m1xxk9dfyqirz72y61ycl4hnagmr",
+    "url": "https://android.googlesource.com/platform/system/hwservicemanager"
+  },
+  "system/incremental_delivery": {
+    "dateTime": 1632177840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e24e625ca5677f7f0435526e3b8e4d553876cdc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qlkk5jyqyqs69h5pl0hi53qfh8f8z9f7vllrrd4vbckl1bp57gn",
+    "url": "https://android.googlesource.com/platform/system/incremental_delivery"
+  },
+  "system/iorap": {
+    "dateTime": 1626224981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87a45d4663ed3576070e99d9abad5729b85ed023",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0q3ip59rm8b3x3ralfn414bc0q51p42hxk2n2mr9pdd7d3vhmbpb",
+    "url": "https://android.googlesource.com/platform/system/iorap"
+  },
+  "system/keymaster": {
+    "dateTime": 1628910551,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb4b40ef34e06e4840100047b61a851ab716f715",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xfnh774f4s4rkyhpjm2y9lrzha5rp4scbym25jqnlzxamzcnv8l",
+    "url": "https://android.googlesource.com/platform/system/keymaster"
+  },
+  "system/libartpalette": {
+    "dateTime": 1623287367,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c33ed6cf8fe99b5b77751ddea6fc2c9984b3e318",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05l8n7nm3xzcxf8fi5mzbq62hxkgi3wk2sppi416jyfbznvs3h8p",
+    "url": "https://android.googlesource.com/platform/system/libartpalette"
+  },
+  "system/libbase": {
+    "dateTime": 1619745101,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bc6c6226617be836088cb2e752ae31fb9106e239",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0h5aw1r81ikh1y5723m8nzdl3z6f3fq7krrzjfrv80x8zwvgyml2",
+    "url": "https://android.googlesource.com/platform/system/libbase"
+  },
+  "system/libfmq": {
+    "dateTime": 1622077832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39bf6e401ca1e481bf5d319af650dbec05f1f2fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gnrsz7k2ish726cdcysa2z0ai6npxnx9kpgpq65crakcnswkdgd",
+    "url": "https://android.googlesource.com/platform/system/libfmq"
+  },
+  "system/libhidl": {
+    "dateTime": 1625101795,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa1b2c8c027739f5c18a029994b4afcfd662e1f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1y1sw5p7dlal4b74r00jp6p0y5mjpablpli42cdcq5byhayz08r8",
+    "url": "https://android.googlesource.com/platform/system/libhidl"
+  },
+  "system/libhwbinder": {
+    "dateTime": 1622077833,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c677b8633c90ff22b14b54a42b40bd8adbec62b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "09nwism5hs2514pqccyh5nk558z2qrvrh2fhmqmfv3pm9sdd6bwj",
+    "url": "https://android.googlesource.com/platform/system/libhwbinder"
+  },
+  "system/libprocinfo": {
+    "dateTime": 1625706754,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34cb8b6f88f02cc55ead0cf2f3fb31615ea5d8e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "015y2lxpg1w3ijvlfridfwnbjvqd6gcsgya6fri8xn651m5bhdlz",
+    "url": "https://android.googlesource.com/platform/system/libprocinfo"
+  },
+  "system/libsysprop": {
+    "dateTime": 1618880965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5de42fc80d88524e8b22bc5a2fb5a5fa2f365e8b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0m6nk4r3rp267mlc7pi9cq19a2npb836cf5kv8k1xza1iqiaq0bj",
+    "url": "https://android.googlesource.com/platform/system/libsysprop"
+  },
+  "system/libufdt": {
+    "dateTime": 1620263383,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51727de28aaa66f95381390eaf355edd417c5f49",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lx95r91jpfcqhp9d91yvn6z5rdym4s4z2l3v2sa84dqpb72frpp",
+    "url": "https://android.googlesource.com/platform/system/libufdt"
+  },
+  "system/libvintf": {
+    "dateTime": 1620868161,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "152dc708c3b6597adb6aa10e9b5d0041aa787e9a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11rp914fxzapbdksjn6clmj40n9gmybgdqnngcppyqk4gs97bwz3",
+    "url": "https://android.googlesource.com/platform/system/libvintf"
+  },
+  "system/libziparchive": {
+    "dateTime": 1619140432,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccc61121968cd98f2fae88f078859c909934158e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0xhrhxj1f2cbknk5dgld8v9rhrzk22p2q6dzdhnlvyqgqzyf4rg0",
+    "url": "https://android.googlesource.com/platform/system/libziparchive"
+  },
+  "system/linkerconfig": {
+    "dateTime": 1624496955,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d023580fd7dcde736d271890e992981c7ee16eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1090jz2sdzzv677q42xs7d4p7y0wasnhydp6pj5kcg9d33gdfhc3",
+    "url": "https://android.googlesource.com/platform/system/linkerconfig"
+  },
+  "system/logging": {
+    "dateTime": 1628730561,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43fc3ad048a3129b5d102a9ed362a34280b0f566",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v7nk3yyllk4ah448kkjil1idv017h1zmi2qslp5zl19c9k1n495",
+    "url": "https://android.googlesource.com/platform/system/logging"
+  },
+  "system/media": {
+    "dateTime": 1628910557,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c1a5d75dea5f44c1333a7f2288eeb4605b22356",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0ny4n3qpm8rf87scd32a25a0m9nf82rfl3yinhksj0qk3f9v0kqs",
+    "url": "https://android.googlesource.com/platform/system/media"
+  },
+  "system/memory/libdmabufheap": {
+    "dateTime": 1628910558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ed76fb26353871bb3d38bc30ed782eacfc64732",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03l8sr6dmi8rnf9psclm0sg0pwqfnp7vknc6vydxgbz1gjxgdr34",
+    "url": "https://android.googlesource.com/platform/system/memory/libdmabufheap"
+  },
+  "system/memory/libion": {
+    "dateTime": 1613866148,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ae3c997e314f8dcee2c0c74e3cdf71d4e0f26c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0jmb5lh6hgyzpsp711dd5igns56xls0crb2aqnzwqfyvn6dinbz3",
+    "url": "https://android.googlesource.com/platform/system/memory/libion"
+  },
+  "system/memory/libmeminfo": {
+    "dateTime": 1626397924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef08468788ab6b009e5b641e61956422725e20c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hxknnvj22ap00v3nsh6867vi1bcb6dpsm90n223c7z0247kb5az",
+    "url": "https://android.googlesource.com/platform/system/memory/libmeminfo"
+  },
+  "system/memory/libmemtrack": {
+    "dateTime": 1617844159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8d83622c0aa2d076fe89e23095b7b8eb0644b21",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1v1zrkh94ynxgsi30s5i1ivahdabv10clysam1v1c762rczsgr8v",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemtrack"
+  },
+  "system/memory/libmemunreachable": {
+    "dateTime": 1623374314,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cedb34829203545298ea35f1453b869cddcd2423",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1hg82k95l8ph8phl9n982yxy016z68m4hbwjj5sdsnmi217v2cpy",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemunreachable"
+  },
+  "system/memory/lmkd": {
+    "dateTime": 1627096168,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "981421d6632b271d52a2285a8517e0110d9dd19a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zlvab36smkk5wzi57jiwyw5pw5d911gyp3i2v0mc95q2r171a8y",
+    "url": "https://android.googlesource.com/platform/system/memory/lmkd"
+  },
+  "system/netd": {
+    "dateTime": 1628910560,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da1c3ab83272905b72f5570d97e4737dc2625592",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qjcbfimki4jvhndiv400h232dpy9hibwfhjksmdnmsbkd7zz8sg",
+    "url": "https://android.googlesource.com/platform/system/netd"
+  },
+  "system/nfc": {
+    "dateTime": 1632177833,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "461dc1d3ddb7d3319f8a199b8dc190d7cd2cbe1b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0dyhv0n0a58y0mw1rxkr806dayvq444h2bm1mva79phzmb92mjsg",
+    "url": "https://android.googlesource.com/platform/system/nfc"
+  },
+  "system/nvram": {
+    "dateTime": 1612577346,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b318d555b12344d3bcdf553649a686f7107865d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "05xspxnd1366hmv4sjq2fmhbgjq4camppfnqpmakkydd4pw4qnn0",
+    "url": "https://android.googlesource.com/platform/system/nvram"
+  },
+  "system/security": {
+    "dateTime": 1628910562,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe8532cea0525e867b424675fe255c14307d3bfc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1iv6pcwja9pjjywf3hjxk6flgcqby7dsmc8f297c6750z8djs9dd",
+    "url": "https://android.googlesource.com/platform/system/security"
+  },
+  "system/sepolicy": {
+    "dateTime": 1629441558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81b700532fe7dc4e747d3ecddfb4f356dfd347dd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "15mja7cys0x123v5ycb8d786jqr899fqnxm8s5jw3d2w24j84545",
+    "url": "https://android.googlesource.com/platform/system/sepolicy"
+  },
+  "system/server_configurable_flags": {
+    "dateTime": 1613866152,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff4d441eeb60ef2da0d3bdd32b5fad7f6bea26d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1ih665qh777kw9vyz8sgsbk3nm2bnhklir7v4df25j8wdr8kw4hv",
+    "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
+  },
+  "system/teeui": {
+    "dateTime": 1617066552,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3cc03ddc26bbff9b492d0054be7e59cc68077c14",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1bicz4kmz79mifxfmzc2rzrgvp95zmcxm7giw8lqsigv32m55avl",
+    "url": "https://android.googlesource.com/platform/system/teeui"
+  },
+  "system/testing/gtest_extras": {
+    "dateTime": 1613866153,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "06c88d5c497d8893ffa3ecd894933aae7a13f67f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v5ifyrq7wxsm0mh9843fidj4jmr2x10xqdvdwsshb1p17hxjyyp",
+    "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
+  },
+  "system/timezone": {
+    "dateTime": 1627952952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab96f7acce7876943d5609914aaf3c5099e7fefc",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13xdgikj46ffw18bn25c17n78biy41c8nraswsrfxl1pfcfq73df",
+    "url": "https://android.googlesource.com/platform/system/timezone"
+  },
+  "system/tools/aidl": {
+    "dateTime": 1627434619,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "877d6132a6a4f27fcae81a240f15edf726eb5aff",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0nzvdrjj211iavx6f69kqc1wk4ifzw9yl8j11bmmhzv31qsir7c6",
+    "url": "https://android.googlesource.com/platform/system/tools/aidl"
+  },
+  "system/tools/hidl": {
+    "dateTime": 1627700964,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3fdc5cb42d57811cda49019d7983ee9c20b4b3a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "14klv5dx95fcihfck1r41bz9nxgcblf838sj62mad685pjmah7fb",
+    "url": "https://android.googlesource.com/platform/system/tools/hidl"
+  },
+  "system/tools/mkbootimg": {
+    "dateTime": 1620263394,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da844fe0e84ae3f3824151138ba004033eb00e6b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1agwi6aripi1mwv9cx38q5944g7nw3kccfwa2y73n3v22vrnlw4r",
+    "url": "https://android.googlesource.com/platform/system/tools/mkbootimg"
+  },
+  "system/tools/sysprop": {
+    "dateTime": 1616634537,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "038886b1423b25424d82a5305d24cca7d3dbdf47",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0hvq6n3kj0lyyx782wwy32q1m24qclkmas5jdb2wy5hxcrsqvwds",
+    "url": "https://android.googlesource.com/platform/system/tools/sysprop"
+  },
+  "system/tools/xsdc": {
+    "dateTime": 1624410572,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f1003b358cb81ae2eaed885bd6fb86eb01bc98f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01kh80wg5r9b1csz23p7x0rqlpb26x5z4r4gi2y4ibisy5bva3w4",
+    "url": "https://android.googlesource.com/platform/system/tools/xsdc"
+  },
+  "system/unwinding": {
+    "dateTime": 1625706774,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19bd041d1847bf191d2a1c5c3f0228e61c183c43",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zhi0ck2j28qqsdy20jzh9ik3w7wyxb106f7q69nv7b9gdkdd3da",
+    "url": "https://android.googlesource.com/platform/system/unwinding"
+  },
+  "system/update_engine": {
+    "dateTime": 1627434622,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "694b09fa6c67f65e8d859cb85102c9e176d9f34d",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "16xv9rd7bwjz6i95xr8y2kqmck9lb8pka2w6zc55x8scwxa3f2n7",
+    "url": "https://android.googlesource.com/platform/system/update_engine"
+  },
+  "system/vold": {
+    "dateTime": 1628910568,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf701460f97c3bb12a67e417a80d917d0e408a83",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0k85r9ggw0a96mcs1kwg27bb2mqijqgskkp1j39ilgwj73ng03ad",
+    "url": "https://android.googlesource.com/platform/system/vold"
+  },
+  "test/app_compat/csuite": {
+    "dateTime": 1620350066,
+    "groups": [],
+    "rev": "872d6b5faa2ce9e562bf4a8163dbe0f35473d543",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "11h6hldlwrcfk314wn77a218384yh4kz4xz3nzvy3yqm99ywhz8n",
+    "url": "https://android.googlesource.com/platform/test/app_compat/csuite"
+  },
+  "test/catbox": {
+    "dateTime": 1628982569,
+    "groups": [],
+    "rev": "cf1f012d3d6d2b2112b4961b374a1480ddaad24b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02lahsm3xbcr6rgjkwknwwi6sm5w79h0wpg4mm89y6vh2yrf60b6",
+    "url": "https://android.googlesource.com/platform/test/catbox"
+  },
+  "test/cts-root": {
+    "dateTime": 1624676963,
+    "groups": [],
+    "rev": "d8843c4c69c0ecdf7ffd56fa3feba610dd6ce631",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1garbzndz4qsxmv6cys2zf3gwlsay5yw5svfbz770hhim4i037b6",
+    "url": "https://android.googlesource.com/platform/test/cts-root"
+  },
+  "test/framework": {
+    "dateTime": 1613866158,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "b9af4577fa2ca30e299d83c632948c2bef1dc1bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1p4gak809gfak9r64pzrq708p53i7y7045x10q7ji16jycw123lv",
+    "url": "https://android.googlesource.com/platform/test/framework"
+  },
+  "test/mlts/benchmark": {
+    "dateTime": 1619485758,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e8e456dea3e9b1897923b62dc275e5c6b3a6104",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0n5yjswf4lnshqg8y0lb2wi65gqqqa0xjfgffkif6m8ma6642mh5",
+    "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
+  },
+  "test/mlts/models": {
+    "dateTime": 1594523026,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1f2b6787f48eea1331cacbd723915266fc056335",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "136fcq4lmc69yp1gzlynvrv7126z91aw2l1y1gns0d69xk9hfbjf",
+    "url": "https://android.googlesource.com/platform/test/mlts/models"
+  },
+  "test/mts": {
+    "dateTime": 1628557796,
+    "groups": [],
+    "rev": "3d076cd08ce894acb31bf22d5f659287d7e3e70f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0vwwzl8mqyvr2lc2cm0c0nlw8x03smqvflh93hq138rnpmdwd7qc",
+    "url": "https://android.googlesource.com/platform/test/mts"
+  },
+  "test/vti/dashboard": {
+    "dateTime": 1551088143,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "1d319d8e8126c8d1df9236ce66bfe4d48dbd6650",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
+    "url": "https://android.googlesource.com/platform/test/vti/dashboard"
+  },
+  "test/vti/fuzz_test_serving": {
+    "dateTime": 1551002920,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "651af906ae4259d06ec094784968dc8bafa4f27a",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
+    "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
+  },
+  "test/vti/test_serving": {
+    "dateTime": 1588820910,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "7837d124efb9918c4f23f4a869c3ae59727555f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12y5bwvhbj1yscbi87irp0xgwmb018fck905zf678aii8qckhp9l",
+    "url": "https://android.googlesource.com/platform/test/vti/test_serving"
+  },
+  "test/vts": {
+    "dateTime": 1628910573,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "009d92415368884a5268011db6f479d8450bccc5",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1din8aywgwyivk6dskkz5d3wr28nkxbcmd5wikviww2r0mjx51w0",
+    "url": "https://android.googlesource.com/platform/test/vts"
+  },
+  "test/vts-testcase/fuzz": {
+    "dateTime": 1613866164,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "1336c16340ff52412021a0ed04960ebec93ce31e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "106hmz81aaqpy3gq6apgz4a1j6nmvhzp8rbzpldqcl7ymn552h76",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
+  },
+  "test/vts-testcase/hal": {
+    "dateTime": 1628910574,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "7ba2768b217a22b2cbd2fd8ddda1ae7364ad8c82",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1im3dxiz9m5akg4r3zjcnsmdx4ml6khdym58h45bn9v913is6r2i",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
+  },
+  "test/vts-testcase/hal-trace": {
+    "dateTime": 1551088166,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "aef6d21220fc86443d4290dff81b33d0edcc2f13",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
+  },
+  "test/vts-testcase/kernel": {
+    "dateTime": 1628910575,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0183331e4a1d030b4192d52b4330f331af029057",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dznqir4b3b8klcwh0h3qrbvbdrd4rx9gjpsygf7gry0nasbsh6g",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
+  },
+  "test/vts-testcase/nbu": {
+    "dateTime": 1613866166,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "93719b3ce165d118bb4c779e9cddba9e455dbc29",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1h3vd99wax8n5ygs6cg15f0p8kj07kas75n72j7b20n4qdy2bflz",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
+  },
+  "test/vts-testcase/performance": {
+    "dateTime": 1613866167,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0f060cc514a1d4bdd78e2dc97bbd357f6c338372",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dh5n3pprrdb607f3jriz2madgq3ri8fv4c4mcmqld5fbc56w05b",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
+  },
+  "test/vts-testcase/security": {
+    "dateTime": 1629162573,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "a212cbc3289d37d098d96b59cbbaa942d994bd39",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "08rnpidhp5h8yljvv6syb8sykqwqyyk996gc4sgml1kbx4h393q3",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
+  },
+  "test/vts-testcase/vndk": {
+    "dateTime": 1618880988,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f2248b5be767b37a4fc6ba2d87c3e0dae5b74f97",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0k1q28rbqw01qy4r0v7j875zfjywc88rhs8szg10pdg3j9cin6l5",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
+  },
+  "toolchain/benchmark": {
+    "dateTime": 1613866171,
+    "groups": [],
+    "rev": "eff49ab2f0be1bd6b643f9fad2a280037c87170f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "04c2hzbgqxcim23z4brvq0px4cifmz52434lxacq741kqy8a3yn8",
+    "url": "https://android.googlesource.com/toolchain/benchmark"
+  },
+  "toolchain/pgo-profiles": {
+    "dateTime": 1626491414,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "afc71f0bcd580c596aca838abe026b2a90bada12",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "023wq00bzc3lafcy4l4dwyhx0dxlpxikqr7wixj8jvz39n0hlq9g",
+    "url": "https://android.googlesource.com/toolchain/pgo-profiles"
+  },
+  "tools/aadevtools": {
+    "dateTime": 1619997024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87d0d33b9cef103db409b6c7804244accddaa258",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1zb9yfwjj9f0hk75vi7qg9j3fllpk3n5mfhgky8z385bh2jmzk5v",
+    "url": "https://android.googlesource.com/platform/tools/aadevtools"
+  },
+  "tools/acloud": {
+    "dateTime": 1620954588,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "tools",
+      "tradefed",
+      "vts"
+    ],
+    "rev": "9ef03640565579ad749b3fafada05be607e8692e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "02svjyi2vj85r6yi6k5i0xffkxkkxh6iyf7bpf99aiwq80aw3hfq",
+    "url": "https://android.googlesource.com/platform/tools/acloud"
+  },
+  "tools/apifinder": {
+    "dateTime": 1623287397,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "4a9927afeeefb111714f081499b491e0ce6d9d2b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0bfac5abla83d56kz7hvwdb12h60h90lj9ahy7cgg75qfgjnj9ic",
+    "url": "https://android.googlesource.com/platform/tools/apifinder"
+  },
+  "tools/apksig": {
+    "dateTime": 1622257780,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "aa8c65ec8b46a5507399ff69ac59c355f1b870de",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1dl6k7qnk9kl26sdr3a6hy2mg9939a20bk7qp11jb3c5vnmarcsy",
+    "url": "https://android.googlesource.com/platform/tools/apksig"
+  },
+  "tools/apkzlib": {
+    "dateTime": 1619485771,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "0618ae018c6d6dd47cead75bb831ed88c2e5bc76",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qbj6g2jivxjlxgm1z27anqgb0hh50fm3mqfpb4bd55mqn73csi8",
+    "url": "https://android.googlesource.com/platform/tools/apkzlib"
+  },
+  "tools/asuite": {
+    "dateTime": 1628039381,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "91cd88b3cc6467b2ec460e0f9bdb5b4fa1546570",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0lhpqxdbakqawxvkm8ad53m11yvcha5s75jzcqyni806wcspnc2w",
+    "url": "https://android.googlesource.com/platform/tools/asuite"
+  },
+  "tools/carrier_settings": {
+    "dateTime": 1619838584,
+    "groups": [
+      "tools"
+    ],
+    "rev": "bfae438ea004235cee6b4e072ad5bf113c8042ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1gcpddy94nmhqbmpr3y1s6b29w6zx3r5ixn53hd0s4y0rfw9ahj6",
+    "url": "https://android.googlesource.com/platform/tools/carrier_settings"
+  },
+  "tools/currysrc": {
+    "dateTime": 1611368165,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9bc2b8bcaf750e74bef9a7883ba1e148305f1477",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0h3smd8j3lrd8lnmzcpirn70k9q8l645sbgzfw6cxdrzbi7p2d1a",
+    "url": "https://android.googlesource.com/platform/tools/currysrc"
+  },
+  "tools/dexter": {
+    "dateTime": 1614996550,
+    "groups": [
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "edaf6ec0fc858c8e3cb8eeb73d71e6d9ba6a5352",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1mmldb1h69bcxil78y708hfzr1v5s7y547j0v9cb2vgg48m109dg",
+    "url": "https://android.googlesource.com/platform/tools/dexter"
+  },
+  "tools/doc_generation": {
+    "dateTime": 1613866176,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "5aebd0e5cb480d1edb6061fb531577cfb2c753b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "03gsa3dsaxzxsbmj00dpp2c2x9gq0rv9adqmibic0ciw6q1pm6mw",
+    "url": "https://android.googlesource.com/platform/tools/doc_generation"
+  },
+  "tools/external/fat32lib": {
+    "dateTime": 1613441348,
+    "groups": [
+      "tools"
+    ],
+    "rev": "4ac33e3d61ac4882f75694531240be74695fbc9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0zx9wqm0l5w1ghcyj49bsfm39y8b97bckfmy9l5r62f6yx4hcgsh",
+    "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
+  },
+  "tools/external_updater": {
+    "dateTime": 1620954596,
+    "groups": [
+      "tools"
+    ],
+    "rev": "42055d30ec1f5ff37d44d62d1e0cd455bd16232e",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0aa7dhk94wdc6qa45q2bhc8qc17x7f4n53gn8bqb06pdvwdiilmz",
+    "url": "https://android.googlesource.com/platform/tools/external_updater"
+  },
+  "tools/metalava": {
+    "dateTime": 1623374349,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "07b5ce345cddeabb7ac6250e0f10bc9c574c4a4f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "01clliylngzky0lljv77vw9bf52ca4jqv8g62867wcw46vh7n5lj",
+    "url": "https://android.googlesource.com/platform/tools/metalava"
+  },
+  "tools/ndkports": {
+    "dateTime": 1599793810,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41a55def41fb06c0d77e8aee220e4441c8a91824",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "13f0scvw1gkwjx24l6hqgk9v7q919zilas7v0b6h8pg2akiyd45h",
+    "url": "https://android.googlesource.com/platform/tools/ndkports"
+  },
+  "tools/platform-compat": {
+    "dateTime": 1621386604,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5f1cea624788e2d2d39abb69db9addef3a46f87b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1swgzjiagj0qz7grj6c33wbgyqrfv48k35xl53szgbymd0y7kg4k",
+    "url": "https://android.googlesource.com/tools/platform-compat"
+  },
+  "tools/repohooks": {
+    "dateTime": 1611281631,
+    "groups": [
+      "adt-infra",
+      "cts",
+      "developers",
+      "motodev",
+      "pdk",
+      "tools",
+      "tradefed"
+    ],
+    "rev": "38bd8f778f9b882e1932a288c4fdb04c16b55e56",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0c525jc6ysp6iqzjdqhmp47mb5cn2wx6aay8cknmjq9wnl9yjbld",
+    "url": "https://android.googlesource.com/platform/tools/repohooks"
+  },
+  "tools/security": {
+    "dateTime": 1620090587,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "982a0ab333898e5798afaed27414bca619e71314",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1pd6isfz0nab12mqmczmyvvp1dhsz1q18m7wzbh0mz3s4584dip4",
+    "url": "https://android.googlesource.com/platform/tools/security"
+  },
+  "tools/test/connectivity": {
+    "dateTime": 1629162590,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4fc2029ff0a1bce719eea5223c1842fe60a7ccd",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0gv4cl60l5988cbc8xik1hnjgx3cjdp0gw8k4i5c05gs2wydf7j5",
+    "url": "https://android.googlesource.com/platform/tools/test/connectivity"
+  },
+  "tools/test/graphicsbenchmark": {
+    "dateTime": 1619053794,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ca3b2bd680a5942cc0733e885fbd8b86a6c5c9f",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "0v5b8p7lwcwrmd1sxc6axf7qkdqyq9p5dqcyazngr0amhdf2xg0j",
+    "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
+  },
+  "tools/test/openhst": {
+    "dateTime": 1613866187,
+    "groups": [
+      "tools"
+    ],
+    "rev": "893961654f56ab37d96ae60b37af842d6298af22",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1qlnvcpsy11nd9cjjh6yy1bhcsikx3xg5rzkqbfhli0q0a5jwrpp",
+    "url": "https://android.googlesource.com/platform/tools/test/openhst"
+  },
+  "tools/tradefederation/prebuilts": {
+    "dateTime": 1628910594,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "a4c2db7b3ee3f6cbebb8f8c3dafb3651798c07d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "00pkpabpc8xa0k9aja8myfzfai63d9srkn9ia62797m76sgdy64j",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation/prebuilts"
+  },
+  "tools/treble": {
+    "dateTime": 1619745181,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "b1dfe2b8d51c2e6fd9f61ec24de0ddede0f2532b",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1cm4prh06srq421ibkac8s9kdjxvq6s0gy336sa92wc886hg8k2d",
+    "url": "https://android.googlesource.com/platform/tools/treble"
+  },
+  "tools/trebuchet": {
+    "dateTime": 1620954606,
+    "groups": [
+      "cts",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "dfe6913fcbcf96521fd3b8186e9fc3695f4c0c87",
+    "revisionExpr": "refs/tags/android-12.0.0_r14",
+    "sha256": "1i3iz9fyd0jbvmjawxy3w0qvf6ycnv6jvmxk6c7xm272ad43gxag",
+    "url": "https://android.googlesource.com/platform/tools/trebuchet"
+  }
+}

--- a/modules/apv/latest-telephony-provider.json
+++ b/modules/apv/latest-telephony-provider.json
@@ -1,9 +1,9 @@
 {
   "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider",
-  "rev": "7c376deb24af2a6ad28fac211ec9f3bb373bc023",
-  "date": "2021-10-07T23:50:29+00:00",
-  "path": "/nix/store/r30mn9py7x7i1vlaxyan8s8zv6khv9y9-TelephonyProvider",
-  "sha256": "10la1s0w5qy0aifcswzn5i7sijf828fbxz45ncfp22ci465nsz5l",
+  "rev": "198a7ea779d76760dcbb7a4d23cf38cb10d5c289",
+  "date": "2021-11-12T08:43:51+00:00",
+  "path": "/nix/store/jcycbjmndw82vay5rikwvn3zaymr8183-TelephonyProvider",
+  "sha256": "02pqfacv0xngaha0kj56jx6sm2xrdv88w3k1kc2xkk4xpq9wbngq",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/modules/pixel/pixel-drivers.json
+++ b/modules/pixel/pixel-drivers.json
@@ -24,6 +24,14 @@
     "sha256": "3c776c0ee304ed78f29f6ae0ee784b06b15a4214491df413894e4fa184e20e12"
   },
   {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-oriole-sd1a.210817.037-12db5cf3.tgz",
+    "sha256": "e020216a82294b42dd4aa58c39eed84521d5adfa5c303587a0489eae10de4b0c"
+  },
+  {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-oriole-sd1a.210817.037.a1-6978ded8.tgz",
+    "sha256": "04999922e7a844f0697f2edc3f9cc6337edd34f2c7f9b1e406ad7edb714b4916"
+  },
+  {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.015.a4-31a5656a.tgz",
     "sha256": "4267914736943b542103ee037b872084fce71b06f90c3f638cd7aca7d009abb4"
   },
@@ -46,6 +54,14 @@
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.036.a8-03abedb7.tgz",
     "sha256": "0165fec18bb51d63dc213b340caaf732b0f0815513f85eff1079e6c3b2b22be7"
+  },
+  {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.037-a7c22bf5.tgz",
+    "sha256": "1fd21d28123c5a3ae4c77d042f10b78c435dad9e1b841690c63751a8bddb5fa2"
+  },
+  {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.037.a1-fc28fe0d.tgz",
+    "sha256": "5beb707052bc5d8608ebc87c3b48f91de299d5dc3a56247351d6a2272b2deb50"
   },
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-barbet-rd2a.210605.006-22c86344.tgz",

--- a/modules/pixel/pixel-imgs.json
+++ b/modules/pixel/pixel-imgs.json
@@ -36,6 +36,18 @@
     "sha256": "65854912c9891bc163c2a662f1650753ecbb4f0d7c4bb0493eb51f24387700c6"
   },
   {
+    "device": "oriole",
+    "version": "12.0.0 (SD1A.210817.037, Nov 2021)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-sd1a.210817.037-factory-ae9f34e0.zip",
+    "sha256": "ae9f34e05fbb439c95d509a4ffa1dc0877cdcc0f3cd5248f5c7032f3483566b2"
+  },
+  {
+    "device": "oriole",
+    "version": "12.0.0 (SD1A.210817.037.A1, Nov 2021, Verizon)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-sd1a.210817.037.a1-factory-de27b0ae.zip",
+    "sha256": "de27b0aeedcf42bf409d3614f97861e36bf40dcf8eef478b25365bcbc2f8f73a"
+  },
+  {
     "device": "raven",
     "version": "12.0.0 (SD1A.210817.015.A4, Oct 2021)",
     "url": "https://dl.google.com/dl/android/aosp/raven-sd1a.210817.015.a4-factory-bd6cb030.zip",
@@ -70,6 +82,18 @@
     "version": "12.0.0 (SD1A.210817.036.A8, Nov 2021, Verizon)",
     "url": "https://dl.google.com/dl/android/aosp/raven-sd1a.210817.036.a8-factory-7352ca24.zip",
     "sha256": "7352ca245a03aa460322d0f4aead47935224ca8ddf3840d4c84405a730a79162"
+  },
+  {
+    "device": "raven",
+    "version": "12.0.0 (SD1A.210817.037, Nov 2021)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-sd1a.210817.037-factory-0827bca4.zip",
+    "sha256": "0827bca482a4fc8620032c3e5144699ff505a01e7fcd1821686b1c71c8ac0f03"
+  },
+  {
+    "device": "raven",
+    "version": "12.0.0 (SD1A.210817.037.A1, Nov 2021, Verizon)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-sd1a.210817.037.a1-factory-0245a00a.zip",
+    "sha256": "0245a00aad1f3dd53d3262ab8583bf2ec99c6f15faf93966703dc1a5a9b39fe3"
   },
   {
     "device": "barbet",

--- a/modules/pixel/pixel-otas.json
+++ b/modules/pixel/pixel-otas.json
@@ -36,6 +36,18 @@
     "sha256": "41f0de8282beac2f3a71e0f6522b570d5f94b40fda10aea34dec347a6502d5a5"
   },
   {
+    "device": "oriole",
+    "version": "12.0.0 (SD1A.210817.037, Nov 2021)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sd1a.210817.037-933c0db2.zip",
+    "sha256": "933c0db24a2434eebbaaea0a77f07f3096e0c55c18cb42d9d05e06cb85c97b1a"
+  },
+  {
+    "device": "oriole",
+    "version": "12.0.0 (SD1A.210817.037.A1, Nov 2021, Verizon)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sd1a.210817.037.a1-13ffb191.zip",
+    "sha256": "13ffb1911a02dd16149f421bc63cf146fdf126124e7d1e73f53a5bea657ad564"
+  },
+  {
     "device": "raven",
     "version": "12.0.0 (SD1A.210817.015.A4, Oct 2021)",
     "url": "https://dl.google.com/dl/android/aosp/raven-ota-sd1a.210817.015.a4-83028e9c.zip",
@@ -70,6 +82,18 @@
     "version": "12.0.0 (SD1A.210817.036.A8, Nov 2021, Verizon)",
     "url": "https://dl.google.com/dl/android/aosp/raven-ota-sd1a.210817.036.a8-b21a7e4f.zip",
     "sha256": "b21a7e4f609d07a4cec139a4714af5a116a712bcf2f18ad71dea8f27b6e08163"
+  },
+  {
+    "device": "raven",
+    "version": "12.0.0 (SD1A.210817.037, Nov 2021)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sd1a.210817.037-1543ec70.zip",
+    "sha256": "1543ec70cdd0cbca70f47335c305625d97b00b0a819fc84bd21d9300ea765e14"
+  },
+  {
+    "device": "raven",
+    "version": "12.0.0 (SD1A.210817.037.A1, Nov 2021, Verizon)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sd1a.210817.037.a1-9436a359.zip",
+    "sha256": "9436a359659e5f42bd7cff4d98c913ffddc4680938ca91a1b1bde7c51ea3990c"
   },
   {
     "device": "barbet",


### PR DESCRIPTION
It's a tiny OTA containing firmware updates that can supposedly bring ["some fingerprint sensor performance improvements"](https://support.google.com/pixelphone/thread/135866170/november-software-update-for-pixel-6-and-pixel-6-pro-us-and-japan-only-selected-carriers?hl=en&msgid=135866170). I ran diffoscope against SD1A.210817.036 and SD1A.210817.037, and here is a list of changed files in the vendor partition:

- `vendor/apex/com.google.pixel.camera.hal.apex` (Camera)
- `vendor/firmware/cs40l20.bin` (Vibrator)
- `vendor/firmware/g6.app` (Fingerprint trusty app)
- `vendor/lib/libsitril.so` (Radio)
- `vendor/lib64/libsitril.so` (Radio)
- `vendor/lib64/libgf_hal.so` (Fingerprint)
- `vendor/build.prop`
- `vendor/odm/etc/build.prop`
- `vendor/odm_dlkm/etc/build.prop`

I tested it on my Pixel 6, and it did improve the success rate with my thumb noticeably. For some reason, only my thumb was particularly problematic and I could unlock with my index finger fine (but it would be very awkward). Note that I did try re-registering the finger a few times. So I assume they adjusted the acceptance threshold or something along those lines in this update. It did *not*, however, improve the speed of the sensor.

[The comment section at Android Police](https://www.androidpolice.com/google-addresses-pixel-6-fingerprint-sensor-problems-with-surprise-software-update-but-only-for-some/) has some more anecdotal evidence of the improvement.