### PR TITLE
Provide recoveryImg output

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -85,7 +85,7 @@ in {
   # in the future:
   inherit (config.build)
     targetFiles unsignedTargetFiles signedTargetFiles
-    ota incrementalOta img factoryImg bootImg otaDir
+    ota incrementalOta img factoryImg bootImg recoveryImg otaDir
     releaseScript generateKeysScript verifyKeysScript
     emulator;
 }

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -139,6 +139,7 @@ in
 
     # Pull this out of target files, because (at least) verity key gets put into boot ramdisk
     bootImg = pkgs.runCommand "boot.img" {} "${pkgs.unzip}/bin/unzip -p ${targetFiles} IMAGES/boot.img > $out";
+    recoveryImg = pkgs.runCommand "recovery.img" {} "${pkgs.unzip}/bin/unzip -p ${targetFiles} IMAGES/recovery.img > $out";
 
     # BUILDID_PLACEHOLDER below was originally config.apv.buildID, but we don't want to have to depend on setting a buildID generally.
     otaMetadata = (rec {


### PR DESCRIPTION
This is useful for devices that have a dedicated recovery image. This
includes, but is not limited to old devices, and *newest* devices. This
is because newest devices with dynamic partitions has dropped the silly
"boot as recovery" scheme, and rely again on a discrete recovery
partition.

This is useful mainly for LineageOS like deployment schemes.

Tested only with LineageOS devices, tested with:

 - :heavy_check_mark: begonia\*
 - :heavy_check_mark: lavender

Counter-tested with boot-as-recovery devices on LineageOS:

 - :x: aura
 - :x: pioneer

This fails (as expected) with those devices as they don't have a recovery partition.

Side-note: only the *lavender* recovery image was tested on-device this way. *begonia* is a mess for many reasons, and I haven't dared try the LineageOS recovery on it. Though I figure it should work fine? ¯\\\_(ツ)\_/¯