### PR TITLE
grapheneos: 2021111414 -> 2021112021

### DIFF
--- a/flavors/grapheneos/repo-SP1A.210812.015.2021112021.json
+++ b/flavors/grapheneos/repo-SP1A.210812.015.2021112021.json
@@ -92,7 +92,7 @@
         "src": "core/root.mk"
       }
     ],
-    "dateTime": 1635876894,
+    "dateTime": 1636113780,
     "groups": [
       "pdk"
     ],
@@ -122,9 +122,9 @@
         "src": "tools"
       }
     ],
-    "rev": "4e532f414872fc199099cef09710167c2c8b3cf3",
-    "revisionExpr": "4e532f414872fc199099cef09710167c2c8b3cf3",
-    "sha256": "0hxrsznhh0281svf71s83i5zw7s7qbfsni2lgvirjzwa5wmvkdpi",
+    "rev": "a401fcd344cd6c76c302a42a557c5ab3c03935c0",
+    "revisionExpr": "a401fcd344cd6c76c302a42a557c5ab3c03935c0",
+    "sha256": "0rfkh6z0swmykf9z1z3flsplf7l3aiw27yn2rz1vhzwq4lhayy5s",
     "url": "https://github.com/GrapheneOS/platform_build"
   },
   "build/pesto": {
@@ -942,19 +942,19 @@
     "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
   },
   "external/Auditor": {
-    "dateTime": 1636687207,
+    "dateTime": 1637346664,
     "groups": [],
-    "rev": "19f12babe2de807250023070140909a8136b843d",
-    "revisionExpr": "19f12babe2de807250023070140909a8136b843d",
-    "sha256": "19gqyjpmj9ikzcclg4fnrgzkyvih27hs9i3lnjh0qq1i3wmdg4hp",
+    "rev": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "revisionExpr": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "sha256": "0j425b2j5b73myp8xvgkyyiv1gld5cznxjr8jirli58iwba0kyxp",
     "url": "https://github.com/GrapheneOS/platform_external_Auditor"
   },
   "external/Camera": {
-    "dateTime": 1636849236,
+    "dateTime": 1637441850,
     "groups": [],
-    "rev": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "revisionExpr": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "sha256": "1im3wfxy6962byzlgf78fnlspixi7czlm6r02099f4k04i088i6p",
+    "rev": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "revisionExpr": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "sha256": "0z71vfzbkfkj6gj4ma1krwwzm0q0cb4k5arx7wsfy4vmf2vs54p4",
     "url": "https://github.com/GrapheneOS/platform_external_Camera"
   },
   "external/FP16": {
@@ -6380,11 +6380,11 @@
     "url": "https://android.googlesource.com/platform/external/tagsoup"
   },
   "external/talkback": {
-    "dateTime": 1633768092,
+    "dateTime": 1637128001,
     "groups": [],
-    "rev": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "revisionExpr": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "sha256": "09msjfx4gmx3k45ly4kjb5214rlp4jk0wvh4w1wkphwxd8j0bfxb",
+    "rev": "40400705ae097763a58f199c3ac1770e2b619575",
+    "revisionExpr": "40400705ae097763a58f199c3ac1770e2b619575",
+    "sha256": "1k800n4iqcnj9cxf5xv2fm6h7ksy4n99pzsss85gb9wnqf57d1lx",
     "url": "https://github.com/GrapheneOS/platform_external_talkback"
   },
   "external/tcpdump": {
@@ -6580,11 +6580,11 @@
     "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
   },
   "external/vanadium": {
-    "dateTime": 1636687291,
+    "dateTime": 1637031076,
     "groups": [],
-    "rev": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "revisionExpr": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "sha256": "0nnczwygrs11i9y7rbvyh94g037rlaasjnwmld8hkfwfl4xhm787",
+    "rev": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "revisionExpr": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "sha256": "0b4lnp31fiy54ai75s3wllc9rsjra5grn8bamfj7jkl1b2ahsg9m",
     "url": "https://gitlab.com/GrapheneOS/platform_external_vanadium"
   },
   "external/vboot_reference": {
@@ -6838,14 +6838,14 @@
     "url": "https://android.googlesource.com/platform/frameworks/av"
   },
   "frameworks/base": {
-    "dateTime": 1636900447,
+    "dateTime": 1637432828,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "revisionExpr": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "sha256": "0247w0gpfqnmxdwd3h9pdqflq37jin5yz731dqai15im28xa1kya",
+    "rev": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "revisionExpr": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "sha256": "1rws6zkwvslkcf8d0zz9mzmim7m420ny2mh8cgqbwfc1dbyq1pxg",
     "url": "https://github.com/GrapheneOS/platform_frameworks_base"
   },
   "frameworks/compile/libbcc": {
@@ -8744,13 +8744,13 @@
     "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
   },
   "packages/apps/Settings": {
-    "dateTime": 1635801211,
+    "dateTime": 1636996381,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "revisionExpr": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "sha256": "06ndrsh22q7w7wrq5zbamhv6jv812il22vgc8f5h6vq3c6mqrkk6",
+    "rev": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "revisionExpr": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "sha256": "1lhiivw6w9lazvz84s9xi3izamz1gqqmh0alxprk7pmfkpl984jc",
     "url": "https://github.com/GrapheneOS/platform_packages_apps_Settings"
   },
   "packages/apps/SettingsIntelligence": {
@@ -9296,14 +9296,14 @@
     "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
   },
   "packages/providers/DownloadProvider": {
-    "dateTime": 1633927314,
+    "dateTime": 1637432791,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "revisionExpr": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "sha256": "128jhy9gmlkcjj2lrfbmz36sdkmw5v44gk5cypmgkxkcz4yv5z2v",
+    "rev": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "revisionExpr": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "sha256": "0zifarl2i5vjmk56g5hfh5hdznmxg52bamqby184b44q3jvmpihk",
     "url": "https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider"
   },
   "packages/providers/MediaProvider": {
@@ -10121,11 +10121,11 @@
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
   },
   "script": {
-    "dateTime": 1636687326,
+    "dateTime": 1637447862,
     "groups": [],
-    "rev": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "revisionExpr": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "sha256": "1r0c8i6pfx810lxd0x2ynb3q3y1p7ns96mjkihp47prwvy85xyvx",
+    "rev": "2e7c64babdaa060e43215f53618e4fdaffcd399c",
+    "revisionExpr": "2e7c64babdaa060e43215f53618e4fdaffcd399c",
+    "sha256": "0wz8q10cmyhp6yqpa96i97v36msj32gk7hgwyni25h9sar36xf8y",
     "url": "https://github.com/GrapheneOS/script"
   },
   "sdk": {

--- a/flavors/grapheneos/repo-SP1A.211105.002.2021112021.json
+++ b/flavors/grapheneos/repo-SP1A.211105.002.2021112021.json
@@ -942,19 +942,19 @@
     "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
   },
   "external/Auditor": {
-    "dateTime": 1636687207,
+    "dateTime": 1637346664,
     "groups": [],
-    "rev": "19f12babe2de807250023070140909a8136b843d",
-    "revisionExpr": "19f12babe2de807250023070140909a8136b843d",
-    "sha256": "19gqyjpmj9ikzcclg4fnrgzkyvih27hs9i3lnjh0qq1i3wmdg4hp",
+    "rev": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "revisionExpr": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "sha256": "0j425b2j5b73myp8xvgkyyiv1gld5cznxjr8jirli58iwba0kyxp",
     "url": "https://github.com/GrapheneOS/platform_external_Auditor"
   },
   "external/Camera": {
-    "dateTime": 1636849236,
+    "dateTime": 1637441850,
     "groups": [],
-    "rev": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "revisionExpr": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "sha256": "1im3wfxy6962byzlgf78fnlspixi7czlm6r02099f4k04i088i6p",
+    "rev": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "revisionExpr": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "sha256": "0z71vfzbkfkj6gj4ma1krwwzm0q0cb4k5arx7wsfy4vmf2vs54p4",
     "url": "https://github.com/GrapheneOS/platform_external_Camera"
   },
   "external/FP16": {
@@ -6380,11 +6380,11 @@
     "url": "https://android.googlesource.com/platform/external/tagsoup"
   },
   "external/talkback": {
-    "dateTime": 1633768092,
+    "dateTime": 1637128001,
     "groups": [],
-    "rev": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "revisionExpr": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "sha256": "09msjfx4gmx3k45ly4kjb5214rlp4jk0wvh4w1wkphwxd8j0bfxb",
+    "rev": "40400705ae097763a58f199c3ac1770e2b619575",
+    "revisionExpr": "40400705ae097763a58f199c3ac1770e2b619575",
+    "sha256": "1k800n4iqcnj9cxf5xv2fm6h7ksy4n99pzsss85gb9wnqf57d1lx",
     "url": "https://github.com/GrapheneOS/platform_external_talkback"
   },
   "external/tcpdump": {
@@ -6580,11 +6580,11 @@
     "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
   },
   "external/vanadium": {
-    "dateTime": 1636687291,
+    "dateTime": 1637031076,
     "groups": [],
-    "rev": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "revisionExpr": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "sha256": "0nnczwygrs11i9y7rbvyh94g037rlaasjnwmld8hkfwfl4xhm787",
+    "rev": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "revisionExpr": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "sha256": "0b4lnp31fiy54ai75s3wllc9rsjra5grn8bamfj7jkl1b2ahsg9m",
     "url": "https://gitlab.com/GrapheneOS/platform_external_vanadium"
   },
   "external/vboot_reference": {
@@ -6838,14 +6838,14 @@
     "url": "https://android.googlesource.com/platform/frameworks/av"
   },
   "frameworks/base": {
-    "dateTime": 1636900447,
+    "dateTime": 1637432828,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "revisionExpr": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "sha256": "0247w0gpfqnmxdwd3h9pdqflq37jin5yz731dqai15im28xa1kya",
+    "rev": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "revisionExpr": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "sha256": "1rws6zkwvslkcf8d0zz9mzmim7m420ny2mh8cgqbwfc1dbyq1pxg",
     "url": "https://github.com/GrapheneOS/platform_frameworks_base"
   },
   "frameworks/compile/libbcc": {
@@ -8744,13 +8744,13 @@
     "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
   },
   "packages/apps/Settings": {
-    "dateTime": 1635801211,
+    "dateTime": 1636996381,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "revisionExpr": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "sha256": "06ndrsh22q7w7wrq5zbamhv6jv812il22vgc8f5h6vq3c6mqrkk6",
+    "rev": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "revisionExpr": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "sha256": "1lhiivw6w9lazvz84s9xi3izamz1gqqmh0alxprk7pmfkpl984jc",
     "url": "https://github.com/GrapheneOS/platform_packages_apps_Settings"
   },
   "packages/apps/SettingsIntelligence": {
@@ -9296,14 +9296,14 @@
     "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
   },
   "packages/providers/DownloadProvider": {
-    "dateTime": 1633927314,
+    "dateTime": 1637432791,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "revisionExpr": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "sha256": "128jhy9gmlkcjj2lrfbmz36sdkmw5v44gk5cypmgkxkcz4yv5z2v",
+    "rev": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "revisionExpr": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "sha256": "0zifarl2i5vjmk56g5hfh5hdznmxg52bamqby184b44q3jvmpihk",
     "url": "https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider"
   },
   "packages/providers/MediaProvider": {
@@ -10121,11 +10121,11 @@
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
   },
   "script": {
-    "dateTime": 1636687326,
+    "dateTime": 1636932922,
     "groups": [],
-    "rev": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "revisionExpr": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "sha256": "1r0c8i6pfx810lxd0x2ynb3q3y1p7ns96mjkihp47prwvy85xyvx",
+    "rev": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "revisionExpr": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "sha256": "0kyync5xa66bf22zai7vm7qlnb60305v0976il2xw3d8wmg74y48",
     "url": "https://github.com/GrapheneOS/script"
   },
   "sdk": {

--- a/flavors/grapheneos/repo-SP1A.211105.003.2021112021.json
+++ b/flavors/grapheneos/repo-SP1A.211105.003.2021112021.json
@@ -942,19 +942,19 @@
     "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
   },
   "external/Auditor": {
-    "dateTime": 1636687207,
+    "dateTime": 1637346664,
     "groups": [],
-    "rev": "19f12babe2de807250023070140909a8136b843d",
-    "revisionExpr": "19f12babe2de807250023070140909a8136b843d",
-    "sha256": "19gqyjpmj9ikzcclg4fnrgzkyvih27hs9i3lnjh0qq1i3wmdg4hp",
+    "rev": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "revisionExpr": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "sha256": "0j425b2j5b73myp8xvgkyyiv1gld5cznxjr8jirli58iwba0kyxp",
     "url": "https://github.com/GrapheneOS/platform_external_Auditor"
   },
   "external/Camera": {
-    "dateTime": 1636849236,
+    "dateTime": 1637441850,
     "groups": [],
-    "rev": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "revisionExpr": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "sha256": "1im3wfxy6962byzlgf78fnlspixi7czlm6r02099f4k04i088i6p",
+    "rev": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "revisionExpr": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "sha256": "0z71vfzbkfkj6gj4ma1krwwzm0q0cb4k5arx7wsfy4vmf2vs54p4",
     "url": "https://github.com/GrapheneOS/platform_external_Camera"
   },
   "external/FP16": {
@@ -6380,11 +6380,11 @@
     "url": "https://android.googlesource.com/platform/external/tagsoup"
   },
   "external/talkback": {
-    "dateTime": 1633768092,
+    "dateTime": 1637128001,
     "groups": [],
-    "rev": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "revisionExpr": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "sha256": "09msjfx4gmx3k45ly4kjb5214rlp4jk0wvh4w1wkphwxd8j0bfxb",
+    "rev": "40400705ae097763a58f199c3ac1770e2b619575",
+    "revisionExpr": "40400705ae097763a58f199c3ac1770e2b619575",
+    "sha256": "1k800n4iqcnj9cxf5xv2fm6h7ksy4n99pzsss85gb9wnqf57d1lx",
     "url": "https://github.com/GrapheneOS/platform_external_talkback"
   },
   "external/tcpdump": {
@@ -6580,11 +6580,11 @@
     "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
   },
   "external/vanadium": {
-    "dateTime": 1636687291,
+    "dateTime": 1637031076,
     "groups": [],
-    "rev": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "revisionExpr": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "sha256": "0nnczwygrs11i9y7rbvyh94g037rlaasjnwmld8hkfwfl4xhm787",
+    "rev": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "revisionExpr": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "sha256": "0b4lnp31fiy54ai75s3wllc9rsjra5grn8bamfj7jkl1b2ahsg9m",
     "url": "https://gitlab.com/GrapheneOS/platform_external_vanadium"
   },
   "external/vboot_reference": {
@@ -6838,14 +6838,14 @@
     "url": "https://android.googlesource.com/platform/frameworks/av"
   },
   "frameworks/base": {
-    "dateTime": 1636900447,
+    "dateTime": 1637432828,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "revisionExpr": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "sha256": "0247w0gpfqnmxdwd3h9pdqflq37jin5yz731dqai15im28xa1kya",
+    "rev": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "revisionExpr": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "sha256": "1rws6zkwvslkcf8d0zz9mzmim7m420ny2mh8cgqbwfc1dbyq1pxg",
     "url": "https://github.com/GrapheneOS/platform_frameworks_base"
   },
   "frameworks/compile/libbcc": {
@@ -8744,13 +8744,13 @@
     "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
   },
   "packages/apps/Settings": {
-    "dateTime": 1635801211,
+    "dateTime": 1636996381,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "revisionExpr": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "sha256": "06ndrsh22q7w7wrq5zbamhv6jv812il22vgc8f5h6vq3c6mqrkk6",
+    "rev": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "revisionExpr": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "sha256": "1lhiivw6w9lazvz84s9xi3izamz1gqqmh0alxprk7pmfkpl984jc",
     "url": "https://github.com/GrapheneOS/platform_packages_apps_Settings"
   },
   "packages/apps/SettingsIntelligence": {
@@ -9296,14 +9296,14 @@
     "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
   },
   "packages/providers/DownloadProvider": {
-    "dateTime": 1633927314,
+    "dateTime": 1637432791,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "revisionExpr": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "sha256": "128jhy9gmlkcjj2lrfbmz36sdkmw5v44gk5cypmgkxkcz4yv5z2v",
+    "rev": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "revisionExpr": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "sha256": "0zifarl2i5vjmk56g5hfh5hdznmxg52bamqby184b44q3jvmpihk",
     "url": "https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider"
   },
   "packages/providers/MediaProvider": {
@@ -10121,11 +10121,11 @@
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
   },
   "script": {
-    "dateTime": 1636687326,
+    "dateTime": 1636932922,
     "groups": [],
-    "rev": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "revisionExpr": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "sha256": "1r0c8i6pfx810lxd0x2ynb3q3y1p7ns96mjkihp47prwvy85xyvx",
+    "rev": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "revisionExpr": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "sha256": "0kyync5xa66bf22zai7vm7qlnb60305v0976il2xw3d8wmg74y48",
     "url": "https://github.com/GrapheneOS/script"
   },
   "sdk": {

--- a/flavors/grapheneos/repo-SP1A.211105.004.2021112021.json
+++ b/flavors/grapheneos/repo-SP1A.211105.004.2021112021.json
@@ -942,19 +942,19 @@
     "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
   },
   "external/Auditor": {
-    "dateTime": 1636687207,
+    "dateTime": 1637346664,
     "groups": [],
-    "rev": "19f12babe2de807250023070140909a8136b843d",
-    "revisionExpr": "19f12babe2de807250023070140909a8136b843d",
-    "sha256": "19gqyjpmj9ikzcclg4fnrgzkyvih27hs9i3lnjh0qq1i3wmdg4hp",
+    "rev": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "revisionExpr": "51e68256f4b7f08a8c09be105928b7d00432b19b",
+    "sha256": "0j425b2j5b73myp8xvgkyyiv1gld5cznxjr8jirli58iwba0kyxp",
     "url": "https://github.com/GrapheneOS/platform_external_Auditor"
   },
   "external/Camera": {
-    "dateTime": 1636849236,
+    "dateTime": 1637441850,
     "groups": [],
-    "rev": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "revisionExpr": "34a21af3cbd2ea8d45dc046e67986fd7f044ed95",
-    "sha256": "1im3wfxy6962byzlgf78fnlspixi7czlm6r02099f4k04i088i6p",
+    "rev": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "revisionExpr": "b8ab3bd096462640076d79bae3b4d72c664b5da5",
+    "sha256": "0z71vfzbkfkj6gj4ma1krwwzm0q0cb4k5arx7wsfy4vmf2vs54p4",
     "url": "https://github.com/GrapheneOS/platform_external_Camera"
   },
   "external/FP16": {
@@ -6380,11 +6380,11 @@
     "url": "https://android.googlesource.com/platform/external/tagsoup"
   },
   "external/talkback": {
-    "dateTime": 1633768092,
+    "dateTime": 1637128001,
     "groups": [],
-    "rev": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "revisionExpr": "ecd0e67fd945d8826330631297ebbaa88d007a77",
-    "sha256": "09msjfx4gmx3k45ly4kjb5214rlp4jk0wvh4w1wkphwxd8j0bfxb",
+    "rev": "40400705ae097763a58f199c3ac1770e2b619575",
+    "revisionExpr": "40400705ae097763a58f199c3ac1770e2b619575",
+    "sha256": "1k800n4iqcnj9cxf5xv2fm6h7ksy4n99pzsss85gb9wnqf57d1lx",
     "url": "https://github.com/GrapheneOS/platform_external_talkback"
   },
   "external/tcpdump": {
@@ -6580,11 +6580,11 @@
     "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
   },
   "external/vanadium": {
-    "dateTime": 1636687291,
+    "dateTime": 1637031076,
     "groups": [],
-    "rev": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "revisionExpr": "d6ec612953256b36ba99f6b1be3d6e665cc3a9bb",
-    "sha256": "0nnczwygrs11i9y7rbvyh94g037rlaasjnwmld8hkfwfl4xhm787",
+    "rev": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "revisionExpr": "d0587875b5c04a9230515c3c99f3f8822a24d982",
+    "sha256": "0b4lnp31fiy54ai75s3wllc9rsjra5grn8bamfj7jkl1b2ahsg9m",
     "url": "https://gitlab.com/GrapheneOS/platform_external_vanadium"
   },
   "external/vboot_reference": {
@@ -6838,14 +6838,14 @@
     "url": "https://android.googlesource.com/platform/frameworks/av"
   },
   "frameworks/base": {
-    "dateTime": 1636900447,
+    "dateTime": 1637432828,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "revisionExpr": "7f26fcdf18f29d86d81a498fa7b7f282b7dc7ce9",
-    "sha256": "0247w0gpfqnmxdwd3h9pdqflq37jin5yz731dqai15im28xa1kya",
+    "rev": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "revisionExpr": "123fb2f6900fb90e4a994a511e11ed1f9d55d608",
+    "sha256": "1rws6zkwvslkcf8d0zz9mzmim7m420ny2mh8cgqbwfc1dbyq1pxg",
     "url": "https://github.com/GrapheneOS/platform_frameworks_base"
   },
   "frameworks/compile/libbcc": {
@@ -8744,13 +8744,13 @@
     "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
   },
   "packages/apps/Settings": {
-    "dateTime": 1635801211,
+    "dateTime": 1636996381,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "revisionExpr": "7dc4a220d43aa177b574c9ee6674299c2748234e",
-    "sha256": "06ndrsh22q7w7wrq5zbamhv6jv812il22vgc8f5h6vq3c6mqrkk6",
+    "rev": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "revisionExpr": "c7751e8c203517e2ae807c209528784b4139eef8",
+    "sha256": "1lhiivw6w9lazvz84s9xi3izamz1gqqmh0alxprk7pmfkpl984jc",
     "url": "https://github.com/GrapheneOS/platform_packages_apps_Settings"
   },
   "packages/apps/SettingsIntelligence": {
@@ -9296,14 +9296,14 @@
     "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
   },
   "packages/providers/DownloadProvider": {
-    "dateTime": 1633927314,
+    "dateTime": 1637432791,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "revisionExpr": "f1f207c0c33661516315f1ddb157521b5e799541",
-    "sha256": "128jhy9gmlkcjj2lrfbmz36sdkmw5v44gk5cypmgkxkcz4yv5z2v",
+    "rev": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "revisionExpr": "00e1748c6b47947a480928ebe52147c1bb1d636c",
+    "sha256": "0zifarl2i5vjmk56g5hfh5hdznmxg52bamqby184b44q3jvmpihk",
     "url": "https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider"
   },
   "packages/providers/MediaProvider": {
@@ -10121,11 +10121,11 @@
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
   },
   "script": {
-    "dateTime": 1636687326,
+    "dateTime": 1636932922,
     "groups": [],
-    "rev": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "revisionExpr": "ae276fc6e3f54b9b93a2edf3e0158d084e389573",
-    "sha256": "1r0c8i6pfx810lxd0x2ynb3q3y1p7ns96mjkihp47prwvy85xyvx",
+    "rev": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "revisionExpr": "7fa3cd7fceef753fceab8699c41a0e27fe31dbd5",
+    "sha256": "0kyync5xa66bf22zai7vm7qlnb60305v0976il2xw3d8wmg74y48",
     "url": "https://github.com/GrapheneOS/script"
   },
   "sdk": {

--- a/flavors/grapheneos/upstream-params.nix
+++ b/flavors/grapheneos/upstream-params.nix
@@ -1,1 +1,1 @@
-{ buildNumber = "2021111414"; buildDateTime = 1636900597; }
+{ buildNumber = "2021112021"; buildDateTime = 1637444258; }


### PR DESCRIPTION
Tested on bramble.
Does _not_ include the vanadium update.