### PR TITLE
vanilla/raviole: SQ1D.211205.017 -> SQ1D.220105.007

### DIFF
--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -12,7 +12,7 @@ let
 in
 (mkIf (config.flavor == "vanilla" && config.androidVersion == 12) (mkMerge [
 {
-  buildDateTime = mkDefault 1641669748;
+  buildDateTime = mkDefault 1642284614;
 
   source.manifest.rev = mkDefault (
     if (config.deviceFamily == "raviole") then "android-12.0.0_r27"

--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -15,11 +15,11 @@ in
   buildDateTime = mkDefault 1641669748;
 
   source.manifest.rev = mkDefault (
-    if (config.deviceFamily == "raviole") then "android-12.0.0_r19"
+    if (config.deviceFamily == "raviole") then "android-12.0.0_r27"
     else "android-12.0.0_r26"
   );
   apv.buildID = mkDefault (
-    if (config.deviceFamily == "raviole") then "SQ1D.211205.017"
+    if (config.deviceFamily == "raviole") then "SQ1D.220105.007"
     else "SQ1A.220105.002"
   );
 

--- a/flavors/vanilla/12/repo-android-12.0.0_r27.json
+++ b/flavors/vanilla/12/repo-android-12.0.0_r27.json
@@ -1,35 +1,33 @@
 {
   "art": {
-    "dateTime": 1635530964,
+    "dateTime": 1635476367,
     "groups": [
       "pdk"
     ],
-    "rev": "930e161497640991a8720775fcbf37c2bcf169c5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "267bff0378b4b875641487dae257b7a2554a8852",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q5l3x7qdyz6a11pgqbfsjf7frfnhxrz5nms5rcijfg9swahrh2b",
-    "tree": "fb530e0d302071bab9b3cbfdfe2e7ce424596520",
     "url": "https://android.googlesource.com/platform/art"
   },
   "bionic": {
-    "dateTime": 1627095683,
+    "dateTime": 1628888011,
     "groups": [
       "pdk"
     ],
-    "rev": "9e695cabc652600cc5b52470c615a92cc2d95ae9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "930c3b5c613893203bc0dd9609cf4dda0c49726c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0y25max15fzxf1c226hshcb2kjsr24gj37n2m0p7lhjbjgxc33d6",
-    "tree": "93d699e33848416768e81412a3b42677c161c6d4",
     "url": "https://android.googlesource.com/platform/bionic"
   },
   "bootable/libbootloader": {
+    "dateTime": 1616521027,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "2fda87b18495ac8c90da46eeea432b2fcf689a99",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d1b40207399b542e38ea1ecafb338a847dbca659",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1g10xsdj43z21cw7yl1mg70jdmgf27xqm713al4bvpqy7g3l177j",
-    "tree": "9ca17f2be17f89776417c94d9a6d570140c06957",
     "url": "https://android.googlesource.com/platform/bootable/libbootloader"
   },
   "bootable/recovery": {
@@ -37,14 +35,13 @@
     "groups": [
       "pdk"
     ],
-    "rev": "0d4977b38f89d27b7ad8e2837dbefece58333ae2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "33291c80de7f59ab1f94dce5561cc5d330211722",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b81pl4qdqr0zqjv4qncdcgrxz0jg0ngmn93z6iqmm43y1xp00qf",
-    "tree": "d29110f02a00665a9296772627d02f532c5ff41b",
     "url": "https://android.googlesource.com/platform/bootable/recovery"
   },
   "build/bazel": {
-    "dateTime": 1620954077,
+    "dateTime": 1620912184,
     "groups": [
       "pdk"
     ],
@@ -62,22 +59,20 @@
         "src": "bazel.BUILD"
       }
     ],
-    "rev": "28f8d89eb6f4400f2e52405aff0d35de9e064856",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "66ac50d71063df9afa5fcd1d782e84391f86a628",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jsyl5fjbqna5vw2w3qqn6p9gr9rln6mkzisd0dqz1i8wh7nw1rf",
-    "tree": "ece95204c9b80e30cc733ade8ac22381441285d1",
     "url": "https://android.googlesource.com/platform/build/bazel"
   },
   "build/blueprint": {
-    "dateTime": 1621904529,
+    "dateTime": 1621853205,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "cad34471f964bfef91ea8823473562a292eb51fa",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "28eb87a7495b99f6a8a2a980ad389270572d32af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yi42fwvv679pfpr4vxy7vfrqr4la043a7s57rpbw2k5v7h6vm2y",
-    "tree": "e1ba8c01ad13d485e97071294f90ca3be9c1c531",
     "url": "https://android.googlesource.com/platform/build/blueprint"
   },
   "build/make": {
@@ -87,7 +82,7 @@
         "src": "core/root.mk"
       }
     ],
-    "dateTime": 1638280068,
+    "dateTime": 1640531118,
     "groups": [
       "pdk"
     ],
@@ -117,25 +112,23 @@
         "src": "tools"
       }
     ],
-    "rev": "b55e4fbe0ad8123f6b1ac8935f471df72deb50d7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "04kixrpnxdsqjn5m65n3mqrvab6k03dinvgi6dba8g07kxyn8pjz",
-    "tree": "f5e09d0679b4dabed98f59deae97f677b45f94fa",
+    "rev": "33319d94a00e1f87af341574c1c7122ebada9ee1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p7d4h529wlkyza4y1ss3bplimk0wiswsm7ywpimjrjchix0h57i",
     "url": "https://android.googlesource.com/platform/build"
   },
   "build/pesto": {
-    "dateTime": 1620867700,
+    "dateTime": 1620840185,
     "groups": [
       "pdk"
     ],
-    "rev": "5874acb82928ed6aa885e40bc732c1e4240a2ad2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "eab614a30eedd5e183cb03bede8294004714861a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cgw3nmazi87f7qam00szqzy37laz7lv5w9l5zagniv5z0kjl10j",
-    "tree": "8649d023cca68532982dcb0cc432054efeca6c7e",
     "url": "https://android.googlesource.com/platform/build/pesto"
   },
   "build/soong": {
-    "dateTime": 1631235639,
+    "dateTime": 1631222448,
     "groups": [
       "pdk",
       "tradefed"
@@ -150,90 +143,85 @@
         "src": "bootstrap.bash"
       }
     ],
-    "rev": "124d6ffa3ced106cd990860e528b3c0abeeabaa6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2d4fa2ffffdef3e167d756bb60f55ea85dfd6132",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03qphi937i0hh83j9ga94x0yzryx2g8fpwi19q8jm8j2s405kv7q",
-    "tree": "e85ce78d80f1dcf2eaf658beb5f7a04e6fd4baae",
     "url": "https://android.googlesource.com/platform/build/soong"
   },
   "compatibility/cdd": {
-    "dateTime": 1618880487,
+    "dateTime": 1618861524,
     "groups": [
       "pdk"
     ],
-    "rev": "58bbe2ca028c88308b119e246279eaec8978478a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f81ac3b554a1d801c915ceedccb59dae9f4167df",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04l9jdf0i7pf4lq3dxrik4gg3k00v2r3dr9mp6bznf6mm37cvzh9",
-    "tree": "74d781122a28d5551100b1bdde81fae2cf95ff3b",
     "url": "https://android.googlesource.com/platform/compatibility/cdd"
   },
   "cts": {
-    "dateTime": 1634653009,
+    "dateTime": 1640531095,
     "groups": [
       "cts",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "d4f3415c37170b2547fe62abfa13a088bc37f564",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "0zds7dmnk2h4vqls84xamcyfdkh8lbmr7ciz7scf90ll14r5wn3f",
-    "tree": "24ed6eb47b82de6a3a1bf814d6d870f631da26db",
+    "rev": "8cf9aa78bf1c02c464f6aef2e7c52b07e7997a11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jbffqg6g2y90mdrxvgm4yn8g20d9ihxqmq175n6y5m8sh1ic8ah",
     "url": "https://android.googlesource.com/platform/cts"
   },
   "dalvik": {
-    "dateTime": 1617930074,
+    "dateTime": 1617898924,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "52f02517a89486b20f00163ba56ff7926b08c224",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "75bc2c404a03b08dd29d4c07d0e947099b64c276",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18iw5p98mm7wnfjd0yhnb1fcrnjwrigp1apbz2lyizlm95hkgz2v",
-    "tree": "9d5f5f55f2fc50a9287d24b462d5b9ac7e590545",
     "url": "https://android.googlesource.com/platform/dalvik"
   },
   "developers/build": {
+    "dateTime": 1613823750,
     "groups": [
       "developers",
       "pdk"
     ],
-    "rev": "4d9d0a164ed69ce028d339d810b4cded93d4aab6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "49ba0b0d72e6a4dbc2bb4ba05f8237d1b80fc359",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pvgglif7iy8n6sx8xkxw7xf6gcv60lgfh4kbd4k1ry75rb1hfy3",
-    "tree": "b0f66e2bacf9250c370f5455691ab68403acbbe7",
     "url": "https://android.googlesource.com/platform/developers/build"
   },
   "developers/demos": {
+    "dateTime": 1496909782,
     "groups": [
       "developers"
     ],
-    "rev": "b7359b021d8a2e933d44eedd56cd7e70c5e14ada",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6d49948be584151255e8a937dfad5c119ae3a02a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ciqaaj6jkykb6lkksqfka0077fhz1md6qiw5m337llyyiz29ywc",
-    "tree": "8df37fe9ba0824e56020adc5fdc2944e187ffb4c",
     "url": "https://android.googlesource.com/platform/developers/demos"
   },
   "developers/samples/android": {
+    "dateTime": 1619805757,
     "groups": [
       "developers"
     ],
-    "rev": "dd352170b1aff51087daafb3a0f8c9405b3076fe",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6186d97ca71298606da65da8a9e25a57d0984455",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1npnk3yyvchp4lh38aa7b31kly968h4j9af3x0ad894qigdmbk2g",
-    "tree": "d51fe2c9b495971f9cde4ab36814184d070aa0b7",
     "url": "https://android.googlesource.com/platform/developers/samples/android"
   },
   "development": {
-    "dateTime": 1629939650,
+    "dateTime": 1629870092,
     "groups": [
       "developers",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "af32da91370e09e77716359fa783a0a6494abc5e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7707b5aff0056a1788fe5758d48ee12271ee49af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03cjbillfbqs8hpzfpvxbgb6vb0jyxnk6wrkcbxryxdn90jsn3c7",
-    "tree": "fb7e0dd55d92792aedbf485a97d90d80ddc6dbd8",
     "url": "https://android.googlesource.com/platform/development"
   },
   "device/amlogic/yukawa": {
@@ -243,86 +231,82 @@
       "pdk",
       "yukawa"
     ],
-    "rev": "8b5bd9663d65127813654cda023392606bc8eb69",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8298d0d3dd262a8d541aeb937e8e264124d844cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qk861pyigxp903dckyzls5lw8cz5vp4pzx0l0y1g5bvag84i65l",
-    "tree": "ef619758bd8ce41573b0bc8db8801d55f2169a94",
     "url": "https://android.googlesource.com/device/amlogic/yukawa"
   },
   "device/amlogic/yukawa-kernel": {
-    "dateTime": 1617152461,
+    "dateTime": 1617062257,
     "groups": [
       "device",
       "pdk",
       "yukawa"
     ],
-    "rev": "20b4bdb0f1e7b9437e0da62d3fe8192d6d3354a5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2a1f90f337c98f6653d77a63893281239969804d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hfm6i7s4jrhfkxggkdvi58bwkl0gs0zyhn0p2p4gkg4vn1xhzyi",
-    "tree": "fed2ad0a590803490ef50c9eb8cbd4bc9f22928c",
     "url": "https://android.googlesource.com/device/amlogic/yukawa-kernel"
   },
   "device/common": {
-    "dateTime": 1630458038,
+    "dateTime": 1630361020,
     "groups": [
       "pdk",
       "pdk-cw-fs"
     ],
-    "rev": "b7272b0b6a4e4aabbdc9dd05333cf5c587c87a63",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3b037b3abe5a57849abf73de773a01fdecc65266",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l39hk80ai2nsxjcbqg9kgf4xyb5s05kjijvswg2w055j0cmxsi9",
-    "tree": "959f5c2f87c4d25cd27a1cdb2c79c9f433bdbd3b",
     "url": "https://android.googlesource.com/device/common"
   },
   "device/generic/arm64": {
+    "dateTime": 1588703768,
     "groups": [
       "pdk"
     ],
-    "rev": "0d8b319b2971ac63da95f1a882739d35c5db0011",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6ae09aac298ec8df4a0c524896a5e990a6c7b8ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l66va61ybzf224l9q2gq60i132ikb75k58h1za1faq18m8hwvyx",
-    "tree": "5b10c31ac56b53881c53cec8dffab43bbe47b26e",
     "url": "https://android.googlesource.com/device/generic/arm64"
   },
   "device/generic/armv7-a-neon": {
+    "dateTime": 1614993775,
     "groups": [
       "pdk"
     ],
-    "rev": "3235fdeadcf5bcbfa14353e23b6e8c4a242d7ecb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dfc68e43c5c25ebdd289f3a4da89adc5faabb687",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1986xyq0p2cqf4bgw3xf21qjszbidll8iwz2snzvffapybhr1213",
-    "tree": "4ddba5e458b78a0d97053c902ba0541130f4237c",
     "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
   },
   "device/generic/art": {
+    "dateTime": 1613834499,
     "groups": [
       "pdk"
     ],
-    "rev": "3cfebb1ac647622f43ef643ac329ca79c9c14c60",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "431da08d4fd02ca5d55a9cfd82af2d9bc7d56d34",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ijzwbsqb7xhzlj1bc84mp6hx782q30cvdsk4z6m36yibwlmkd97",
-    "tree": "537764cbc9630243d2584a172624c59216ad9126",
     "url": "https://android.googlesource.com/device/generic/art"
   },
   "device/generic/car": {
-    "dateTime": 1628125314,
+    "dateTime": 1628039971,
     "groups": [
       "pdk"
     ],
-    "rev": "966615ff165d76e52ad65c711dba21318a18d6b6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2a90acc1a65c5fab882990c1df6bcc25351036e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rlgpfbiv77038zlys5rxwpb1hv99gfdw01vkqwpmd9fjdr1xvbv",
-    "tree": "ecc3faddc9e2d40a0a5ad73aa9d78f9758bd374d",
     "url": "https://android.googlesource.com/device/generic/car"
   },
   "device/generic/common": {
+    "dateTime": 1621414074,
     "groups": [
       "pdk"
     ],
-    "rev": "84fe1a27fd85aafe43d2a8aff7dd686e9629247e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8ea35cdf94bca987389101bb8afe1ec9fa0dbd0c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1fvph5bf626bja9c0fq8c849qc7vgj5nnwasyjs5gkbhgzx0s9hc",
-    "tree": "db6b1ef26720320819cacfdc0e4aa5d2e962961f",
     "url": "https://android.googlesource.com/device/generic/common"
   },
   "device/generic/goldfish": {
@@ -330,257 +314,242 @@
     "groups": [
       "pdk"
     ],
-    "rev": "b1dc3675da99f17f031cd014294eb03877b1d04a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "64bce5a1739ba687b4d7b9aa1023b8407bba6ba6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09b8naf7hb03wfb5qcr9k78w3vh3bs0dm5c4178g9g95ddl67iga",
-    "tree": "1925df9cadb38a773cc1ed742f969a2b79d6ca16",
     "url": "https://android.googlesource.com/device/generic/goldfish"
   },
   "device/generic/goldfish-opengl": {
-    "dateTime": 1631329253,
+    "dateTime": 1631311649,
     "groups": [
       "pdk"
     ],
-    "rev": "d945e0c890e60fe0ec5f8e8849e430bffaa21358",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1d081c0579693e2247fcf153266bbeb54b457d4b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07lr2xssjibvn22gaca19z9lz99rf8p6qzgdp33zg65368dfkl3k",
-    "tree": "7436a747457fb4bc78daf8f0c5c3c858cb6fb072",
     "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
   },
   "device/generic/mini-emulator-arm64": {
+    "dateTime": 1599966332,
     "groups": [
       "pdk"
     ],
-    "rev": "99ae3e549ccc90482e687fecd7f0b2ef7485db18",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ddbff8ff46cd0441b666985b96ab1d02d9fc700e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
-    "tree": "91d404617acb138681c16a1c4a87d2741a801719",
     "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
   },
   "device/generic/mini-emulator-armv7-a-neon": {
+    "dateTime": 1599966332,
     "groups": [
       "pdk"
     ],
-    "rev": "478f9fad873cf5b21b61cbfa77d9ef6818938146",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "661c2c995d203a69969986b3ccda59188da3af27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
-    "tree": "91d404617acb138681c16a1c4a87d2741a801719",
     "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
   },
   "device/generic/mini-emulator-x86": {
+    "dateTime": 1599966333,
     "groups": [
       "pdk"
     ],
-    "rev": "7e01c0354f4e4aca3f5a29f1d18857f7ac7833ad",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "66c28d5a6f73415636430cc0d7548bfbd7402c1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
-    "tree": "91d404617acb138681c16a1c4a87d2741a801719",
     "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
   },
   "device/generic/mini-emulator-x86_64": {
+    "dateTime": 1599966333,
     "groups": [
       "pdk"
     ],
-    "rev": "b87f4aced5953ffc71fbe6f0881525605ecd0c25",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "04b8a3b7f779c402b76b994eb8d55fbe8b314fca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
-    "tree": "91d404617acb138681c16a1c4a87d2741a801719",
     "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
   },
   "device/generic/opengl-transport": {
+    "dateTime": 1613437326,
     "groups": [
       "pdk"
     ],
-    "rev": "9843a5840656ebf870731833d4ee401d76544d9f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a834afcdec4fd617854b13eb2991e060d2c0cbf9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1j6amjg99zbjsdg3xzgls29i0awz5rxdq8wklvkvrymhczk9ibr8",
-    "tree": "5a14900c65cc5b3e18e60e60f6363d0e08f2c109",
     "url": "https://android.googlesource.com/device/generic/opengl-transport"
   },
   "device/generic/qemu": {
+    "dateTime": 1599966332,
     "groups": [
       "pdk"
     ],
-    "rev": "bbbdcde7df7f22f9de1bfe21b9858c54f24cd268",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d7dc0a7f56668fa1710f5000fb41ee15daf216d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/device/generic/qemu"
   },
   "device/generic/trusty": {
-    "dateTime": 1620781300,
+    "dateTime": 1620754469,
     "groups": [
       "pdk"
     ],
-    "rev": "d0805b0dcda255121a5cb4be8793bbf606d9c8cf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bac7be1a2957771f48403b9df61b5348ae3885c4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hj6w5lsdahw94dh8zgj2a6zs1vidcxdyi0wsxm7zwsvl1pwmrmr",
-    "tree": "3876337430a5624a2e43a6d2cc7a0a3e579b71ee",
     "url": "https://android.googlesource.com/device/generic/trusty"
   },
   "device/generic/uml": {
-    "dateTime": 1613865723,
+    "dateTime": 1613829303,
     "groups": [
       "device",
       "pdk"
     ],
-    "rev": "d5da13d179eb9ea70a2e9b2771a94f01f7be808f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d9b54b345d4f883fada7fde9eb973322b5b76014",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18ninwq7gwgxxkrf5pgqfd05n8wjfnl9wc2wmwrs9r4kzgawmhgs",
-    "tree": "6dba6a8ddcbefd1eeef221e11b217798d2ba4db4",
     "url": "https://android.googlesource.com/device/generic/uml"
   },
   "device/generic/vulkan-cereal": {
-    "dateTime": 1621047718,
+    "dateTime": 1621016465,
     "groups": [
       "pdk"
     ],
-    "rev": "e0d875ac94d3fd3594cea2f99f1c1ed389c7a75a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "56ba159617bed11e929864491794366394a0e709",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1702hi0dw0rsar4dh0acgy7na6qcw0gv6cryidx1kpql6g8i265k",
-    "tree": "d22d9d982b110d339ec5639abb12b5f58bdc02ee",
     "url": "https://android.googlesource.com/device/generic/vulkan-cereal"
   },
   "device/generic/x86": {
+    "dateTime": 1588705083,
     "groups": [
       "pdk"
     ],
-    "rev": "5df18cdd149d009d80cfb248702e10ef19d3c917",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a6bb44a5b167d789f92d2ba40c66e8e1358d650f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1msvricg8asj7vhkpfx4vd3jykdg3xqs0yhrvhj7m48lhsandfdz",
-    "tree": "d833386e6b2d2e4611aa12f4295ec38655b6c899",
     "url": "https://android.googlesource.com/device/generic/x86"
   },
   "device/generic/x86_64": {
+    "dateTime": 1588704382,
     "groups": [
       "pdk"
     ],
-    "rev": "f4910da60df02d46c7b4bbadf1488327750a00f0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2e5a769ef7503203049e651f432865a97d007aad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1w7b33sap7ym1y23435n3cjsbvl8ws49m46lk8h1kgy8apg08mkw",
-    "tree": "0d43e05d12da93b82ef0a3ec66892831ff03c754",
     "url": "https://android.googlesource.com/device/generic/x86_64"
   },
   "device/google/atv": {
-    "dateTime": 1627700488,
+    "dateTime": 1629398178,
     "groups": [
       "broadcom_pdk",
       "device",
       "generic_fs",
       "pdk"
     ],
-    "rev": "5114ebe680b357573c59dcf7afc90f08d25a8313",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "328eb730a4b8b3b75d234882b395acb21c651729",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1fivwc6acv199pfci1pvwm2qxhvv228794rh4v9w46skp0yfd6a1",
-    "tree": "d668b784a3d0406d0b2780eb2e8cd76227d8f93d",
     "url": "https://android.googlesource.com/device/google/atv"
   },
   "device/google/barbet": {
-    "dateTime": 1633748502,
+    "dateTime": 1633748462,
     "groups": [
       "barbet",
       "device"
     ],
-    "rev": "802c3857ab4c7fa19ebc923a4462e741709646b0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cc8591a245b27e05f45f867b488c767fa9163d06",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "180zq2gq9v6q7qsgprrfyvxa2n4s3k4yg2p77zcb0ywbg4jq4bwj",
-    "tree": "aca7f1342873f87b5c27afc191835199ef631d0e",
     "url": "https://android.googlesource.com/device/google/barbet"
   },
   "device/google/barbet-kernel": {
-    "dateTime": 1633482074,
+    "dateTime": 1633482045,
     "groups": [
       "barbet",
       "device"
     ],
-    "rev": "fef365a8156e1b23c629278466f5e6f0d2d74d35",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f43cf12fcabef32318fa9507bdcc9830175272e6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0219nh986ndn9cf16qv3s17n9j6q4wa9r6yks2ndx9vcglfgr33y",
-    "tree": "09bf55ca65ac2f5b5cabfa1337ac3063facf63cf",
     "url": "https://android.googlesource.com/device/google/barbet-kernel"
   },
   "device/google/barbet-sepolicy": {
-    "dateTime": 1626310910,
+    "dateTime": 1626253712,
     "groups": [
       "barbet",
       "device"
     ],
-    "rev": "950a10771079840c330a6d22048e9cbf4f0bf5d3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6ac922ef1912f03029f5a228439cbb65049a47de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lwjsrfcvdzj8lqkjy55y58bqmzirfg25zb19nhrp0bfnph3wlln",
-    "tree": "e78b745fc37b351b4ce7356181f967d9e35dd8b0",
     "url": "https://android.googlesource.com/device/google/barbet-sepolicy"
   },
   "device/google/bonito": {
-    "dateTime": 1633748504,
+    "dateTime": 1633748464,
     "groups": [
       "bonito",
       "device"
     ],
-    "rev": "49b5530b6deac88d9d45dd994cb5cb2439b97958",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2f69af482a891a4442486a7a1a2ca4d3d91e148c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0iq8xk5rjdfll6qy9zgmxlqlgg0xhzcmq2dm7791rgmv4g5brmka",
-    "tree": "257b4a9bb523e24f0c6cd5d94723a2aab9d4d41b",
     "url": "https://android.googlesource.com/device/google/bonito"
   },
   "device/google/bonito-kernel": {
-    "dateTime": 1633482088,
+    "dateTime": 1633482048,
     "groups": [
       "bonito",
       "device"
     ],
-    "rev": "4c706b174a4b3e46cde8292abc94812d919eda20",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "14316e3e4326eb670c380ac2b1434d2e7956445d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l6zj308s53sbg71rqilb82z9k8dik8yszpmz2wbv84k92665hs8",
-    "tree": "1c2a55502ae3f577adbb6d665b9c79dc3a8fc925",
     "url": "https://android.googlesource.com/device/google/bonito-kernel"
   },
   "device/google/bonito-sepolicy": {
-    "dateTime": 1629421274,
+    "dateTime": 1629231264,
     "groups": [
       "bonito",
       "device"
     ],
-    "rev": "5e240605a984ac7c7f6e1503034fcd8ae4109192",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ab13e60b7dce772f618037f1c0548f0754ab0f11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yvwg0ygskxiin0ajk6ds4g661dsi1n4ijfis4jxxzknpwyxixq7",
-    "tree": "36d80839318405b3f9d90548b384ce4253567cac",
     "url": "https://android.googlesource.com/device/google/bonito-sepolicy"
   },
   "device/google/bramble": {
-    "dateTime": 1631581249,
+    "dateTime": 1630425408,
     "groups": [
       "bramble",
       "device"
     ],
-    "rev": "2f15d92a5a8f66aba75cc335644efb33f919312b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8a0d0d06fc41e7081f4caa43d8680b88f7770870",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pyg9alhpzm7qq5pwbd84xiylpmbljd1acf2ynpidvrjir5hxgaf",
-    "tree": "12384b7c342e01e4d0b294f23896dbace0a55592",
     "url": "https://android.googlesource.com/device/google/bramble"
   },
   "device/google/bramble-sepolicy": {
-    "dateTime": 1618966911,
+    "dateTime": 1618880054,
     "groups": [
       "bramble",
       "device"
     ],
-    "rev": "9c2cb252496b93c154360138f57e233a90633510",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f99881a4d535ef8bad796a8b364b018a7b2e7ecb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05f5cn22jkv4vjcdghy8j6g8g33yayrp4qk0bh289xri41l56yy2",
-    "tree": "91e47407e4f1255d792c92def42ec98d708d5135",
     "url": "https://android.googlesource.com/device/google/bramble-sepolicy"
   },
   "device/google/contexthub": {
-    "dateTime": 1620262932,
+    "dateTime": 1620164601,
     "groups": [
       "device",
       "pdk"
     ],
-    "rev": "5ed1329059afbd18725a57d48f56dc4f228f52c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a76f4276b5a9821764758ffb3f0f10feac8b8413",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vs3ya2smc8qdhwlwiy4ksy2qfkwd6limy58kvwy12gbgcyqx483",
-    "tree": "bf22f3c9b36397971b9c899a7d2c0d706b7baf04",
     "url": "https://android.googlesource.com/device/google/contexthub"
   },
   "device/google/coral": {
@@ -590,121 +559,113 @@
       "device",
       "generic_fs"
     ],
-    "rev": "fd87fd626e03030216b4ef446c85ed34b4c7614d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5223ecafa9250ba1c08cba9581629b73508d006b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12h4wzy033v3bcbiqhc9xgmi56p2wsv4qbr2nvs55psrir7amdwc",
-    "tree": "2616cc7a52434c7e5b113140cfc10cc1bfffd7a4",
     "url": "https://android.googlesource.com/device/google/coral"
   },
   "device/google/coral-kernel": {
-    "dateTime": 1633482091,
+    "dateTime": 1633482051,
     "groups": [
       "coral",
       "device",
       "generic_fs"
     ],
-    "rev": "20d916d1263991f8ea58949ae9c349ec8ee31e3b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fccfdafe3c6665a5561b9581ad76a6f361d46371",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1fz6av23l379f26nzckhzacwlgldynp0vl5hsq98rc1cfd8zr623",
-    "tree": "5ce5d4572c9c6d6299dd7979aee61c1423d9ef96",
     "url": "https://android.googlesource.com/device/google/coral-kernel"
   },
   "device/google/coral-sepolicy": {
-    "dateTime": 1633395666,
+    "dateTime": 1633395653,
     "groups": [
       "coral",
       "device",
       "generic_fs"
     ],
-    "rev": "d8f6acfd9ac745226b55938d8bca1f6a9e61b79d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f07fcc087b07b42a2dedd39ef5b6da0a62b79f76",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hcb1rqnijh6srhbrpylrdd3wcn3gcli4hf87sagys3r4q1x8m58",
-    "tree": "36a51543ae22691be71ffbee7c4251fe09caac25",
     "url": "https://android.googlesource.com/device/google/coral-sepolicy"
   },
   "device/google/crosshatch": {
-    "dateTime": 1631329275,
+    "dateTime": 1631240057,
     "groups": [
       "crosshatch",
       "device",
       "generic_fs"
     ],
-    "rev": "8f5646880b43ecf310aeb67b619dde4afd9cffe6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9494e66316ca494f422beeb5ec092a4dffc8c318",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zy6rkqzxhyx14ypgyjd7iw6cq8krpbgp4qy6vi7kzcm4qm825ha",
-    "tree": "d5fcae3defc6d9729a28bee66d4a4b3b87bb26f9",
     "url": "https://android.googlesource.com/device/google/crosshatch"
   },
   "device/google/crosshatch-kernel": {
-    "dateTime": 1628305317,
+    "dateTime": 1628188305,
     "groups": [
       "crosshatch",
       "device",
       "generic_fs"
     ],
-    "rev": "55f71020f140b49ddcc15b934de66a1e6a8eb2f0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6c20c6ff8fc344d35ebf3fdd8675d37f80c207a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0y2984wgi8277hkalin5spnhkljdx9qx2s6pppxm0aalcxk34shj",
-    "tree": "a8eb832b363d1c2ececa63add283e0f7ed367f7c",
     "url": "https://android.googlesource.com/device/google/crosshatch-kernel"
   },
   "device/google/crosshatch-sepolicy": {
-    "dateTime": 1629421286,
+    "dateTime": 1629244181,
     "groups": [
       "crosshatch",
       "device",
       "generic_fs"
     ],
-    "rev": "8de58afcfcf320a37db26c0e6df18a36d7e66be2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "530c9dc009c0151badcb63e2d5d6a8807895628b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0srgkbjps68w7lfizih11gv9bahn0pjr1fmqszkjycwamcf8rvpr",
-    "tree": "b7e697d8be432d0a7f84a59a3cfa018a9783c6c1",
     "url": "https://android.googlesource.com/device/google/crosshatch-sepolicy"
   },
   "device/google/cuttlefish": {
-    "dateTime": 1633395675,
+    "dateTime": 1633395662,
     "groups": [
       "device",
       "pdk"
     ],
-    "rev": "dd58dab77cd7b76955f75ef7545328f6a5d9b9cc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b9c1af38a5f08e4e02a6674a88276d9b8ae1ae9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ma4m33y8w0sx0jrd43i25h4i98xh6y6g8pfhfzm02b03nvfvngk",
-    "tree": "07aadda8f3b6fd6a9ae0cbd2df2d5371b6b53041",
     "url": "https://android.googlesource.com/device/google/cuttlefish"
   },
   "device/google/cuttlefish_prebuilts": {
-    "dateTime": 1633568498,
+    "dateTime": 1633568493,
     "groups": [
       "device",
       "pdk"
     ],
-    "rev": "4c70d9986249c0bfb5ace9b0c3410721d68d6e61",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bbea0d9ba8d038ac62d0648141c1317b7c21c0b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1scgp6scm0mzqqc0bv59fzm50gb53jij1nbrza5p9vxfdr6kl3kd",
-    "tree": "7178e35b0d4661157ce03eacb0754101ae777e3c",
     "url": "https://android.googlesource.com/device/google/cuttlefish_prebuilts"
   },
   "device/google/fuchsia": {
+    "dateTime": 1613815503,
     "groups": [
       "device"
     ],
-    "rev": "ad1d05835b7412ddc0793eb18313db9da73f7d80",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c14c37fa6dd6bb87e897a3a229bbb77cf37178d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "131k68cyq4yl559hjy9qxll6smzavph9c2l39q5wwqxlb8w96gzp",
-    "tree": "3ebd1f1bc905a6117283d074b0dc72c26cda34fc",
     "url": "https://android.googlesource.com/device/google/fuchsia"
   },
   "device/google/gs-common": {
+    "dateTime": 1621363244,
     "groups": [
       "device",
       "pdk-gs-arm",
       "slider"
     ],
-    "rev": "53d12e5e7c0e1082413c4e0b7c8d2b24d347a4c5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6d80278f8d1a0858370eaa11df203b62472d7d85",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/device/google/gs-common"
   },
   "device/google/gs101": {
@@ -713,10 +674,9 @@
       "device",
       "slider"
     ],
-    "rev": "2838c85f2dcc92f18910ea1b42af564c46e81b9d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4d80c4a097ad688b95dab764d0adb8600f548aad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rn0nbyc2gb98ymb7ngy6rpivc6zmdkn0y6q10g4v4rfmzscw0km",
-    "tree": "18636ebcc7b84a99a6459928b1626024ba824ae5",
     "url": "https://android.googlesource.com/device/google/gs101"
   },
   "device/google/gs101-sepolicy": {
@@ -725,34 +685,31 @@
       "device",
       "slider"
     ],
-    "rev": "c5d3756e7b3071d859363e4791a2575b4a12b909",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f07d21c6553f6a8b67d1e0885705d16c9e75e9d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ibm4793ryd0gzm2pnxfb8s5b5r4yzjkar0rgjwyasxfsbp6zm6j",
-    "tree": "065865c73f7e30d4953cef33091bfe7289361986",
     "url": "https://android.googlesource.com/device/google/gs101-sepolicy"
   },
   "device/google/raviole": {
-    "dateTime": 1638280062,
+    "dateTime": 1640531093,
     "groups": [
       "device",
       "slider"
     ],
-    "rev": "44fd8da6396d9a54c7e4d0193df0cca941696c03",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "070zh9681bdgjzd2hkadipv10zadz0my23ayrwag6422z6kl9zlm",
-    "tree": "f2ac56be1507b8281a41feffd86c71a8aa473785",
+    "rev": "7f0472217720110af6fc9cefc75ec20ea5cf8641",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0li34i369mimwkxmdqkg3lvk2fxhccmhb8f9xd971kf8mvs92z8z",
     "url": "https://android.googlesource.com/device/google/raviole"
   },
   "device/google/raviole-kernel": {
-    "dateTime": 1637208612,
+    "dateTime": 1640531094,
     "groups": [
       "device",
       "slider"
     ],
-    "rev": "b3c1e9cacd78047146fc2d9bea031cc0e4f0a452",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "18fykn8bnrzidzqd12fdansg76id430lxl6bakw2n4hbfxakj6mi",
-    "tree": "a4d8886956e1991f003ef6ff68ca3e6ef3b7579b",
+    "rev": "f40f94b2528cb94bc73fe7a407cd66fcd9b2bea6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hqrvg7y761sljsjdhix1ab2818zjq8xramnki4p9zq03207wagh",
     "url": "https://android.googlesource.com/device/google/raviole-kernel"
   },
   "device/google/redbull": {
@@ -761,59 +718,54 @@
       "device",
       "redbull"
     ],
-    "rev": "6b10bc6a4b1a4ee7cf94f003422c5f5dba5df5b5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff65d000d419a9af5c8d88c4fbcf3c92aa044ff1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jg4n1cdivpf3qc53ldrnb1kq80ln5vdbj0pqq8qz77l67p1bziq",
-    "tree": "f1240d71b0c3578ffcc2dd73c9a78ead4a0d96a9",
     "url": "https://android.googlesource.com/device/google/redbull"
   },
   "device/google/redbull-kernel": {
-    "dateTime": 1633482096,
+    "dateTime": 1633482056,
     "groups": [
       "bramble",
       "device",
       "redfin"
     ],
-    "rev": "bf645acfe23c98424825d4b3ce74dec688519d48",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9a92ec53e8969fc8173cc9c32a65c26f015cb618",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mb037mwbp8jnx3r5vil3y0rri0jf2mv13sqzrgflb6hh0g00fjg",
-    "tree": "fc76e57eb97f4510d74f2cb9d2f64c0cdf4c9bfa",
     "url": "https://android.googlesource.com/device/google/redbull-kernel"
   },
   "device/google/redbull-sepolicy": {
-    "dateTime": 1631667658,
+    "dateTime": 1629686236,
     "groups": [
       "device",
       "redbull"
     ],
-    "rev": "a0a614fb5d7c1cdbbe2b071c66e157b2a75a2f6e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1839945a35ad28df9761e8c3388bea1b40356200",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09v6smlwrgc15v58j8w9nym31fgmbyi800r2v4clcgyg0h66ww83",
-    "tree": "c46422b02627ab868e2da2571f6c12bce81b63e2",
     "url": "https://android.googlesource.com/device/google/redbull-sepolicy"
   },
   "device/google/redfin": {
-    "dateTime": 1631581257,
+    "dateTime": 1630425123,
     "groups": [
       "device",
       "redfin"
     ],
-    "rev": "519b56ec9f1c5594c63b8664df66e1596fb8c70c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c3eec9c30dd3102ae20d705a9433cfa7c3fad7ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0847pvcnxaxcmaqircg2wr9n4rm710rwkn3dpf5sh3na7jfaca4d",
-    "tree": "c1fac040ec0852d4293a540a5819c7e290394bd4",
     "url": "https://android.googlesource.com/device/google/redfin"
   },
   "device/google/redfin-sepolicy": {
-    "dateTime": 1618966918,
+    "dateTime": 1618880055,
     "groups": [
       "device",
       "redfin"
     ],
-    "rev": "b44a5a74fd2f5bb210b3c2199d02066b5dbac774",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ab0045a6261a824d09b3d1d179e55f0f5d6bf725",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18ng4p4hgm1mcr9j7py85420hsdasv34hqbi3whg3kiynsbflj10",
-    "tree": "c04069a9cb7e043e3b8d27ea7042a6500a6d74bf",
     "url": "https://android.googlesource.com/device/google/redfin-sepolicy"
   },
   "device/google/sunfish": {
@@ -822,191 +774,180 @@
       "device",
       "sunfish"
     ],
-    "rev": "de81f0ebbb8274888c413f605c05bd5193dd5819",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e7d7cc6114209b2460e087e2a276993534f20fb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rdyv7s9g492baxdbgbgk62nqd8ki0kd089yzwaa5mr9yv01xrbs",
-    "tree": "f31d515fa07f05353bd87adce1eec8c859e3879a",
     "url": "https://android.googlesource.com/device/google/sunfish"
   },
   "device/google/sunfish-kernel": {
-    "dateTime": 1633482099,
+    "dateTime": 1633482059,
     "groups": [
       "device",
       "sunfish"
     ],
-    "rev": "a2d2b82f89bf14f3b69af5428841725d68c5149e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "013cd94d47a062920a6b47988af82301547c35ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cij1hd62d36ab0a7kq9n6876aq8c05bzrpi1sjash5dcxcfpsgm",
-    "tree": "b5b3e4400b8c27722ded0858f9f2452791727c0b",
     "url": "https://android.googlesource.com/device/google/sunfish-kernel"
   },
   "device/google/sunfish-sepolicy": {
-    "dateTime": 1633395673,
+    "dateTime": 1633395660,
     "groups": [
       "device",
       "sunfish"
     ],
-    "rev": "67d80b3ad4154a0e17a6ddb733866ee5233baaae",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8bb02077de7e3e3cc59d742986c6c87c8e7b48f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b28h7l3fsnj9304anv5arjnnbjv732xy0m2fs6sdzrvsw3dbs2i",
-    "tree": "902374f5f16c0b9b044b7720e242e87fdc181679",
     "url": "https://android.googlesource.com/device/google/sunfish-sepolicy"
   },
   "device/google/trout": {
-    "dateTime": 1633748519,
+    "dateTime": 1633748479,
     "groups": [
       "device",
       "gull",
       "pdk",
       "trout"
     ],
-    "rev": "58ca9a447841cb0e9439efa82fbfb91e1fb4b740",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "295d01400d06e42eb6d7723d4690ba2c95f15de2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jhfiwgq6mhn83zr0865jy2bmnigm9bj206irjwilafcnp2358rf",
-    "tree": "9caa5d8cae23e79a8c792007d54f0d8a40b699e3",
     "url": "https://android.googlesource.com/device/google/trout"
   },
   "device/google/vrservices": {
-    "dateTime": 1613865745,
+    "dateTime": 1613821483,
     "groups": [
       "pdk"
     ],
-    "rev": "8d9d9c15dfedb59bcf4b93124b36de0be6e206fc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6873ee29419d3c641b1bcab13856b922ea480ba9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bqfiyv18g1il413rkmyhz4prkmq85ww4sh2d5i0rzpddc9rldjy",
-    "tree": "08b53652857dee6697fc8de5862737052c12d33d",
     "url": "https://android.googlesource.com/device/google/vrservices"
   },
   "device/google_car": {
-    "dateTime": 1628643732,
+    "dateTime": 1628562091,
     "groups": [
       "pdk"
     ],
-    "rev": "91c05d23f786819858ebb372e2a12bdb13505db7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f91aa3489bb3933b97cf157bfe3d22e00098ee9b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0f3fdlhf3a00aykpm568hdgwn3jsp4gvizmqw8a8r29mhn04w25v",
-    "tree": "f950d1364fd2c04a29a74155221f6b3cb8d6f1d5",
     "url": "https://android.googlesource.com/device/google_car"
   },
   "device/linaro/dragonboard": {
-    "dateTime": 1624496557,
+    "dateTime": 1624468316,
     "groups": [
       "device",
       "dragonboard",
       "pdk"
     ],
-    "rev": "b0c9039c628251e5516c3a78d3bb42d452273e75",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "38cc3a86bae93f3204c572c211a2d8129f8e46ed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pb3mqvj4r549lgvqv53cd8x3qyx0byj9a87v5gl5q99lsrbjar9",
-    "tree": "7622701a3935559d56862b7b92161eba26411317",
     "url": "https://android.googlesource.com/device/linaro/dragonboard"
   },
   "device/linaro/dragonboard-kernel": {
+    "dateTime": 1613829420,
     "groups": [
       "device",
       "dragonboard",
       "pdk"
     ],
-    "rev": "c0d993c6d3421f07ef77e3b432ef65872ceefd47",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f7e766f68a0907ec59948d06a10ce80b07c06fd1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0prblxspjvp5nsz9ff236ia761539rbnn9wmna8za4k2qg4j26xk",
-    "tree": "d747d6d7702d9a6e69b19996fdb19bf42a620a66",
     "url": "https://android.googlesource.com/device/linaro/dragonboard-kernel"
   },
   "device/linaro/hikey": {
-    "dateTime": 1619139692,
+    "dateTime": 1619053367,
     "groups": [
       "device",
       "hikey",
       "pdk"
     ],
-    "rev": "fe50e7353398d697b335d38c4cff3a56d9d352a5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "833f9bc5814f1e6ecd4bb41dddc40ff8c397500c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l5bkan588ig1g44bf1c5pwcd27i6wysh3i7sdfvlabkv6h0g86z",
-    "tree": "bdc346889f77bf17918688727ddc16de4e80a1d6",
     "url": "https://android.googlesource.com/device/linaro/hikey"
   },
   "device/linaro/hikey-kernel": {
+    "dateTime": 1613826996,
     "groups": [
       "device",
       "hikey",
       "pdk"
     ],
-    "rev": "1f764f0210564a6cb40b8542c0f2e048774fa0fc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ef76756f5cdf1859b0ae50e23fdc7f10f01308b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r994z41qd5fq9vsg0360glrljrivkwa4wsms1amaw503vdxx2nn",
-    "tree": "7e0fe52d8664fbfd32073e180e0eeb839f6fa182",
     "url": "https://android.googlesource.com/device/linaro/hikey-kernel"
   },
   "device/linaro/poplar": {
+    "dateTime": 1620243049,
     "groups": [
       "device",
       "pdk",
       "poplar"
     ],
-    "rev": "4ddd9603f9bd741a84d5e68e447198eb7a84d842",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2fe57031060750bcc819fbad0bf88dde79702a46",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1j921jkjwi0v7mhf6lybdlv2axyzlrhmyfkpdghmfyny9y1za7bz",
-    "tree": "7a2dd29801e931b8966c0c12781b3c6ebed97b59",
     "url": "https://android.googlesource.com/device/linaro/poplar"
   },
   "device/linaro/poplar-kernel": {
+    "dateTime": 1558122724,
     "groups": [
       "device",
       "pdk",
       "poplar"
     ],
-    "rev": "9302ccbf22b41c0b0afc9b6fa2a36a30a7aeffbc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f6aac891c28a8e1cd444dca6fa7fd362df67f795",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0danmswzl4r3skm19gg0868p36fxlhd5vj793v4i5allqkqgnxin",
-    "tree": "9e2aa9d89740449a9f3ab0aba6c5510fa6de59ce",
     "url": "https://android.googlesource.com/device/linaro/poplar-kernel"
   },
   "device/mediatek/wembley-sepolicy": {
-    "dateTime": 1624598345,
+    "dateTime": 1624578728,
     "groups": [
       "device"
     ],
-    "rev": "5e16bc51a6b1ee591961b54bfe520787cc3672da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a28997f7520c12e6bf7427732ef9096df248ced5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "184isr5327zlh5fjaqzcyanldbjxr7lp934141r80c2pydgfx765",
-    "tree": "896946ced9898d2cfb119b47d5d995e7f6459bce",
     "url": "https://android.googlesource.com/device/mediatek/wembley-sepolicy"
   },
   "device/sample": {
-    "dateTime": 1620442937,
+    "dateTime": 1620388245,
     "groups": [
       "pdk"
     ],
-    "rev": "d56838bebd7190fe6042d1df57c069d04fbe1423",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1a562f50ebf8202186478b1c137b285cfffcbf7e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "14iyki70hlnb95i416izsw29hiyfpj1dnfb2pxnrr82qy3xk6dr7",
-    "tree": "13b6e11bea583bd0d274a89858ea23cb3090c482",
     "url": "https://android.googlesource.com/device/sample"
   },
   "device/ti/beagle_x15": {
-    "dateTime": 1617152508,
+    "dateTime": 1617084084,
     "groups": [
       "beagle_x15",
       "device",
       "pdk"
     ],
-    "rev": "e1073f31b818b74d5627db4407b03cefd9632ca7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e847af24784df22ec2d33386b811ab2e7e7d1676",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vbknk4k3dx9gbmhnhgvaiinfmhk8s0f3j5hzihbbdljqp0j65mj",
-    "tree": "8abbab950346d8c319bc0847b328140cc6a64c0b",
     "url": "https://android.googlesource.com/device/ti/beagle-x15"
   },
   "device/ti/beagle_x15-kernel": {
+    "dateTime": 1554368860,
     "groups": [
       "beagle_x15",
       "device",
       "pdk"
     ],
-    "rev": "b28792e0801c455a2c8c49d30b55c4528512af36",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2bd2395b55dd6b5ef780f1decfaa43c14176154a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ahsr4x06x982y975jizgy0k3jix70rd1ypzgg3v3k24wpifrnn3",
-    "tree": "de071f02555c4f129537681669c26c9a392f3362",
     "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
   },
   "external/ComputeLibrary": {
@@ -1014,121 +955,117 @@
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "1fc483a90e3e5aa49e7756a5d3ce360c3d0a7a86",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fcddded3b981f58de607b308f58b2e8a6374b5cf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k1ian6l5wkr2lgbn061rqggrv2k37z8x56jw2k005ga020qb71k",
-    "tree": "3aab6c17d52adf5138adbe89f0340c466525566e",
     "url": "https://android.googlesource.com/platform/external/ComputeLibrary"
   },
   "external/FP16": {
+    "dateTime": 1613692256,
     "groups": [
       "pdk"
     ],
-    "rev": "df15a85a4a9b6bf13fadd947899dc5a42c9f503d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "95098b8418f4ef7accf20e99baaccb689e3ba987",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13lwr9v1rhr35mlvhzvwhwx9zcsry9nmin57w8wy8f3jm3m65lsd",
-    "tree": "bf795792c727b7d3d47af92580a2ac7157e72cd1",
     "url": "https://android.googlesource.com/platform/external/FP16"
   },
   "external/FXdiv": {
+    "dateTime": 1613828351,
     "groups": [
       "pdk"
     ],
-    "rev": "8a59a954da0549246dafc87ba37b6283c16648b4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d39ec24ee981e81da5f2f47b5b9657be6ddbfa27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1804qzjg3vn7crqfzb8qv4f8sz5gl09b6h1lsgdr2plz2iga6b6m",
-    "tree": "9e71b2fb2df83e4bfd8abbc2bfa56c2a09d0118e",
     "url": "https://android.googlesource.com/platform/external/FXdiv"
   },
   "external/ImageMagick": {
+    "dateTime": 1619030979,
     "groups": [
       "pdk"
     ],
-    "rev": "f2803769041ee7914bcd94c21ac495bf88ced51a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "39c9d2a31ed7ae09f47408392a2bb77142c483e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06ngnvlj2yd1n5r9d5jg914br23ynp0hjwqlvcp9kyb9wnz8n7ll",
-    "tree": "03045c94afd42a25472029b2b83fee3c60a2929b",
     "url": "https://android.googlesource.com/platform/external/ImageMagick"
   },
   "external/OpenCL-CTS": {
-    "dateTime": 1621991117,
+    "dateTime": 1621445785,
     "groups": [],
-    "rev": "030d957f7f3f8bca5f1355c3e08421668642ca23",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dde1869eb746edd8e5d9d292141369d55808e4be",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vs5jdpd0mxglmpcs0yjf778ink7mhkliahd7py6smw8mlram7kx",
-    "tree": "68ef86716c782f27d390623b7e0b43451262b611",
     "url": "https://android.googlesource.com/platform/external/OpenCL-CTS"
   },
   "external/OpenCSD": {
+    "dateTime": 1613823814,
     "groups": [
       "pdk"
     ],
-    "rev": "5d880512b606b09f52792fe556b7183d75e1047e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "93cfff8bb015396bea979db38e8ddaa9ab21f9ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b3sn1yxyjl7ghzvgq2fk50q1q52s5wbwg7lgdd37kn0dfj8f7pw",
-    "tree": "b89158aa98c2558ba697f4fc0a0175649bb024e3",
     "url": "https://android.googlesource.com/platform/external/OpenCSD"
   },
   "external/Reactive-Extensions/RxCpp": {
+    "dateTime": 1613582546,
     "groups": [
       "pdk"
     ],
-    "rev": "15d18ea7023c52b7e440b8f80960f2d70c3b1960",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e57817bfad4d163de712534ed69938b2756d3cc3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ydkh937q0vss0y5zid0zfrhlvk0rib57g2cnylzl2f667svabr0",
-    "tree": "051bad073977aaef75ac75fdc4bcdc6ecb616ce1",
     "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
   },
   "external/XNNPACK": {
+    "dateTime": 1616547430,
     "groups": [
       "pdk"
     ],
-    "rev": "b42a7a75a37d36cd29efd6e4b8e731607c5dbddc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b53c1c799f2a5d3fe7a728990f07d6037aae0856",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ps0gzf10n84ppcv23m03knwbllqd6x1skvn69sn6ssfiw12slwh",
-    "tree": "620677917f38b4015358dac80d83b3a760d9b25f",
     "url": "https://android.googlesource.com/platform/external/XNNPACK"
   },
   "external/aac": {
-    "dateTime": 1620514915,
+    "dateTime": 1620503750,
     "groups": [
       "pdk"
     ],
-    "rev": "bd50675fbe6e1c8d85560586923295ccc984154e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "236499aad909221b26debfa8badc2c7eacdc3d50",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bg8wabf6snkr7fy3izis441jhqhag1gngi53dlzfk7g7ljiz3if",
-    "tree": "c6a1ddee22e29d9ea00ec2523071a711368189cd",
     "url": "https://android.googlesource.com/platform/external/aac"
   },
   "external/abseil-cpp": {
+    "dateTime": 1613516541,
     "groups": [
       "pdk"
     ],
-    "rev": "0fbc846fdfed7faeee0479e2f609aa97917c5eb4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0fb733d08b18f82bde95cb422cb8bfd72c702546",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "090a9pkyc3pxqz1pa42kmgqzqn3cs80f4arabm9sffnkxgds1254",
-    "tree": "6cf3c89b6849ab38ec1689687d291a3e249796ab",
     "url": "https://android.googlesource.com/platform/external/abseil-cpp"
   },
   "external/adhd": {
-    "dateTime": 1618275720,
+    "dateTime": 1618259723,
     "groups": [
       "pdk"
     ],
-    "rev": "e88f05395dce2be74ee3af497ec800feb6fc9110",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7a39d6673b3cf1d2de5a1ae0ec99cb5dcf45169f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k726ay3gq777jc9g57aqcnfvafh9xxhkfahcgi4mjcys6x60rbd",
-    "tree": "7e0e07b9d8d50fc5dd352d5b36d74fa3cb3427db",
     "url": "https://android.googlesource.com/platform/external/adhd"
   },
   "external/android-clat": {
+    "dateTime": 1622589567,
     "groups": [
       "pdk"
     ],
-    "rev": "c1c2af1c339827dc21bcfe728a3868d302f59589",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b2643968020cba18b7594dc7e8426f7a005116a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08bddsbl7za78ac6drf63pmpimyqcjkqp3xkjacqqppa16gk15f0",
-    "tree": "4ce3e86e3851116f8acda0333bd44bbfd6436b4a",
     "url": "https://android.googlesource.com/platform/external/android-clat"
   },
   "external/android-nn-driver": {
@@ -1136,142 +1073,139 @@
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "76dcabd8d877440cd2cd85de701891f80323d57e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1e699697e86ce1692e504b85380cb96afb4af69f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "060pv319qq0wdmy6xjbllc83mx5xkkz0jaanzbmgwiv2cq2xsc1h",
-    "tree": "a5263225fce8b7d828c13195eb549bcce523b3b8",
     "url": "https://android.googlesource.com/platform/external/android-nn-driver"
   },
   "external/androidplot": {
+    "dateTime": 1619205494,
     "groups": [
       "pdk"
     ],
-    "rev": "958fdc49024f38190e23abe91f4c8ef01e8f6af4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cddadef64739fa387c738aafae5542cbf006fa39",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dxx539y2fbys0v3108mvk6ac875rjz6sw552xa2mhdhj5hywx32",
-    "tree": "c19652f571e82fda8df37b011482d499d6fab485",
     "url": "https://android.googlesource.com/platform/external/androidplot"
   },
   "external/angle": {
-    "dateTime": 1631754114,
+    "dateTime": 1631650514,
     "groups": [
       "pdk"
     ],
-    "rev": "67cefc40dec333d31270ad3082a3d46e498f61e9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f0e2bd12b5ed3765e0cf3e63f5ff8a981537a081",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sgr6i1qw61gi1brgqpxrcnnlp8ibq9ar8lzm577xxrjrivp3j21",
-    "tree": "449f55443cdd38fc4701b127d4a8d0f05a91cc85",
     "url": "https://android.googlesource.com/platform/external/angle"
   },
   "external/ant-glob": {
+    "dateTime": 1613582543,
     "groups": [
       "pdk"
     ],
-    "rev": "fa5924ad58aab379cc6df9dfec8ac53f0ff1e132",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5c52eff266c361f867dddd5d9684b7f745d074c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kv13x3rrjv04fyipfjgdmvbj9c22wb4ws8xikp2byvqss5qfyfj",
-    "tree": "5cb85282d1906e64622c8014a45275f9ea666ea6",
     "url": "https://android.googlesource.com/platform/external/ant-glob"
   },
   "external/antlr": {
+    "dateTime": 1613516532,
     "groups": [
       "pdk"
     ],
-    "rev": "1ed09ffa4fc9b7e2ddbe719f0669fdb916c11720",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1bcb750cfee3fe9dffcc174f1d0565dc8b3e040b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09m5na2mm1qbbffzvmyvkvvp48wcfyd2m90asg07adaf94pw7xkb",
-    "tree": "0dda7c6f519668ef88610559e88075f672c87856",
     "url": "https://android.googlesource.com/platform/external/antlr"
   },
   "external/apache-commons-bcel": {
+    "dateTime": 1613513322,
     "groups": [
       "pdk"
     ],
-    "rev": "5e56c3262b6657b3234af1d9a0cc77a72c4a7d70",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "67bcd0956c87ba6f9162b5479390ec20b829aa08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wg1k32wz232b3d0iz8n0krpclz21l8jmmpd08ybgx410ga0nlwb",
-    "tree": "7becac4f172bc523d6803aabc6fc4ab2a4c6c259",
     "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
   },
   "external/apache-commons-compress": {
+    "dateTime": 1613516533,
     "groups": [
       "pdk"
     ],
-    "rev": "dee8111f9ecb70114d90af50f9b1cb535d78921a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "612c676ea534b558b430012cb092d4a905eff1b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mrr0ypp23pljll9i0xawar6h4snw52k10xnggmsrj638xi5bmms",
-    "tree": "2e226ee46d90ec1737a202ae6cf02029b349b54c",
     "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
   },
   "external/apache-commons-math": {
+    "dateTime": 1613516535,
     "groups": [
       "pdk"
     ],
-    "rev": "ba5becfdb8afc57a10f12ae1743128add62bc46b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "149420d9dbde87e71585e12baa55f683432a00eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17f2wbjgrpyjbcxxmwyfyxfbr7ci4z14ry1vp7dac0hlzn57rpln",
-    "tree": "cabd27a5c87d941c6681fc4c4381c9ba6a511853",
     "url": "https://android.googlesource.com/platform/external/apache-commons-math"
   },
   "external/apache-harmony": {
-    "dateTime": 1622077387,
+    "dateTime": 1621989520,
     "groups": [
       "pdk"
     ],
-    "rev": "0cb26f21a4d3622c7edfe1bd2e3c9ac4ae743321",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2f2fcb047055c4f32fbbeb33425f6f8cd32f0d14",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13j3zz0wjvyyy8i4n56039n96yrla6iqzng13fi02fia2wwv5vjb",
-    "tree": "f8164a04bd5a75dfd9fc4d8d816eddb51530b615",
     "url": "https://android.googlesource.com/platform/external/apache-harmony"
   },
   "external/apache-http": {
+    "dateTime": 1622823701,
     "groups": [
       "pdk"
     ],
-    "rev": "8939ce8da86305802466c8773f9b130eb1ec2ba8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5408d2abe6b2792600ecae57c30f91d8b5f8e585",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "180wkbj8pj021w6wizcjlnjl8giw3bs998jrxxpyrkpnjbf7nw2a",
-    "tree": "c0ef7660bac140abe46b991b8a779138961e5552",
     "url": "https://android.googlesource.com/platform/external/apache-http"
   },
   "external/apache-xml": {
+    "dateTime": 1614863600,
     "groups": [
       "pdk"
     ],
-    "rev": "a9aba21f53c1186af220192bc78fb65c639ca9ec",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5d0e3bf8cdb5e8b44edc02dc1593619692a14ad6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07p95202kf49p5wpg5fq9nc99hcjcphac903sbm8wlsvcvppw6hx",
-    "tree": "3c1badb7488f3ce3c9d358a7b9173f9756850092",
     "url": "https://android.googlesource.com/platform/external/apache-xml"
   },
   "external/arm-neon-tests": {
+    "dateTime": 1613504485,
     "groups": [
       "vendor"
     ],
-    "rev": "ba6cd14cbdabd18518c739a1d0f1a8e8dade12a2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "77ae105cbd3df608ca435bc398be123098190186",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05q3rb390d3zdmva3br4r2njy8hwvnn3ny796dbbsy8fwyq6ijzg",
-    "tree": "e0e7f83ac2a3ba4506488455e43c70116310161d",
     "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
   },
   "external/arm-optimized-routines": {
+    "dateTime": 1619680113,
     "groups": [
       "pdk"
     ],
-    "rev": "e97a736dda538e8af8a88c8249684faab109e461",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c3f64a7dde7880b36a61a7b3a2a80809331790e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ag1zvd22685wxp2yk82vkwc246y2n1csqqjspx6zsbixgjrap5x",
-    "tree": "7ded61f3cfe322fe4706181e50b2f28b35d8a4a0",
     "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
   },
   "external/arm-trusted-firmware": {
+    "dateTime": 1613512057,
     "groups": [
       "pdk"
     ],
-    "rev": "2c8706b3a06b629ff7c4fd995aec52d645158f4a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7eb3bd4a5a03885d5af78733a8b139b0a104d7c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rdw9ffppv0lqb2gy6pljp9irrckg389afkb9m90nlx84cw4kg4j",
-    "tree": "37a21c69306801ee7cdda5167a30896c8740155b",
     "url": "https://android.googlesource.com/platform/external/arm-trusted-firmware"
   },
   "external/armnn": {
@@ -1279,5675 +1213,5491 @@
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "69829bd0385e89be606a0eb689d29d02fd1e8c50",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3068ad2d09865c45b06369e7ba9138d84d0a84ca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1s30csg50az4hgmc0idc8ifnckw4rrjmhxlc3pl19kqywv1ng9m1",
-    "tree": "5561ca57639650f9893e926183c235676ced22c8",
     "url": "https://android.googlesource.com/platform/external/armnn"
   },
   "external/auto": {
+    "dateTime": 1613821355,
     "groups": [
       "pdk"
     ],
-    "rev": "2527e14eeec67246f1edd47ea3f58980e7f896bf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b88897f4035af37d4d192d8025046ebc12311f12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02zs1cf9553f3wamv53sfxpphh2ss7l6lvww39f970zdpkkr1k85",
-    "tree": "960b44a6f1f21102baf56bc4d3c00f2ff9737762",
     "url": "https://android.googlesource.com/platform/external/auto"
   },
   "external/autotest": {
+    "dateTime": 1613832706,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "4315cb8e6398cd1d3281efdbc406b44eebdacbdc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e31cbc81773d3d7cc8d44e8bbe8f579bf3eae7d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wnd234ci6hwfflsdf248jvmwp8dd08hcka8nll3gh0wqmy9bizf",
-    "tree": "970bfee28a0ee405c81505a96ecebf10ce798f23",
     "url": "https://android.googlesource.com/platform/external/autotest"
   },
   "external/avb": {
-    "dateTime": 1625706359,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "547153d2ae828d465c2d2e7f85570c704611485a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4ac009735dd5a88b1677086a213606dd1f90036a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1s35d3zns4w00k7x2x2pvc4b2y4c8kd46rmi7x860kszkl02kvwx",
-    "tree": "611cea55179701e5f8bc6d04182f4695f76445bf",
     "url": "https://android.googlesource.com/platform/external/avb"
   },
   "external/bazelbuild-rules_android": {
+    "dateTime": 1616444141,
     "groups": [
       "pdk"
     ],
-    "rev": "5fdcba51a5efa8f27f6163765512e7260559c261",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1eb2a132a25cf1dfc73ffdd80633e2d1fb45c99d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mg4iyzaq22b9n07146vmq273vrk2f0hlyj7jm71s6vhmlqzvl3z",
-    "tree": "4ff6434731886c36f5a6eef7606a7d31696542df",
     "url": "https://android.googlesource.com/platform/external/bazelbuild-rules_android"
   },
   "external/bc": {
+    "dateTime": 1620322862,
     "groups": [
       "pdk"
     ],
-    "rev": "1622c2739247e4942684f0cc12532d81f9326e6c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3de3a8b03134e422877ea0567e4764217d1bae00",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ijih5ka54195h55c019z9nq5hmb71f3smgkssnh0rmjry6h5dld",
-    "tree": "439eb6a5bda538c326a2a854b852c36389dce04d",
     "url": "https://android.googlesource.com/platform/external/bc"
   },
   "external/bcc": {
+    "dateTime": 1613814570,
     "groups": [
       "pdk"
     ],
-    "rev": "7547e3bf9c7499a9cc59c248bd2f5e494f3c4662",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "091549abc50d64f8f6504f948f07ee3ee7ae337f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04kphwmxxnpv72ycsn8skhlc8hkmm01rb8w8x0jl0gcbcw28dbng",
-    "tree": "b7b8d586ccc26581c99d4c96b15f62aa60029e71",
     "url": "https://android.googlesource.com/platform/external/bcc"
   },
   "external/blktrace": {
+    "dateTime": 1613934263,
     "groups": [
       "pdk"
     ],
-    "rev": "e011286363e010add905a0372154385d4261f0db",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1d483b516c347bd13c53753b5a92a56d32ffc781",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v4znxs40lqzd9k5qw5my887x3ybybdfhhcf7qi3y4v9p8wqk9mw",
-    "tree": "51e2927dad8e330c62a779954ab2d3d5b24c93b6",
     "url": "https://android.googlesource.com/platform/external/blktrace"
   },
   "external/boringssl": {
-    "dateTime": 1619391741,
+    "dateTime": 1619371958,
     "groups": [
       "pdk"
     ],
-    "rev": "6018c47be12d3fb738881c9bd39b47db69f45eb1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f6603aa3245aef2f4a257a7b1acb394e7e63c44",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zdzw01rab9qnsj9vn4ygk0x2i3bm2zjidl7fxwxf8z42h027bpx",
-    "tree": "323655a79032144978e5c081cfc4477da3fefad6",
     "url": "https://android.googlesource.com/platform/external/boringssl"
   },
   "external/bouncycastle": {
-    "dateTime": 1620954149,
+    "dateTime": 1620907722,
     "groups": [
       "pdk"
     ],
-    "rev": "8e344b8d76de4c62d59bcea62756e07ac45bcf3b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "be907c90cdfcd2db987cf6329de706d6cc91514f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0x4sy9406gffkglnkyg1pwpi66p1mhkrhh0p1245f2mbap6zbhx4",
-    "tree": "daf45d522673930ba2a90970d64295962b9ce13e",
     "url": "https://android.googlesource.com/platform/external/bouncycastle"
   },
   "external/brotli": {
+    "dateTime": 1613829216,
     "groups": [
       "pdk"
     ],
-    "rev": "2a9d3bd5256afd04c6e4a3cf738232b0353eb9dd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cb6bf9f89f37ab8c10a954bdc74efb7a5beb1ed4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jjahi9515i5fchmym5rc9fk63hh8dmmbacpvf5q8bfb96vc52bg",
-    "tree": "97a85c8ac40ee60ac80a8663fc1d5fb86e9c6e27",
     "url": "https://android.googlesource.com/platform/external/brotli"
   },
   "external/bsdiff": {
-    "dateTime": 1618966958,
+    "dateTime": 1618891219,
     "groups": [
       "pdk"
     ],
-    "rev": "e2a9090f4d307b0d4093350d6195b8af0caf4564",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7c44647e287a465e23697dacd185568956d120e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bvvbndadhzqsl8avqwzxag02i90zmplbzw5xfiprdrbzr3l07im",
-    "tree": "6a5fca95ce93294ff06b53dbdfd4e3a81548cea3",
     "url": "https://android.googlesource.com/platform/external/bsdiff"
   },
   "external/bzip2": {
+    "dateTime": 1613834102,
     "groups": [
       "pdk"
     ],
-    "rev": "19e6a8d83232c7af8cbf6603ab8303ab0eea88d2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ce6db7bbcbd569600c4c38bef64c9afefbff4a73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vc2m1fz3dhypn771zbhfdf1my1lgm1naz08zyfcm62j6p0263sw",
-    "tree": "134faa56762a17c775fa18d4b4784aeea3e352ae",
     "url": "https://android.googlesource.com/platform/external/bzip2"
   },
   "external/caliper": {
+    "dateTime": 1614282416,
     "groups": [
       "pdk"
     ],
-    "rev": "53a6387442f53ac1f347484a2a1b833bb76cd378",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "83159506859460313eb1904ed1c8360d3d7e20ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hg2c1b1vqrx3ky9s1s9bdalvpf47sgm2w2m3cwwc66p92x9sk8y",
-    "tree": "d2a8615b53cbd8d2a5add45543e271b5664861d7",
     "url": "https://android.googlesource.com/platform/external/caliper"
   },
   "external/capstone": {
+    "dateTime": 1613835333,
     "groups": [
       "pdk"
     ],
-    "rev": "4a83c1617ae944ceb8001c8c9107245a4a5ec42c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c18d1d02b15d90cb50c86493881c2675d4a710a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "181svy2yh8400xdjbz09rfmkzbzic8i8zjpj3mmicpq3lrbp37lz",
-    "tree": "810878d1f4e7da73475be66b4e3f751ffd52f9bd",
     "url": "https://android.googlesource.com/platform/external/capstone"
   },
   "external/catch2": {
+    "dateTime": 1613516546,
     "groups": [
       "pdk"
     ],
-    "rev": "cd4472a4591ff516edc7ba6269f0d5402c5af537",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ee8b2931cd6802aa0f99d960903357af0964da4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "121f7mvnhl9ss3ckwliiqfdkpi0c1siq7vy2ghd46lk17yc7lc7l",
-    "tree": "a3d2bfe065ce75a6840fceeb2bf10aab1a77149a",
     "url": "https://android.googlesource.com/platform/external/catch2"
   },
   "external/cblas": {
+    "dateTime": 1613582538,
     "groups": [
       "pdk"
     ],
-    "rev": "37e3750d41c2cefad2014d18be74bcd699ec314b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bfc32c0f8888d2131e2d228ee22ea4be1283396d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vs0bvv7jxg9v853ys0262523qw6f83vlyzkq8dfrsvnsycakzzf",
-    "tree": "923bc4971f5b4dc8e023fad2d98800c17c47f0a9",
     "url": "https://android.googlesource.com/platform/external/cblas"
   },
   "external/cbor-java": {
+    "dateTime": 1613516547,
     "groups": [
       "pdk"
     ],
-    "rev": "685fbb2d2497558f2284601ddc9cb4a45ad92ba7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d6e32b4081e81803462bd9f3f6f19bd4dce953c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18ycp109z76isyfi7pac2nd9idi23wpywkbndp9ki1h69mwr2zmm",
-    "tree": "093e7f4e8b99e937aada1dad8d1512cbd6b3b9f3",
     "url": "https://android.googlesource.com/platform/external/cbor-java"
   },
   "external/chromium-trace": {
+    "dateTime": 1619035266,
     "groups": [
       "pdk"
     ],
-    "rev": "a4722f2ac9107ab330b950d143b4ca6846189abb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "748eeb0a79f235198b844f6e14360a6a7af5966c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0alb6ykda1vi6n2g1cw3b3p871c9bpz4xgi163p7kz39hpwv4h5p",
-    "tree": "e3c91cd249ec301599cfb651e542def91e410125",
     "url": "https://android.googlesource.com/platform/external/chromium-trace"
   },
   "external/chromium-webview": {
-    "dateTime": 1624071775,
+    "dateTime": 1623977980,
     "groups": [
       "pdk"
     ],
-    "rev": "66cc298326e2605e81ed1b4b6775180386d74578",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "51e3b0e8c52d17a8c1e4f86cdc731c35b4d58cbb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p4kh9ph8ijnldlkv9yp61aabwba0q3qipq2i1my6073f9fi0r78",
-    "tree": "589760d24e3dd51884de9ff3c90476f7653a6853",
     "url": "https://android.googlesource.com/platform/external/chromium-webview"
   },
   "external/clang": {
+    "dateTime": 1613822470,
     "groups": [
       "pdk"
     ],
-    "rev": "374c24f9510d3219e67395b73e8ca9b5cd16d89e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "df3f64e94d879d9f35211f3f407ab9014eaebce2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06jjzh7xg63a852m61x1dy5mk32g505srm9qax981y1fiqy4pr9b",
-    "tree": "28da730405effc787655ce612d030b4e8c83df0d",
     "url": "https://android.googlesource.com/platform/external/clang"
   },
   "external/cldr": {
+    "dateTime": 1619792850,
     "groups": [
       "pdk"
     ],
-    "rev": "cbcc43b35c0146a0ac4e1cad54e638e131ffe1af",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f49d339e058c84929776caac3c961b52be262ce1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10956w4glpps3sfa2qf69jn75y64vkbxjc0ra11pfx3is0xvbxmc",
-    "tree": "6abd21d8080d42134e40237fc66ae3bff29c93b1",
     "url": "https://android.googlesource.com/platform/external/cldr"
   },
   "external/cn-cbor": {
+    "dateTime": 1613582536,
     "groups": [
       "pdk"
     ],
-    "rev": "5695b5cfc73fc437d6b7b00fb0ab45c8fc311da9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b99cf1b25c758cd5725ae847ac7482c8af3ae9f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gh910wa3zrdk8jaghbbrwhr5cwxj2jiji98b00i79vdndi9fkp4",
-    "tree": "b1a40b5effebc93ce8f5010ec014f98daed1165e",
     "url": "https://android.googlesource.com/platform/external/cn-cbor"
   },
   "external/compiler-rt": {
+    "dateTime": 1613821530,
     "groups": [
       "pdk"
     ],
-    "rev": "bad811d81849ca8f838b92d8aa417a903e6e21d5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "73b16b948fd50f2dcca9b01b41aa85fb13c8dde1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sxxwngwcb9z6x3f9i7fw8j08h27wvzhdnmwxbrx2kz2zphm4gwn",
-    "tree": "d901cea535f52d271a7e1085bbc09c825d9400dd",
     "url": "https://android.googlesource.com/platform/external/compiler-rt"
   },
   "external/connectedappssdk": {
-    "dateTime": 1621472557,
+    "dateTime": 1621418517,
     "groups": [
       "pdk"
     ],
-    "rev": "c05c1f41282993964fb98914979be68d4b3efbdb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8713a3a1a9f631b40a1520c045ae773602a4868f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vavn5xrv27dqs41ijz6h5sp54ysb0azwkn4vzpzwwvvbkdxgdfi",
-    "tree": "62edfd5f2c13fd0b825422d7f53bef0753a88879",
     "url": "https://android.googlesource.com/platform/external/connectedappssdk"
   },
   "external/conscrypt": {
-    "dateTime": 1627095760,
+    "dateTime": 1628888011,
     "groups": [
       "pdk"
     ],
-    "rev": "49aaa76ae7f986a826e89a6da30f96570ef2183c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "500ccf997a3f146d07febad5f640483285f17482",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g9kibaj663hwkbsd31vkxhib941gi2vz9pb757wb0afaayrhdv3",
-    "tree": "4502a0d3bd8ab0c925726d66f3727bbd80ae67fc",
     "url": "https://android.googlesource.com/platform/external/conscrypt"
   },
   "external/cpu_features": {
+    "dateTime": 1614926428,
     "groups": [
       "pdk"
     ],
-    "rev": "2f65ace47e0f602b25e7384e4c75cfb97e56961d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f00473b8f267c63ad456843bbb9c4ee5a36bf50f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "078fa0lqhy0v8nhb81yr4r80lr6d24r0xayxwzvyz9f78phvypi5",
-    "tree": "e6f352f7e260f5907e73795cb94c9b6d2515489f",
     "url": "https://android.googlesource.com/platform/external/cpu_features"
   },
   "external/cpuinfo": {
+    "dateTime": 1613824033,
     "groups": [
       "pdk"
     ],
-    "rev": "7784d3f1206cfabb8a8ca462829f560085f4fbe3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8e0453d374a2f950c37931e0d108ca94842edb9a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0y7api7gknnfphvwz8fc751yzwj5vzzgm7zqdbrcf0r3m09my4yg",
-    "tree": "61775889817f39fb6d1bdeb88fb5fafaee2971da",
     "url": "https://android.googlesource.com/platform/external/cpuinfo"
   },
   "external/crcalc": {
+    "dateTime": 1613516535,
     "groups": [
       "pdk"
     ],
-    "rev": "c8db3a7b6f834a1e89de411282785f902fea06f9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3dcce050eb89954a5c3f611a6c93a718c093a234",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nldnvwr197rpzigkxrdb1342vcnwh1mdazr831ynscqga55f7sc",
-    "tree": "a9b202b5b6992426c1505701ae6dd7c2bcec14b8",
     "url": "https://android.googlesource.com/platform/external/crcalc"
   },
   "external/cros/system_api": {
+    "dateTime": 1588165008,
     "groups": [
       "pdk"
     ],
-    "rev": "f8c1780660689e8b34facc75d2381c9989ee367b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1ee9612b05bee74c462e3062c7f58e425f762355",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jr6jiz7qjgwfm8p15lq6qh18iy25qbyr1accj1mxy2xcp3lcvnl",
-    "tree": "cb891c789d5114d8075da9efe5edb3a434291444",
     "url": "https://android.googlesource.com/platform/external/cros/system_api"
   },
   "external/crosvm": {
-    "dateTime": 1620349357,
+    "dateTime": 1620281201,
     "groups": [
       "pdk"
     ],
-    "rev": "f3e610e4238c0727cbbf79ddc730e0db77af778c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "09dc36d927a6286d25fbc720784bb653603549a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ly6s74ajgf936hz3wb81cqla6a46dmxn0jk9137nqkxqyvanrfx",
-    "tree": "0068dd0351f2e33ec9b57372f41473490d0768bf",
     "url": "https://android.googlesource.com/platform/external/crosvm"
   },
   "external/curl": {
+    "dateTime": 1613834187,
     "groups": [
       "pdk"
     ],
-    "rev": "169cc1c405fc6414d66463e934855d11c324fd5e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b300f0642db1089aec47f6c7f62d9e4c10fe97cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wfyfdkw212wlqdmxwwm985hdm6wwcgx3lagbl373h9f9d6j7y28",
-    "tree": "2f0deeb6f002cb9428ba045ec685c932b0b3414c",
     "url": "https://android.googlesource.com/platform/external/curl"
   },
   "external/dagger2": {
-    "dateTime": 1620954161,
+    "dateTime": 1620860986,
     "groups": [
       "pdk"
     ],
-    "rev": "5bf608715d0b17176b2d11d4d23be03eea8be68c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1d995fb74f41105e144912fa329425f534e7c45c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0aa3q04an07rmyf3fjjs797fpm49mq4fi1y0arqdk3jcn44ha8al",
-    "tree": "6f59a75348d07612173246ac6c4fca04bde0df2c",
     "url": "https://android.googlesource.com/platform/external/dagger2"
   },
   "external/deqp": {
-    "dateTime": 1632877329,
+    "dateTime": 1632823903,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "077eaa1e8b6b70444c5c0823aa71f135fc2d03da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ea9cfc63b8dde88e54d86c0ea218be3973b6bb11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rvdnrfngy0niji5p9lqsgsccxfapjzp5fbvrf47k3z02i6ad07x",
-    "tree": "8b7358800ef2064aa70d1731350ff1776dd6bc26",
     "url": "https://android.googlesource.com/platform/external/deqp"
   },
   "external/deqp-deps/SPIRV-Headers": {
-    "dateTime": 1632877328,
+    "dateTime": 1632823903,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7c19c3f4bdb4d88bca14131ac897820283d97742",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b3e1648c7bfa4434969b166ee7544acaf1e9a98b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "197mx23883n4i2grsaaf7d09cbp70yajzd4ylwr186lg1q94j649",
-    "tree": "829923f7e500a17e9fcfb430d518342f074a9ff3",
     "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
   },
   "external/deqp-deps/SPIRV-Tools": {
-    "dateTime": 1632877329,
+    "dateTime": 1632823904,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "65b9ee1ba8454a046df8165c5b75d74bfc9f244e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bbac3629c886321be6ace9c237d31e8efacb5fd7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n9i57smxsy1hrqa7i0as6ky0ggcyp3y104hgmxmgzmxsch6a4n4",
-    "tree": "5bfa88b833e4004e8e1efe297744560296aa1d7a",
     "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
   },
   "external/deqp-deps/amber": {
-    "dateTime": 1616029327,
+    "dateTime": 1615983911,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "ff524b8b0c41dda96e1b373145b1517acbe3b9cf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "191c4b0c1697dae3c4e40f073fc145409e57e390",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "012vrgcf5afz99avy1107z40ly4dbnvaldzmm60zm074ys2gpczv",
-    "tree": "bdf409c89e96d95b1a90258eb449dfaf7c450239",
     "url": "https://android.googlesource.com/platform/external/deqp-deps/amber"
   },
   "external/deqp-deps/glslang": {
-    "dateTime": 1616029326,
+    "dateTime": 1615987577,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "e5f6c8bba30b940d65e9215c751e562c30eb0b47",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6783fc5a8cf6c9de8c29e9f2b3d7f5bb548ee582",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0m4pvypx9l7d16pslkf8imqm3k21jap1vcb05pm6213rwrgl11im",
-    "tree": "5d74f21d224575044c957e2655ac393cbb94e936",
     "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
   },
   "external/desugar": {
+    "dateTime": 1613516544,
     "groups": [
       "pdk"
     ],
-    "rev": "ef34b5438a4383b1ffa7e1d6b58b413c4e2f5f3e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bd4df200512948cb53d14a61e4ff69e17d2a8f54",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l24kgg5lm93aawfknf9igbhcag5jlacs0v1h0b2cwk7ffq6igyv",
-    "tree": "e8a970ff0d038511d3853490a6da42d409e255c5",
     "url": "https://android.googlesource.com/platform/external/desugar"
   },
   "external/dexmaker": {
+    "dateTime": 1613827223,
     "groups": [
       "pdk"
     ],
-    "rev": "e8b1d5d09d80135800c98d7301274e164d863f1c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "912b4d9120ae6be6104eadd1e930cd1bfd1e9586",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c47k9acimibwfm46zkhnwxr9ijjhz300w14dwzkirwk6hacsmy4",
-    "tree": "cbaf65481330ddfd93acd08775d131d239e59585",
     "url": "https://android.googlesource.com/platform/external/dexmaker"
   },
   "external/dlmalloc": {
+    "dateTime": 1588119024,
     "groups": [
       "pdk"
     ],
-    "rev": "536ed2b9c040ea56a1e7fee66b7ea3426713c1c2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "356ada6caace365363104ea2091d499a2ba09384",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yz7c4y6jppq2gxgc7bnrhis4na6r96w3i9y7rqb32hyh971ym8h",
-    "tree": "b06ac27129c0b61709496137ff6ca8b044928639",
     "url": "https://android.googlesource.com/platform/external/dlmalloc"
   },
   "external/dng_sdk": {
+    "dateTime": 1613827035,
     "groups": [
       "pdk"
     ],
-    "rev": "68fb36ddfccb90e5e94b76fa3f8ca3bc598e2a0e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6828f5d4c78612e7e5a35a6f71b02719ab76dad6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n0kz9ffs327mwd06qj7msmfwrhyiabcvapxsr172az0skr9980p",
-    "tree": "d5dd35e02c3b6767a037533b50136a6034907d1b",
     "url": "https://android.googlesource.com/platform/external/dng_sdk"
   },
   "external/dnsmasq": {
+    "dateTime": 1614816736,
     "groups": [
       "pdk"
     ],
-    "rev": "369437ebd07a40bdefaa3eb0312972d56e5ba846",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "521c8828d514ea021488a1b000929f150eb289ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06lwhhpprrsv7bz2jysf1wjx50zmck3q7wpmnci28lc2r2b39xv1",
-    "tree": "56b00657a3c50d727f830c860a08d620071e1def",
     "url": "https://android.googlesource.com/platform/external/dnsmasq"
   },
   "external/doclava": {
-    "dateTime": 1620867787,
+    "dateTime": 1620851375,
     "groups": [
       "pdk"
     ],
-    "rev": "91591e3a83fdcb008f93c358a6864ff76337cabc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "371d855dce9a186f0dac9f0b5de843b1f1e2753f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1aa1aycv47aavy6j29wkivspdg6fxhrpzkb9fd7mpv7im2z134zi",
-    "tree": "766ef423e8f021e0722776b1d031d9dd4529653f",
     "url": "https://android.googlesource.com/platform/external/doclava"
   },
   "external/dokka": {
-    "dateTime": 1620954167,
+    "dateTime": 1620860982,
     "groups": [
       "pdk"
     ],
-    "rev": "d3bd3eb8f63f1261b36298970fb4a7b2ce9172da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "831d13d425c2be30707a7c096c86e68bafa0b04e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n9lbm134yr4gd9lddlc6kykh0f18q4s3jvp3y09xy6r8hbilxx8",
-    "tree": "7ed184660673e7bac61ae4cd824405bfe2ddb8f7",
     "url": "https://android.googlesource.com/platform/external/dokka"
   },
   "external/downloader": {
+    "dateTime": 1614580415,
     "groups": [
       "pdk"
     ],
-    "rev": "323e8104de83c6b1b0052cab70cdb42ff36dc578",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8fe2640d45369f31826d69e03147fc3cfab5a8b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1prbsya7mwnk2f6z7zmg4a62873kk5yfhjrki7dwb8rzwzq9mm5n",
-    "tree": "f06be8475e67098d027aec111cb0ce273100ef72",
     "url": "https://android.googlesource.com/platform/external/downloader"
   },
   "external/drm_hwcomposer": {
+    "dateTime": 1613821637,
     "groups": [
       "drm_hwcomposer",
       "pdk-fs"
     ],
-    "rev": "c8c94b0dfa0d12e17eac5a26760491e1e4fb9d1f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "45ca9c0553ac9eb56aa6771a862054ee1d7672fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ign732qcsnima7bv7pr63v7c58pr17pw6yrb4y9wip26jq5g54c",
-    "tree": "2831c37bc978d98ce5e2beaaa59c8a47c4ea462a",
     "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
   },
   "external/drrickorang": {
+    "dateTime": 1613828272,
     "groups": [
       "pdk"
     ],
-    "rev": "66db0c68c3928bc995bc08b839cc551ddd9414f3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "75a8c0eb82730c6528673858fe6e38943426d370",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c705icrhgcdkxlbz125yn61hglzbnyvmwj6prafs74l3jb9h2sf",
-    "tree": "1a6143a24b5b0b2bda6c94a83ba3fb08a05c5159",
     "url": "https://android.googlesource.com/platform/external/drrickorang"
   },
   "external/dtc": {
+    "dateTime": 1613830686,
     "groups": [
       "pdk"
     ],
-    "rev": "15c34eae9f9c6adb171b807e3ef1acd281bd278e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cea2527ab2da06b2418b2fddf5c6cd6e3f77e57a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x6qsq1d8ay15is649cy900b6n4syl37m8705fk1x5972gm3s833",
-    "tree": "ab333ed4d847901a1ff2586828588bef3b97a073",
     "url": "https://android.googlesource.com/platform/external/dtc"
   },
   "external/dynamic_depth": {
+    "dateTime": 1617150017,
     "groups": [
       "pdk"
     ],
-    "rev": "d29e4b3383cc217eba0513053d74d05d88392f00",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3f3de03274a8b1461231e338053efb0751584412",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11mw0dwirrrirgrap33k8dvngpilf6qdzwsz0phzbpr05900915j",
-    "tree": "26c5bba83fe27b77cee1369541a2ee78b1c2a9b6",
     "url": "https://android.googlesource.com/platform/external/dynamic_depth"
   },
   "external/e2fsprogs": {
+    "dateTime": 1613827290,
     "groups": [
       "pdk"
     ],
-    "rev": "aee620d6558e468dd8711f00e5313c4eee9cdabd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "81fedccac6f9d36c4ffe12bf9a9be1b31d6e8985",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00y5a8kkqiqwg8q3mgns7vph072s3jiv7ih6b43qbgha622d9xq5",
-    "tree": "e6840663b1693bf32ca1b2951480a8bdd00c1a8f",
     "url": "https://android.googlesource.com/platform/external/e2fsprogs"
   },
   "external/easymock": {
+    "dateTime": 1613934271,
     "groups": [
       "pdk"
     ],
-    "rev": "1f1ecb1650c0eb3c84040cd1480dbd5fdd56ac62",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e3a5e1a07efbc1ee9839f057f34d495008594886",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13x8mwwilrqva7wknhcab80lhmh0j55mgdiha3w5v1crlk7nbgrz",
-    "tree": "493ede54cc3ee337e2021d85ada606212bb8987d",
     "url": "https://android.googlesource.com/platform/external/easymock"
   },
   "external/eigen": {
-    "dateTime": 1617238932,
+    "dateTime": 1617150017,
     "groups": [
       "pdk"
     ],
-    "rev": "a0fd519e44d0be9ff9f4ea9763c2d2a768e83cde",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ef69b4c5533b91c0ebd2cdb70cee010268b17e94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mja982a49hx7mzplq5vb3igzkyv659032hfha4qhg83qc5svpm3",
-    "tree": "b759c77cbd80c075943070072ecca105696b2a18",
     "url": "https://android.googlesource.com/platform/external/eigen"
   },
   "external/elfutils": {
+    "dateTime": 1613829389,
     "groups": [
       "pdk"
     ],
-    "rev": "74389f5eef8badc9ad55c590b12009b4d3b57427",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e96a913e880a4f68486955d42c605eb7df1cad4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1znxr9qbz5mgdl35g263c0n2k33siq2qhgdx0kilf566l9c7cjpp",
-    "tree": "15db324236530f56b2ab76f876a5aeeb6959f8c3",
     "url": "https://android.googlesource.com/platform/external/elfutils"
   },
   "external/emma": {
+    "dateTime": 1613587990,
     "groups": [
       "pdk"
     ],
-    "rev": "cc0d27a34c00d840a941fb8a7a28500b2106f8c0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "539d53815aaac84ea62e1e972c435e3eb15df2bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q783p5xwhrw2hgq2lihxdz80n7gyw6pri9l8ryrzgdklxqgpdhy",
-    "tree": "2fe4ee2ac95c6e7dd3afd9d4f88e4ca9ace9a3b7",
     "url": "https://android.googlesource.com/platform/external/emma"
   },
   "external/erofs-utils": {
-    "dateTime": 1620867793,
+    "dateTime": 1620783044,
     "groups": [
       "pdk"
     ],
-    "rev": "07fc4ecd32a87236041d26c5a69f49702884b559",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c75a114a71962092481eb666b8b37c53e381b6ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jj89j02d66jzcf53yjvrv7rgbwcmfpbi8839ygab0m5zxjdlshv",
-    "tree": "78c0c9f84843ab122bd616e7256ae45d500e73f0",
     "url": "https://android.googlesource.com/platform/external/erofs-utils"
   },
   "external/error_prone": {
+    "dateTime": 1613814729,
     "groups": [
       "pdk"
     ],
-    "rev": "dcafc9bc8097ec0180bb90bb19597c3d29ceb9f1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4d47030c31db0e191ddb2a3631585c53419345bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x5ikif1igni9sh9fcl9ma0k670a8gykvjv8bxl745mhzfnyfwqb",
-    "tree": "6629c9c61262cbd94d561431b05d7b8249a999d2",
     "url": "https://android.googlesource.com/platform/external/error_prone"
   },
   "external/escapevelocity": {
+    "dateTime": 1613934267,
     "groups": [
       "pdk"
     ],
-    "rev": "1db0422d4f165bc74e9901f60216ed59164118ca",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c358dffd344d18d35b158724d7996dcb1fc4a71",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12g3s6l40sncayrl9hvwkixb0diq5gkdf0i3j3llz8yi5i9bh1pp",
-    "tree": "2a4b2331b87128956cfcabcc8ac79ac93841e8b5",
     "url": "https://android.googlesource.com/platform/external/escapevelocity"
   },
   "external/ethtool": {
+    "dateTime": 1613591034,
     "groups": [
       "pdk"
     ],
-    "rev": "dfcb79ad6c34e40ce8e2d7753f69454ce344bce3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8fb2798308b192709a435c8eb47e15ff547c18db",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17i4hhqfprqilra51s34l07rin3k32pzw36sb5xazmgr3g926giy",
-    "tree": "cf86c7bc8c726875ce65ce7588ae43a22b32042d",
     "url": "https://android.googlesource.com/platform/external/ethtool"
   },
   "external/exoplayer": {
-    "dateTime": 1631149353,
+    "dateTime": 1631098752,
     "groups": [
       "pdk"
     ],
-    "rev": "eb8929cb69dc82c487cd53f96af6b90526d13b54",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c1f27d9a2af6a294496ea362349fc54cf9a08c33",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r3zdplwd1h8x1phqmkws4ismz92vnmvvw11s3jyjpay80maqgh4",
-    "tree": "2727117346130da038ea1de49daff68dce9482d0",
     "url": "https://android.googlesource.com/platform/external/exoplayer"
   },
   "external/expat": {
+    "dateTime": 1617411497,
     "groups": [
       "pdk"
     ],
-    "rev": "92a13c28089f03ecce068ca378fc0b28bbfbeb12",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "39ee0001990c524a17ba88806b97776961ac9533",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p1ckravpadk36lb04ahd40f2ivc921wrd21swq7n69c16g4a920",
-    "tree": "f4fe842cbe105849052ce8e3e3e64fb5bf4c3349",
     "url": "https://android.googlesource.com/platform/external/expat"
   },
   "external/f2fs-tools": {
-    "dateTime": 1632963789,
+    "dateTime": 1633072415,
     "groups": [
       "pdk"
     ],
-    "rev": "18cb0c713090ff505e403ed5df8c5e9e0b8378ef",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7364459d074a03fdaa1ef18c16c1fd8b5f018445",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "062r7sgrg626wgg8wvzjimm5gd8pixd3ssm921zmw7ahfzfi9720",
-    "tree": "a9f42f5fec12b5124ed530b3e83bb5e1ff33fa24",
     "url": "https://android.googlesource.com/platform/external/f2fs-tools"
   },
   "external/fastrpc": {
+    "dateTime": 1587748082,
     "groups": [
       "pdk"
     ],
-    "rev": "45807ead8226d447d576d4385f4187d1e5a08931",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6c96a7d480be9f2a929983626e0730bf7fe6390b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mfid59pw4qkv4zdj86g8mm0gsrdqkpc8kcwx6xbq8l42k9br4jl",
-    "tree": "d716961e82370ff4435e14dfc9c582bc3f8081dc",
     "url": "https://android.googlesource.com/platform/external/fastrpc"
   },
   "external/fdlibm": {
+    "dateTime": 1614863569,
     "groups": [
       "pdk"
     ],
-    "rev": "11906af98e9cd30b0dcef3b4fdd302288ed095cc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "31e7f68435db0bce2169f1b09836650354f20534",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cxx79d3l3w7p3b1pzlmnargzw8svaqx3jpl69a816ipq274y5kg",
-    "tree": "baa180efc9ea514f4a3f0c36f706b99e559aeb1d",
     "url": "https://android.googlesource.com/platform/external/fdlibm"
   },
   "external/fec": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "78245ad588b1f2b720c6a32089c42ff5dca785bf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1a9320d1e3baf3af0df01c3aa1792ea24fa8a734",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j0s8xhs6hgzjlybzks1brkjq7xlwlr17xkvay6lkjqb57cdsqxv",
-    "tree": "9c1309dc93abbbf017bd3fd4a775274e07d95872",
     "url": "https://android.googlesource.com/platform/external/fec"
   },
   "external/fft2d": {
-    "dateTime": 1616972543,
+    "dateTime": 1616810301,
     "groups": [
       "pdk"
     ],
-    "rev": "b7a3ce57c34e94394e2c033e8e8c64f36f597e83",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6035f75ae29ef41fcf456b2abac3d9348c08bddd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "061p07mzli7srnhzvnz726j849446yyprlgxc300f5zwjla3cz3j",
-    "tree": "86324182290debfc244531e6823882ea6d52dedc",
     "url": "https://android.googlesource.com/platform/external/fft2d"
   },
   "external/firebase-messaging": {
-    "dateTime": 1624928620,
+    "dateTime": 1624818159,
     "groups": [
       "pdk"
     ],
-    "rev": "f14cd5f42d922df203018df29df30f4ebc4583c6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a3466a7ce1751da8e029061e06a8bf88c031e0a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18c68j3cfc906x8glmlmcsxrbxfqy67dlim116grjmihv491zlsi",
-    "tree": "dc289b1bfbebddd2ec5969e9e8a899f3e23b1c2e",
     "url": "https://android.googlesource.com/platform/external/firebase-messaging"
   },
   "external/flac": {
-    "dateTime": 1616814157,
+    "dateTime": 1616794197,
     "groups": [
       "pdk"
     ],
-    "rev": "1595d5157b0b5d3c2e784f4e12642be6decba1a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "263f641d48c93b402556f73a5c194df28cfd4b42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bxl0m0kxfzwjk10nbm8i2fnsvn92d7793yv8bpwzqj4k7kcrg5m",
-    "tree": "627b9913a78224dd0170e89a301a2cf3a582db44",
     "url": "https://android.googlesource.com/platform/external/flac"
   },
   "external/flatbuffers": {
+    "dateTime": 1613821420,
     "groups": [
       "pdk"
     ],
-    "rev": "caf8debbb239ab3e805a5658728312b98ed7e6f3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d1972551ef9662e03f1d112f0833147a89edb56a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0aqwlh168j42532l0klgx6gsbqw7lhj92l25b8b1380j2qgz23hs",
-    "tree": "5a7f4b1493dee8569a2464fa4b40670fb61ec610",
     "url": "https://android.googlesource.com/platform/external/flatbuffers"
   },
   "external/fmtlib": {
+    "dateTime": 1613835257,
     "groups": [
       "pdk"
     ],
-    "rev": "2039571c9e219ebb480e2c3ac5d296b7e7809b05",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b040d6a6f0a78391eb919dd487a8c069ad66f38a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16x73827rr1sfvxpd4gg4rpx30vqfdp2r2md9ynmbl6lf2qwgqfg",
-    "tree": "97efd94993e7d4231147354ce6702478f1ceb2f9",
     "url": "https://android.googlesource.com/platform/external/fmtlib"
   },
   "external/fonttools": {
+    "dateTime": 1617393047,
     "groups": [
       "pdk"
     ],
-    "rev": "a2754b8c23808467294013e4265be8ff9d7e7a58",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dc599ad45a5240a5158f982698c4f33947ae88e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "082gbxzxji2hssl0h25yxvs0caf8cyaisjd6k09s2wcgvnvvc7n7",
-    "tree": "8e925d800e27f7a70c2b6a131b14526bc0f095b5",
     "url": "https://android.googlesource.com/platform/external/fonttools"
   },
   "external/freetype": {
-    "dateTime": 1619233379,
+    "dateTime": 1619138504,
     "groups": [
       "pdk"
     ],
-    "rev": "b8c61dec3872fe7c7ca174679d1698ed73258874",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9b477d8417b8cc7a389dfd34c489555578b117b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1higwvkpvh6wz0ryjbq31v00fqxq14q9xrr3p7ww32q2nvkych80",
-    "tree": "4932869f24580e9f7305224676711b487f60063a",
     "url": "https://android.googlesource.com/platform/external/freetype"
   },
   "external/fsck_msdos": {
+    "dateTime": 1620240055,
     "groups": [
       "pdk"
     ],
-    "rev": "c37e457b96737a86a67b4615c2bcdc348359e444",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b445b74ff829c292ddd1f53659533de5bd65180",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08js9q4kzic0i6sj67cdppga0q818277a3wivp7dpaxvz4anc40s",
-    "tree": "e2efaa696497cedc92627849723ef1c48b764f6c",
     "url": "https://android.googlesource.com/platform/external/fsck_msdos"
   },
   "external/fsverity-utils": {
+    "dateTime": 1613830694,
     "groups": [
       "pdk"
     ],
-    "rev": "5a99c312638cfe3ddb8caf278882817aafda74de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a3cea3520bbbd4a385010aa8b1440e17edc4899e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v541yjbvlkkddynwnwakrhj77jmawm1niz1nwbr2ish612v07p5",
-    "tree": "4cdaa88e6505f5a9cc97967952415b32a3383eff",
     "url": "https://android.googlesource.com/platform/external/fsverity-utils"
   },
   "external/gemmlowp": {
+    "dateTime": 1615574435,
     "groups": [
       "pdk"
     ],
-    "rev": "8181071f2ed990e78112d694130f402c95390ef7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "88233667706fa0cd97bf55417d2761148ab67bc4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dff6jrd314xnib7jhqwpfc4hyv6ycjgrmb92wwany30drmlnw9l",
-    "tree": "a29716289a0b730ca66a3e632c6ce054eb3b90d6",
     "url": "https://android.googlesource.com/platform/external/gemmlowp"
   },
   "external/geojson-jackson": {
-    "dateTime": 1614736934,
+    "dateTime": 1614664387,
     "groups": [
       "pdk"
     ],
-    "rev": "a5126d2378268cbb08cb54dc85bd44df1a982fba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cd075e217fd9d81d6b5bf04f256ae27324681147",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qrp98sn4q997q5szpz37414hlm3yl6183r504sv14azfwm7ymyf",
-    "tree": "5520f8b348fa75934708b0b968252192d513274b",
     "url": "https://android.googlesource.com/platform/external/geojson-jackson"
   },
   "external/geonames": {
-    "dateTime": 1605485636,
+    "dateTime": 1605020923,
     "groups": [
       "pdk"
     ],
-    "rev": "23eeee58e90f6bdab43e8a58ede27e3f6c2e9252",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2c1c69b46966d4e7280098b728fafc2c11cd5ce5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xcdyb82cs40am7x477cavyczh1ijm5zx785fw2in1wkqah4zp0a",
-    "tree": "8c222e34d9650416cfdb5fb234eb249229a815df",
     "url": "https://android.googlesource.com/platform/external/geonames"
   },
   "external/gflags": {
+    "dateTime": 1613826979,
     "groups": [
       "pdk"
     ],
-    "rev": "4d287a8acf38005369f3a9605611a7c1b2b71c3f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "37fc0b964213bd74de9631e388eccf8a93efd001",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wyiic485x863sdm6834dsl3b4c40fqpagz529v091kribmmm8gz",
-    "tree": "fba0d240dce8c4d4f7784ef24576c099c0f9430f",
     "url": "https://android.googlesource.com/platform/external/gflags"
   },
   "external/giflib": {
+    "dateTime": 1613591035,
     "groups": [
       "pdk",
       "qcom_msm8x26"
     ],
-    "rev": "7894e930a92445be39009608119f65e61f0d9ee6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "79b629f4e5af0bc6a8b2489fcbda5817fef12ab5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sibmcf4ld5cda63fyklr7bd0naydy5c39rszg0fp7iiivx3n8il",
-    "tree": "702fc4e46960850f6ffb6aa874e6d392ca0126bc",
     "url": "https://android.googlesource.com/platform/external/giflib"
   },
   "external/glide": {
+    "dateTime": 1613513320,
     "groups": [
       "pdk"
     ],
-    "rev": "5eb496450326a70c7582334fb66a9ef7f2eeac86",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3376a4544043387a12edea5493a95c9cd1df1bdc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b38i7kvsivigic627hxi04k9sf5iq6ry176drcx9mr6wkbysbvf",
-    "tree": "b000cc72405527ad2e83c4b833b5aa9c8f8cf469",
     "url": "https://android.googlesource.com/platform/external/glide"
   },
   "external/golang-protobuf": {
+    "dateTime": 1613934264,
     "groups": [
       "pdk"
     ],
-    "rev": "5ae8aa43ed04fd75ae814aac3bd9011b2a0b8381",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3edaf3f0be56531237768597ec0094be54578d58",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1za35lgd4h3vfqhv0a9kjbi0arrq9k0phpks113mddzlfg7dxnbw",
-    "tree": "3dd0e0611fe54225bcdac76ce2cb32645a4988e0",
     "url": "https://android.googlesource.com/platform/external/golang-protobuf"
   },
   "external/google-benchmark": {
+    "dateTime": 1613835308,
     "groups": [
       "pdk"
     ],
-    "rev": "e32131e3e58f8091891a17f5bd9af5ced9a5eb8d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "650be92e17c5b4452d2ac69e055e8b0d1ccf958d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jnb9fbib4gp3w9smw5s1nvz2snbz414yxxa1xb58p5wjp7fqx4w",
-    "tree": "61f88d9a095a390cab484c109bd55ce293b117b0",
     "url": "https://android.googlesource.com/platform/external/google-benchmark"
   },
   "external/google-breakpad": {
+    "dateTime": 1614735647,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "31ec51dd340e4850caeae60095191622ba8c0cc9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b73b205ac612c4e9fc199b500433d4272f9f3ca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13l54qb6a8ba4g80h59mk1xxbdiqa0219h4p78rxzx1j75cx7m6h",
-    "tree": "007c6a23022007f52326b10a4843846b59800a00",
     "url": "https://android.googlesource.com/platform/external/google-breakpad"
   },
   "external/google-fonts/arbutus-slab": {
+    "dateTime": 1613835371,
     "groups": [
       "pdk"
     ],
-    "rev": "e99a713f8c43a3477d68f61330fb8857b7a20788",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "277a36a98802de545c5df5c8e69201fa2749b409",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18g7n073qp1ii4gx11n6fpsv8si0ima4ldrx7mraca9mdq72w71m",
-    "tree": "66a42a60c47eb2270a81e2a6a4dc0005a3dabfb5",
     "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
   },
   "external/google-fonts/arvo": {
+    "dateTime": 1613815675,
     "groups": [
       "pdk"
     ],
-    "rev": "046fe70bf3a12b4ed790416d51c6656b9c4e3cf6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1333e8e929799b5a29129603373d16c43a0952f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "144j3kjdp9gm5qi9x0j571m88vnqs1lwm8672qh9l3m7lxxsy0jl",
-    "tree": "235b066a6f3f72c4a456e019484d2fa0cee0318e",
     "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
   },
   "external/google-fonts/barlow": {
+    "dateTime": 1613835220,
     "groups": [
       "pdk"
     ],
-    "rev": "34134d787697f6a41bd1fb0b4545ee70b767d0dc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "26652d070d70791cc1dc8497fb7997a795d8188d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "029n04xijjbwwxmz8lbihwcl9a30bgy9czdzg82ybwylnwq9pfwm",
-    "tree": "7c0b55f740eb26565827ded9156b95cc39e67764",
     "url": "https://android.googlesource.com/platform/external/google-fonts/barlow"
   },
   "external/google-fonts/big-shoulders-text": {
+    "dateTime": 1613823849,
     "groups": [
       "pdk"
     ],
-    "rev": "099eed9994b95a3fc29f333f0f8d8166483a94de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "92e722b258c2ed68162a76c7e8c15cef18f02dcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jpm0ld79d3g66iwiwmx4dn2gxdlrgwsblynf4zwcgcq7ydi4zb0",
-    "tree": "80a7ae4338e98bd113700f0d5fa8fbb49dfb6725",
     "url": "https://android.googlesource.com/platform/external/google-fonts/big-shoulders-text"
   },
   "external/google-fonts/carrois-gothic-sc": {
+    "dateTime": 1613582534,
     "groups": [
       "pdk"
     ],
-    "rev": "d7fe9d0de14e42529cbdb4ee1a232bc7245328af",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "84d771641983def0c77f6327990e01110d0baeff",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "067xqhgd67ngvkr7frxdy1y774pfpzzkih3jjk7fj24wqnkc6d5j",
-    "tree": "befd570ce6877e893fc2ca9337bd167c46dbb796",
     "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
   },
   "external/google-fonts/coming-soon": {
+    "dateTime": 1613582547,
     "groups": [
       "pdk"
     ],
-    "rev": "3dad2c199ae6f5a86f982d82dc16f33459cad689",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a7486e33533a779086901dc5c43bb8ce079d2008",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wz6aji68kbhg58dbwn0zmjg2ywk6cfdq7j7awg38zl2q26nfmq9",
-    "tree": "2dc0ec0d9c5918a97c619ac2d66d47337cc7a415",
     "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
   },
   "external/google-fonts/cutive-mono": {
+    "dateTime": 1617172207,
     "groups": [
       "pdk"
     ],
-    "rev": "be71f9b9725f4e418408901b79edb585d4719b0b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "08f8aab020ae1f487e7d8f868cd61351dc1b4517",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00wfjacl0sqncivpa3za9jmki9wva9q0vf85ads6g2rz4z6nkrff",
-    "tree": "9ba803163b0618253e4f339901be5b0fe73858b8",
     "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
   },
   "external/google-fonts/dancing-script": {
-    "dateTime": 1617238954,
+    "dateTime": 1617172224,
     "groups": [
       "pdk"
     ],
-    "rev": "6bbdd6a988f967875121953126bde34232351f80",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e5a7a0d0ef1dfa462c626e2a9b8f0dec5e3d6008",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hdp4a0gn23n88gzdi65dfqq3pmvw3nadf1p8xnqxan34yv8adyl",
-    "tree": "73201346f8efe651ef89bf9358e7b75d3df4d893",
     "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
   },
   "external/google-fonts/fraunces": {
+    "dateTime": 1613827250,
     "groups": [
       "pdk"
     ],
-    "rev": "a375dea63a65af3b77d3882747a655b3fb1c6115",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b0130e6a2e466a58ed131adec305f9005f4a3b77",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gr0x87wrs8qh2ykpggcvxkxc1qmd6hw0xq6hn6p6s8078pw5b6w",
-    "tree": "df5a6323eafdd606ba7a644946245afda291dd72",
     "url": "https://android.googlesource.com/platform/external/google-fonts/fraunces"
   },
   "external/google-fonts/karla": {
+    "dateTime": 1613828236,
     "groups": [
       "pdk"
     ],
-    "rev": "087b76a6773b15e34e590748ff03af3fb03e9b72",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "645f577ca22e7fe3e7aaaca2c1ca0a6b106289c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0c8ny537pvhjfh0b87lfpc0aga4x0mlry203wkacgx2a1h00irhx",
-    "tree": "bfd5397ee80c3baedbf1920f68b6ab4af6dfca8f",
     "url": "https://android.googlesource.com/platform/external/google-fonts/karla"
   },
   "external/google-fonts/lato": {
+    "dateTime": 1613829266,
     "groups": [
       "pdk"
     ],
-    "rev": "ff09687a82a6066c4275dcf11ab39e192ba055ff",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bb31693eacca2b20329394cda918ae82a2e9d1bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hdy27r466jd7ik69257hiazjqsdzv0hbpzkmid6rq1gk2lkijgz",
-    "tree": "18f772424d0e832e1794832fbce11f93d35b97dd",
     "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
   },
   "external/google-fonts/lustria": {
+    "dateTime": 1613832697,
     "groups": [
       "pdk"
     ],
-    "rev": "58fe88fedf239b763fe0771417c24d76f3561b2b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "daf93358a95e6a4cfac7c1c9ef584a7c838a8f37",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16i0vknh3z23mr79iilxyf6kqs5kqp198by9cx9rmzcg3phgx03y",
-    "tree": "fe80ddfe0177c76e740489b73402869f3acbfd30",
     "url": "https://android.googlesource.com/platform/external/google-fonts/lustria"
   },
   "external/google-fonts/rubik": {
+    "dateTime": 1613828291,
     "groups": [
       "pdk"
     ],
-    "rev": "d2ead262b4888e722f403fb1de3d8e54571b42e5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d91d54c817ba29486ab8233129a97cb78d2ef8b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10ap1n0s7qs742m3xzxrs91xyirp0280xvg4wz8hmpyip631h7f3",
-    "tree": "400d4b821e06718189263647364bbd219129e195",
     "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
   },
   "external/google-fonts/source-sans-pro": {
+    "dateTime": 1613827281,
     "groups": [
       "pdk"
     ],
-    "rev": "6309f71746261b0b9dd8030b638a7f0ec1bb8d62",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ebc08757b20a96a0c8a4dc5c263badf6a51b7dbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nmdmb80pf2pzcdn369q5skspmlqv56sn9in0fcfhx14pib64w86",
-    "tree": "92f271befd7607e8dfae6aced21c85af92e22808",
     "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
   },
   "external/google-fonts/zilla-slab": {
+    "dateTime": 1613821412,
     "groups": [
       "pdk"
     ],
-    "rev": "111a8d5a3fce557ced3121aecd519844fdf0c23f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "299be8918c89283e82432e827934b62e6670afc6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rm6wp6849wpw32ys5wbrx9836937j1zx310fdyyl07kqgx4vhmh",
-    "tree": "4d40e327be587d5257a0a46fd56fc15bec8e7351",
     "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
   },
   "external/google-fruit": {
+    "dateTime": 1619753669,
     "groups": [
       "pdk"
     ],
-    "rev": "9c26c66c4670ce814b5aa054085a65ee178770a7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "25531cf8554e5f421e6b12847acf69a9cba83f52",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wksa168xyk42yijf2idhpvzp8225ww165px3lc9ff9ph883g0ya",
-    "tree": "61d841dc12f982b1afaf7956176f05df58a9d98c",
     "url": "https://android.googlesource.com/platform/external/google-fruit"
   },
   "external/google-java-format": {
+    "dateTime": 1613829565,
     "groups": [
       "pdk"
     ],
-    "rev": "2dbcbbf004e0890221f3f9b5062876b80cc575a3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "554efbe39799b9060d80ad57a151172e0c756755",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g1i78c3km8lly0rb3b6axma754vxl9s9s48jfa0n2l565h2zk0q",
-    "tree": "6702e722773c4faecc6c4d7d35481429ecd1f797",
     "url": "https://android.googlesource.com/platform/external/google-java-format"
   },
   "external/google-styleguide": {
+    "dateTime": 1588028419,
     "groups": [
       "pdk"
     ],
-    "rev": "00d6616937b3fcebe49d4e537d3205161f390cf2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a4848c862d716a8449e1473b0933b7fd6dd5a11e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1krqv8srgkf85hrj0shwz9j4xs6nx4jbj8fzjsbwjg1f589dd8iy",
-    "tree": "7302b3aba66f80328131cca667660087c56825c8",
     "url": "https://android.googlesource.com/platform/external/google-styleguide"
   },
   "external/googletest": {
-    "dateTime": 1625706434,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "90fd13423e8fdcef4e6ceeba84978298c7db7321",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fe4582ab5d3af5afe831a7f5b5554d4ce759f524",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hs29iy2v24vl66qqa85sdzvxlw7awjravhy53gjv9vnq2dzpb84",
-    "tree": "54fb90f190c69a329c719650bad4fe22bf879033",
     "url": "https://android.googlesource.com/platform/external/googletest"
   },
   "external/gptfdisk": {
+    "dateTime": 1613830711,
     "groups": [
       "pdk"
     ],
-    "rev": "653bf0a0f89c74b41e50c2043fc9bf040926221a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4ec172c9be943b4b7f0416ac26f6524fe356e32a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "062g4a8s71lwdh2rkqjcdklbxsb551334rd07hhipygjllwhixzy",
-    "tree": "2782d4c888b85855ffe36724ad02bff0e57d9dbc",
     "url": "https://android.googlesource.com/platform/external/gptfdisk"
   },
   "external/grpc-grpc": {
+    "dateTime": 1616636261,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "337a7280b0195159f79d5eb285c9d93776b0f649",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "25d9af0bedde9ca88a9abf9a5eb6d3b763f729fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b8mdx9x08djdm8fss25r1dc2xbq1hb70zdm782k2rmbwp47axa8",
-    "tree": "474847570e86fd2fc7855c79bd91ad424f0d34dd",
     "url": "https://android.googlesource.com/platform/external/grpc-grpc"
   },
   "external/grpc-grpc-java": {
+    "dateTime": 1613834327,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "b34fc1cb6d712bfb4f5f5fa669ad43599b22ab1f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dee79d6efe93cc1fa5e2ec9afb2aafc8a4b16e08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hwm7wb4zg81cx784piqc316ik0dihbm19iiyn3y22ahhkd3ma4r",
-    "tree": "342002c39fac0adbfbca05420258c5bcdfa74fd4",
     "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
   },
   "external/guava": {
+    "dateTime": 1613834474,
     "groups": [
       "pdk"
     ],
-    "rev": "38af64c9f6e2a20425e6164d5a02787861e264e2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5efe41cd9e7240f0fc145af03a17864d0e4e9bbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hdvqppxkyafrpkv9qzs5c7kab57vi4xhqacbqbwfr7dj0plca56",
-    "tree": "b4a5bf8c37c0f38b7f93fe3b0d2cca936562be08",
     "url": "https://android.googlesource.com/platform/external/guava"
   },
   "external/guice": {
+    "dateTime": 1613822773,
     "groups": [
       "pdk"
     ],
-    "rev": "cd6d612c50ed41bbf6b463132665341910c82c8c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0c3fd35cfacf8303267595e96703e132cb6b78db",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0f9k7ribhyf0n7p9ff2jqk18qk1gim4vbln1bhiazdlfs3v5laws",
-    "tree": "8615c70e58321176ed9a352581f81eef2e900df7",
     "url": "https://android.googlesource.com/platform/external/guice"
   },
   "external/gwp_asan": {
-    "dateTime": 1620867820,
+    "dateTime": 1620772439,
     "groups": [
       "pdk"
     ],
-    "rev": "26ef056d5229fe42cd99914931d6b3e7fb3c7e58",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a03264ddb1e1360460aa7d0c069907ad8669655a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k71w8a36dhr4l5r661rvnmj4bxz49is9md78hndks4jqcnzn036",
-    "tree": "5e1e85016be16b395eef3d2c25a902ee8fa01c58",
     "url": "https://android.googlesource.com/platform/external/gwp_asan"
   },
   "external/hamcrest": {
-    "dateTime": 1613952188,
+    "dateTime": 1613934542,
     "groups": [
       "pdk"
     ],
-    "rev": "5100564fd2f178d0b2af34e0ab09b359352c4ec0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cfc467f1d521561e8a5f8604c379b1d954856ca3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0i05qdmz9zd904apqxk6kdbffbydgj7k7n9yjvgrlw0m7xbynadj",
-    "tree": "cef87e8ae39ba698a34d80b7e8be04490d996505",
     "url": "https://android.googlesource.com/platform/external/hamcrest"
   },
   "external/harfbuzz_ng": {
-    "dateTime": 1613865830,
+    "dateTime": 1613823679,
     "groups": [
       "pdk",
       "qcom_msm8x26"
     ],
-    "rev": "a87ebd194c8f9f3dae40d985f6d5488026c19357",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7120de378dc06db22368b5941af8a4ae8d226865",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m7a4ln2v5dxy5dkcfdxyjsvsrsd3hjbxvmhb4gyx6am6lk6lca8",
-    "tree": "ebb18345758e2a9af6d1c821c2f57c9b544f2e81",
     "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
   },
   "external/hyphenation-patterns": {
+    "dateTime": 1588207981,
     "groups": [
       "pdk"
     ],
-    "rev": "c9814f5a60d3624f977614f828ae4189f7cf4ec5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c6ebdb94ca258f00dd0ccb2bf86f33ae16c7c400",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "184jm20gaz36kwskqkhax7n1allfjanax6rz3vqs70rjgsdvv5i4",
-    "tree": "7f8755699a58ec28fa8af6852f2b74b85521807f",
     "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
   },
   "external/icing": {
-    "dateTime": 1627002207,
+    "dateTime": 1626890988,
     "groups": [
       "pdk"
     ],
-    "rev": "91d27f5d94c8d353eb7a8f284867b3e9f68b047b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8ff0d99397be5d96f702275cbaed06185ce78e2b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "167siw8fxdjrw4dl6a4k25xilj3qv8y59ih2s9a7g5rb3sz6pfl4",
-    "tree": "c0a00b9b4d52ff3dfeb50f5d894bad2d71389b00",
     "url": "https://android.googlesource.com/platform/external/icing"
   },
   "external/icu": {
-    "dateTime": 1625281418,
+    "dateTime": 1628888013,
     "groups": [
       "pdk"
     ],
-    "rev": "70d4c14c797c396cbce5e8fe51f6fed499ba12b8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "aeddeb69080a16ff78aaac329dfa01d584522e1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17ncsqdp28q238a5hhpkw3z3yskf6yw34hf39cb4nfmdn858pa8s",
-    "tree": "fab690fdde9c1afa49bd1729545500b56d0abac4",
     "url": "https://android.googlesource.com/platform/external/icu"
   },
   "external/igt-gpu-tools": {
-    "dateTime": 1617843792,
+    "dateTime": 1617754617,
     "groups": [
       "pdk"
     ],
-    "rev": "724c40d263349391823f6be80147ac55cded6935",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "131006b81245402dda837764dc860345e42bb2e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c5cw7jgcfny776y5cqx7jcy8w4sqanx4b0qwrza6zqhgcc2cqhi",
-    "tree": "1532999add43e4b3c9d79b6fcaee864c06873603",
     "url": "https://android.googlesource.com/platform/external/igt-gpu-tools"
   },
   "external/image_io": {
+    "dateTime": 1613827333,
     "groups": [
       "pdk"
     ],
-    "rev": "3537fe6656d69124d67c06fba03b36b31dea1280",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c0ea26afcfa3abbe4684e1e0c080ca648d829bef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0257h57ygzpj2vknj5k8whkznrsmqd2fhzzb9gl3rys9qgljjmvx",
-    "tree": "0120666903281fc2589b5fc8e5cd22175ff79fe0",
     "url": "https://android.googlesource.com/platform/external/image_io"
   },
   "external/ims": {
-    "dateTime": 1620781408,
+    "dateTime": 1620756808,
     "groups": [
       "pdk"
     ],
-    "rev": "6712b141c05ed903f462f4bab374afce4d29b779",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "22925544cc6075997e845c6acd371c10f649a42b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1476c1dbyhsmvak2m5ffrgjxrf8ixigx5fsi5w805kfaifignmin",
-    "tree": "b24321ac17884be632351c22f458e3f75ece2aa2",
     "url": "https://android.googlesource.com/platform/external/ims"
   },
   "external/iperf3": {
+    "dateTime": 1613934636,
     "groups": [
       "pdk"
     ],
-    "rev": "97f116795112373c5c78d9b23fdddc30d9b2de87",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0c91e80b7630b6f12ce904ef986bf79f778d4acd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1malr0g6ha2s0qb6qrr4cly161vcj2d4xy5wbnxj43pnhg0k4gqb",
-    "tree": "02bbd66233f7731973ac468cf9c3cb6d45a5bf3a",
     "url": "https://android.googlesource.com/platform/external/iperf3"
   },
   "external/iproute2": {
+    "dateTime": 1622589724,
     "groups": [
       "pdk"
     ],
-    "rev": "1059968d84f758872c1ae9c2c6ecec98499f422c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "86cd9241daa4a2d16dc0f331c72db343e10e69c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1527d8lzl7px9b84fxm1742nvz6d4h0r8nwibjh0d18j62xhz1mg",
-    "tree": "898b0b36f5cf2cd98b160057f23d939750870492",
     "url": "https://android.googlesource.com/platform/external/iproute2"
   },
   "external/ipsec-tools": {
+    "dateTime": 1613582540,
     "groups": [
       "pdk"
     ],
-    "rev": "ab56cd0c2606953ab964aceae7fa1e0f08430698",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "def1488d68523e71f3f08863f9047b6bf1ba1b5e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qz2058mcb75x22jarlls8ki6zhh9zd422nsn9wdzq29xk4a9cg1",
-    "tree": "a8579cf35b3d55a1e5e276a205294c85401281c2",
     "url": "https://android.googlesource.com/platform/external/ipsec-tools"
   },
   "external/iptables": {
+    "dateTime": 1622589761,
     "groups": [
       "pdk"
     ],
-    "rev": "291f1b637c2c52f0445f4e73e046730f9865babb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0355d238630c5323b826806de53ccc037dd176cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0d2vfhzixszwl3nwch9f996yx7kafr9rn7fni41hbzrh8nra476y",
-    "tree": "d3b12fcc78b5ad0e8e25c7e3f068be047b461d91",
     "url": "https://android.googlesource.com/platform/external/iptables"
   },
   "external/iputils": {
+    "dateTime": 1613582547,
     "groups": [
       "pdk"
     ],
-    "rev": "6abb07685e791f2e3fe575154d23695f316958ea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "61b2d503bc54ac80fea0a0e221e063301f140300",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q24bn8swbjsaa19kc6jdk2fw93cbipi6xbdh95w07pdp3v1xazr",
-    "tree": "0df19d97ec45c1bbeca95069cf3b80e7b158fe4c",
     "url": "https://android.googlesource.com/platform/external/iputils"
   },
   "external/iw": {
+    "dateTime": 1613516541,
     "groups": [
       "pdk"
     ],
-    "rev": "8836dce27cb2f7a94f589c3fb219a875a1c60d91",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "866e8d025debeee64148cbc9422232c157b8bd4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01k08an490nvpzjyb7f6p8l67gxpkkg9fnc44f1lcc6ygb1rymsb",
-    "tree": "ab135c114c9c68b7ea8a1f0f674764b394c08868",
     "url": "https://android.googlesource.com/platform/external/iw"
   },
   "external/jackson-annotations": {
-    "dateTime": 1616972574,
+    "dateTime": 1616809880,
     "groups": [
       "pdk"
     ],
-    "rev": "5544c2a8839e0adb3d680e5c207d51d43a6949b8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c91023d9d0c4ffe9a094cda3a6fdbe4d3473cd98",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0apc5cffr02drfhfxri1fqs449i6bsk62a5kb0yfk73maya5wlw2",
-    "tree": "f26a188603eaad310423345d73ae09b0bd815dea",
     "url": "https://android.googlesource.com/platform/external/jackson-annotations"
   },
   "external/jackson-core": {
-    "dateTime": 1616972574,
+    "dateTime": 1616810394,
     "groups": [
       "pdk"
     ],
-    "rev": "e32d6f2cb5379c01f372d9dfb2b45eec5311ca9b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b02b4c1c8c75d3c5cbb01aa0a43f9e43933a3fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c1amlrk7idijwhbhr2xvs822kc8cvfcmz2vxw9y03ylbicwnq42",
-    "tree": "2ea976e35ebc7c2f0a054ecb11b07aa9680a7617",
     "url": "https://android.googlesource.com/platform/external/jackson-core"
   },
   "external/jackson-databind": {
-    "dateTime": 1616972574,
+    "dateTime": 1616808257,
     "groups": [
       "pdk"
     ],
-    "rev": "b50668bfce41a0043dc28478dc0dcf47da881477",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b6d0559682b885d2ef20f403187caccc5cf5ec8b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f4qf4dy0cyjv9cbmsvqawq0xp3r68snv5nidhj00jdnxcixh5zi",
-    "tree": "76a830de5dd85ed3bf66d5aca404d3da0cc41cbd",
     "url": "https://android.googlesource.com/platform/external/jackson-databind"
   },
   "external/jacoco": {
+    "dateTime": 1615234311,
     "groups": [
       "pdk"
     ],
-    "rev": "0469ec6041734ff9f54dbe4ec58088642d688f16",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "681e869d755e22fd459cacd1421e16ecf6032294",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v0gdd5rasmh1q8sbq2f3ckhrlra73h1n9m0j9p3j3zpgq5a4x9s",
-    "tree": "362a5a2b6e57fc8955d3af74ce2cafbbca7f65b3",
     "url": "https://android.googlesource.com/platform/external/jacoco"
   },
   "external/jarjar": {
+    "dateTime": 1613516542,
     "groups": [
       "pdk"
     ],
-    "rev": "1d90e1de42be1b3448704d233de3baee76df315e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e6b4d6f7f382845a3cb2fab88e6d502c757a4d49",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vn1j4pmksskgdjak31yc2vc1l8ph4m3mw06nsm0ql7fhbmy00yg",
-    "tree": "4d923f9cfd9b90cc05993ef7907f76d25705145c",
     "url": "https://android.googlesource.com/platform/external/jarjar"
   },
   "external/javaparser": {
-    "dateTime": 1613531717,
+    "dateTime": 1613516542,
     "groups": [
       "pdk"
     ],
-    "rev": "c5628b1d68f73f54a5ff1d42aaaa968102ca235a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "94908d664f9e8a7cc40093a52c9c1fd4f6acd649",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l5hikg3bhk5fasrbwgbiascl8jwimacmpj0if2yqmbzcr6bglzs",
-    "tree": "98df4b866e577b82546819f6e1e043fa1ab84ed4",
     "url": "https://android.googlesource.com/platform/external/javaparser"
   },
   "external/javapoet": {
+    "dateTime": 1613582537,
     "groups": [
       "pdk"
     ],
-    "rev": "a7ec85b64be05743117817142ba3b5d7ea69c825",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5d0fc1c588274585021a0ca52f529a7770d34332",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kwklwk1xjnnvwblfb5hga4ks1p3jdmh9dc30c5mifksrp8fsyr6",
-    "tree": "3468c8c75334dc5332cd858fa5cac271017a11de",
     "url": "https://android.googlesource.com/platform/external/javapoet"
   },
   "external/javasqlite": {
+    "dateTime": 1613516548,
     "groups": [
       "pdk"
     ],
-    "rev": "08892046ad2b99a32c8179f1f5be47c8c7f728cb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "924e1e55260f53dbc362855de52d4f8a54c55804",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1801cchvl1nys58y41qxk9if6wamrakpvpq6c2k3fj65053kizi6",
-    "tree": "eaae0ae162d4f4761151e2811e53a626ef688fa2",
     "url": "https://android.googlesource.com/platform/external/javasqlite"
   },
   "external/javassist": {
-    "dateTime": 1616972577,
+    "dateTime": 1616864907,
     "groups": [
       "pdk"
     ],
-    "rev": "2fd9699f7c361e22201c83039662ef0e26b813db",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "793778def89ddc855b52680e2ad212bde4f49ddb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zfcnqlgyl59pv4h0s0nnc8lhgljpq5dq4p05anay43lnrszn3ca",
-    "tree": "9d896c2e475840c036965d3978f05e6d234e2126",
     "url": "https://android.googlesource.com/platform/external/javassist"
   },
   "external/jcommander": {
+    "dateTime": 1613516536,
     "groups": [
       "pdk"
     ],
-    "rev": "2e781615446cbc9e42e0127e3f440b9ebce3f943",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a5ff59e43ad0114ed9e4733ea8b3fd41fe5c190a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m4a69hc9k4ixn8sah9rz9n10xgbz06swcfcsx96cjk0svpqyw4w",
-    "tree": "564b53ba25694563902da784be99076494ee45a2",
     "url": "https://android.googlesource.com/platform/external/jcommander"
   },
   "external/jdiff": {
+    "dateTime": 1613591036,
     "groups": [
       "pdk"
     ],
-    "rev": "e42a05cb19135fe2bd324d72b8765b71765072ed",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "582327b730af8cdc85da673fd2333c786ecc9927",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1j5bnl4lmm2288dvbma7mxyx0x52d3jn5d9wpd6idg44ii9ra1ap",
-    "tree": "6dcd7de8a3e46a412650b19b201630444e9d98d8",
     "url": "https://android.googlesource.com/platform/external/jdiff"
   },
   "external/jemalloc_new": {
+    "dateTime": 1613832679,
     "groups": [
       "pdk"
     ],
-    "rev": "8c01127670915236e20686996ca074430df58670",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "361a088dfcfbaa1960c03678b5caeaf397b77182",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xbgga8jnizv1588dh1bd2av005wfmc69xzh867269j0523djcdr",
-    "tree": "783edcf0f46f55fbb297cdba2b1f461f9bba50ab",
     "url": "https://android.googlesource.com/platform/external/jemalloc_new"
   },
   "external/jimfs": {
+    "dateTime": 1613516539,
     "groups": [
       "pdk"
     ],
-    "rev": "79396b18e0d26d8d10f08d64e9b957c7efa7b8de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b46a6ed198ffa3ad3b90a808867d3ffb7162bb2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lgiryx40d8a5854yczzvm5x6fydncj06vaclq4hw07rlwh7kvn0",
-    "tree": "a1ea3a8dec42758d3ed96f945e3634eeb7e618f3",
     "url": "https://android.googlesource.com/platform/external/jimfs"
   },
   "external/jline": {
+    "dateTime": 1620248643,
     "groups": [
       "pdk",
       "pdk-fs",
       "tradefed"
     ],
-    "rev": "b001d300fa08b7e2ce347d82b2c90362fea99f11",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9251052568548695534f92b1824b5ee1af53b699",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qxn0vwnbz0sh9ax9ad52wg7373f48dcpq624bgfiypjgxfniqls",
-    "tree": "df5bc9d2909b8ed4feff07f097b5c0a15d2bab5a",
     "url": "https://android.googlesource.com/platform/external/jline"
   },
   "external/jsilver": {
-    "dateTime": 1613531721,
+    "dateTime": 1613516541,
     "groups": [
       "pdk"
     ],
-    "rev": "78a22e8e2e84ab82e0ee51c52282f12aaeeec73c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f1606513d1b994792dee3fdc7b8a0b40266cbb29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "198msf9yaqbjy52aj4wfshdnxy5nyf1jwn7p2l4gndn1212vkqa1",
-    "tree": "b7d679a8e5bde0f898d7e4c6ca03dd9fb0daf00c",
     "url": "https://android.googlesource.com/platform/external/jsilver"
   },
   "external/jsmn": {
+    "dateTime": 1613504480,
     "groups": [
       "pdk"
     ],
-    "rev": "83e89bd707f84325ccabffd3ac903b4568f28b2b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "da0d696df523180c836ab37ba62999a65029c420",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0czn4n8j87svwm1kgsnjd8qzyriygcjlkwskqj2w79v1s113rlb8",
-    "tree": "3c5f0e8807ab38bcec650b113fe9104e86a5806c",
     "url": "https://android.googlesource.com/platform/external/jsmn"
   },
   "external/jsoncpp": {
+    "dateTime": 1615589399,
     "groups": [
       "pdk"
     ],
-    "rev": "5eaa0d4ae24a514bd4d981e8369be8244e60cd43",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "592ec82179026ea4835babfc2d9e4b14cfe32aa1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00985j9k2yspfp6vi5rhnb4pwbzig055l3p08mq8k1sqm3q47vqy",
-    "tree": "a39bc599e78f83beddd0e70400ba7806c2d1739a",
     "url": "https://android.googlesource.com/platform/external/jsoncpp"
   },
   "external/jsr305": {
+    "dateTime": 1613814611,
     "groups": [
       "pdk"
     ],
-    "rev": "93939a37997a71d5e4cc9874afc835a6c4022a3a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b1c31016be6bcef7265a9f77464a50717041a0c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q8sc6rb67j35r6jk55ap37b9bbrgdca0a8dyyy04ipx07ccw05y",
-    "tree": "2d7da9565b41924f2797d19b3f0aa2674abb94ee",
     "url": "https://android.googlesource.com/platform/external/jsr305"
   },
   "external/jsr330": {
+    "dateTime": 1613591030,
     "groups": [
       "pdk"
     ],
-    "rev": "7116bbf7b13a638cc93cb172294467b4f197ec59",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9007fc517bc854e4c04c4c333d19964e71ec9a8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1s0jbmdd3vjaprwalf10i06n8sfmg1x356y5gz0jfimbsknva989",
-    "tree": "b5430f917b72fe5d8a40463304d9db9ba3be9af2",
     "url": "https://android.googlesource.com/platform/external/jsr330"
   },
   "external/junit": {
-    "dateTime": 1615514570,
+    "dateTime": 1615460631,
     "groups": [
       "pdk"
     ],
-    "rev": "d8c1ddec20ac4d146c0beac4edb4d58d342ad3ed",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1002ff53a1a0165971ce5dde386634d45a158f2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n7rfvpi0pg1m6qjh6wza310gf01p2kv564bnkf3dfsjsczfs0nb",
-    "tree": "da8f1fbae2eb06d58dd28b4c731deb942feebe1a",
     "url": "https://android.googlesource.com/platform/external/junit"
   },
   "external/junit-params": {
+    "dateTime": 1614210830,
     "groups": [
       "pdk"
     ],
-    "rev": "3208ddf0c92ccf8443bbaa8dafa829672be531ec",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5c70e5145254ad9384927356dae1984da03ba350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wda5sh5jy1ww8y50nfsw508ijw185h6g0mn5nba9iv95zs44zmq",
-    "tree": "ebc79d81a0ca3240686c38c15599036ab6c11fe0",
     "url": "https://android.googlesource.com/platform/external/junit-params"
   },
   "external/kernel-headers": {
-    "dateTime": 1620176614,
+    "dateTime": 1620154911,
     "groups": [
       "pdk"
     ],
-    "rev": "d56ac8d5c4e49021cee50e904e5d1e1add922799",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "69e08b26868d2d22064457c1770de009db750f8e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vj1hy930nr1pxrc0jdm9j4fhxnlcr05lcg6700ai5qqgz9i06rw",
-    "tree": "e5313e22a77f67ac0474436facffba03cb50ec26",
     "url": "https://android.googlesource.com/platform/external/kernel-headers"
   },
   "external/kmod": {
+    "dateTime": 1613814883,
     "groups": [
       "pdk"
     ],
-    "rev": "01f6eabaa262585f725a8a3b44bd4524b9f60f01",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a859b6968164411860dd29ce7a2e93fb595bb56b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xv7xwkz8mhn41fq7jv5hq2fy9r2l4srnwkcf3xbaca2ai177g1m",
-    "tree": "8c954764a46db77e5a1eda19a30667043fae3867",
     "url": "https://android.googlesource.com/platform/external/kmod"
   },
   "external/kotlinc": {
+    "dateTime": 1620860981,
     "groups": [
       "pdk"
     ],
-    "rev": "05e7e70cd3b7cd98ed943831307d5c369d85088d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d78618fcccb220764099612a05288cf516324f64",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0dzms659jz4zjm07pwissifi7v57xhmrlzkx7j63s9za6az63719",
-    "tree": "a081613ed74029848a681382071addc16821f811",
     "url": "https://android.googlesource.com/platform/external/kotlinc"
   },
   "external/kotlinx.atomicfu": {
+    "dateTime": 1620860983,
     "groups": [
       "pdk"
     ],
-    "rev": "e20f3649c92268a6eaa94dc86b0d23d3874842b0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "97230e837553ee63e1d2047468d8d2e3f27d3f8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "14zbi4fc70xnspx5kn6jdqq9yf8p177qmhx2bprsflrcdb1np9r5",
-    "tree": "e80306381de920a7ec40993f8e1796499e52c749",
     "url": "https://android.googlesource.com/platform/external/kotlinx.atomicfu"
   },
   "external/kotlinx.coroutines": {
+    "dateTime": 1620860981,
     "groups": [
       "pdk"
     ],
-    "rev": "cbde121cd162b8ea6dfccb5bf6bc46e989da02c1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9df3d935c045b2b4ee7f98ae576e41192c80f068",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xg0g0yn8qzk23p8vvh4laavmvinbmqch5ib1ca44g6fkf7f7df1",
-    "tree": "cd835b4f3ee81a86fc0625444b031b33cb3c2b60",
     "url": "https://android.googlesource.com/platform/external/kotlinx.coroutines"
   },
   "external/kotlinx.metadata": {
+    "dateTime": 1620860981,
     "groups": [
       "pdk"
     ],
-    "rev": "ae9b7cb9608fd7dc3ae2fb1407c2a1aaf5c49732",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5865a735da3f4f36121c81028f4cc8d730aca27e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0fz2mbsb51b6h5d8a1p099iccxi4ll2w4cnw3i8yikjmq5pl64k5",
-    "tree": "d68606e605301b3c17cb37ced3139c8d87b5a4de",
     "url": "https://android.googlesource.com/platform/external/kotlinx.metadata"
   },
   "external/ksoap2": {
-    "dateTime": 1613865853,
+    "dateTime": 1613834160,
     "groups": [
       "pdk"
     ],
-    "rev": "2c212aa72cf9d1333d0347516a9e07eab7031420",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0617a2b91db0f785df127293b93f5aaedf9f7762",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kvfan6g57xczcv075439zlqaw3rxmi5mdz7rrfjxv2qyh3sp2v2",
-    "tree": "fe3c8ec755ec8de9ad4e68e66ce64c0e25cfd5c2",
     "url": "https://android.googlesource.com/platform/external/ksoap2"
   },
   "external/libabigail": {
-    "dateTime": 1617757405,
+    "dateTime": 1617708411,
     "groups": [
       "pdk"
     ],
-    "rev": "690b0b9b3b0f33adf0dc3b9c9b07e5e8e4171e97",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0dfb9140231f6ec6c102ad6fc12d21b97637e4b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13rn7mvpwsvahryp1c8ka6rghblpa0vjsvrji3g86map3ij0shac",
-    "tree": "45dfd96a6dc902ae0fbbfe97f01258546c71a50f",
     "url": "https://android.googlesource.com/platform/external/libabigail"
   },
   "external/libaom": {
+    "dateTime": 1624328735,
     "groups": [
       "pdk"
     ],
-    "rev": "046c8d0a916559f853b66775bb1a904d9561ddac",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e08b8d92ab9170c4a370c980382c2bed7551d9fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01v88ya40i58w9fmwc0ak4rl9l2sc5rm9yyh7j8r388ynhy1rldb",
-    "tree": "608ba896d651a6935d8f0a070d4f4febdbf4cad4",
     "url": "https://android.googlesource.com/platform/external/libaom"
   },
   "external/libavc": {
-    "dateTime": 1633482206,
+    "dateTime": 1633482179,
     "groups": [
       "pdk"
     ],
-    "rev": "cd0ca57305b1ee55959653e8591485f13f49cc06",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0698053e88d9bdb34ea1c1fc7d4e68080b523eb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qsn4fdl7ivhbmvvjspi9qj00vhl6x43cll46qj8cyvhnb6ajqpa",
-    "tree": "c648bf7eeb74aeac43906c6863bbab1d07033e8d",
     "url": "https://android.googlesource.com/platform/external/libavc"
   },
   "external/libbackup": {
+    "dateTime": 1613834023,
     "groups": [
       "pdk"
     ],
-    "rev": "0616f32b8dffee7e69498ecaaf09dcdbe838071f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5ce93fe4494046722604cd96c6a055067ddd54a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ll3ryrbrh2xz90b6r928jck1q0ghnq8wrn5zdy4y9w6naxjy8vc",
-    "tree": "1ac89449162ba88cb338516808b251dca83407d8",
     "url": "https://android.googlesource.com/platform/external/libbackup"
   },
   "external/libbrillo": {
+    "dateTime": 1619471804,
     "groups": [
       "pdk"
     ],
-    "rev": "46a5e445e490b946b69027d1cff2e4940aa684b5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0398940d5c5cbb12ede4c7e77c51399d590ad0ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p9fnd8xjv5xf7jbkp7vmqzfmj0ip219lpmp4d291wxzc1jhy1cy",
-    "tree": "8f6ec66173bb45a55a65c8449f382c2c16b3b13a",
     "url": "https://android.googlesource.com/platform/external/libbrillo"
   },
   "external/libcap": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "804f235b056bf82cf65faa3b47ce4e26ecbddad6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7004b3f997cca6bd2fcc22fc1b5e8fbc9094a973",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f4jkab7ws0sjzfgfvrf6mwrrl8q3ghnm885l8nkrlghqd7s3j9c",
-    "tree": "01d6e4802ff19d73bbebbf0d2c0a95ba61bf223b",
     "url": "https://android.googlesource.com/platform/external/libcap"
   },
   "external/libcap-ng": {
+    "dateTime": 1613504470,
     "groups": [
       "pdk"
     ],
-    "rev": "15febfe5c2ff70768747eb983703233f12999b4a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fdcfa912bc638607f80345d21f8d222953921990",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dsr6r0s5m2aqm2wz9zq023abgvjxdrajjnsfrs8ssi30zxzrxyq",
-    "tree": "6a6715c842555e8921762be034c29526ce8edfa8",
     "url": "https://android.googlesource.com/platform/external/libcap-ng"
   },
   "external/libchrome": {
-    "dateTime": 1625706479,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "5e2f326ea51d2ae05726c5e21981912da6d68d0c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "05d507089cd4087e73b11fd6192a87f0be426835",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mi55n6sb3wzc67a279cnabhx179s8dh4bh0j72ngwbaj9sln1fr",
-    "tree": "0f4d08540c8e5fa16bcd0c99cd413fe815560e4b",
     "url": "https://android.googlesource.com/platform/external/libchrome"
   },
   "external/libchromeos-rs": {
+    "dateTime": 1613587988,
     "groups": [
       "pdk"
     ],
-    "rev": "49d5b60329a1588f6e3f169a52c9b533ddbfad52",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c2b9b6698ae8b4f62e2809f1546523954b3d168",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0lkwghnsaniv3v9lbc1r011ff4dk9d0ja9xzxxk4b58xds6zjpil",
-    "tree": "0cbcf18d33905c6c234eaf3b10e6fbc2af5ae515",
     "url": "https://android.googlesource.com/platform/external/libchromeos-rs"
   },
   "external/libcppbor": {
-    "dateTime": 1625101459,
+    "dateTime": 1624639530,
     "groups": [
       "pdk"
     ],
-    "rev": "0f39a5e1b46e4782124ef2b3e37e2e8a1f209949",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "22dfd038f93ab30f1c03955d9319c68d45d08bde",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "009j2acfkk6207s40y37xcp3aj9jd1m72162xpaqf0r62y4lby4y",
-    "tree": "b9b027af6f181031574ee05829b5fba078b01f2b",
     "url": "https://android.googlesource.com/platform/external/libcppbor"
   },
   "external/libcups": {
+    "dateTime": 1613822904,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "fe7eee622a8ef044a88c544898a1f8941e68d16c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5884b4a877be7dd135fe054ffdd949035fd82c60",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1986mbxc28sxi377ydjj8b7mdhwwvsb1df4n3da1cf0m9rrh90vg",
-    "tree": "4ebddc490b229a7fa48d6852af38e4a50d1fcff1",
     "url": "https://android.googlesource.com/platform/external/libcups"
   },
   "external/libcxx": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "bc1292dbd106f92da5f9b6ea539b2b8fa2a083b4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "52eb03e8e27f2043684131c3aea6aaf3d8310d5f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qvz2zyl6j8pnwbjv1rb7kqvjgq13nmbym2zabb64nch2h0vfs4w",
-    "tree": "dade513ca5fb6e74be05a2b9ab97e2814a6ac863",
     "url": "https://android.googlesource.com/platform/external/libcxx"
   },
   "external/libcxxabi": {
-    "dateTime": 1617757410,
+    "dateTime": 1617665041,
     "groups": [
       "pdk"
     ],
-    "rev": "501059ee9281d178a5362f2ec44f48dc8e874bd6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2319d7cf7641f25436e360db18a50cf5e319f80b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11zz64d974bs5gm1b4vin5bjvq9a13h9gzjhk68lm4ksi1yaga96",
-    "tree": "9a4daaa5e2929bd54c4ded783bdafe762e664823",
     "url": "https://android.googlesource.com/platform/external/libcxxabi"
   },
   "external/libdivsufsort": {
+    "dateTime": 1613587990,
     "groups": [
       "pdk"
     ],
-    "rev": "df26c2ab2675a50860ece0791cd6a6e582532802",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "add0d06ea38aab0d03190012c0f1c8145ffd9fd9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lh8s06r0fvkjsrdb0ns3iv0n97sibvbv3jy97c9s0zp29mfi3wg",
-    "tree": "9facdce8aba5db60d6f4007c02290daf066d9a24",
     "url": "https://android.googlesource.com/platform/external/libdivsufsort"
   },
   "external/libdrm": {
+    "dateTime": 1624402246,
     "groups": [
       "pdk"
     ],
-    "rev": "a25464c4fb3c840c70294a8fd0f67696286d0449",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "be7293007dc21d66abb4c8c91849db1c8f601fea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v85xcr4k6vmdplnq3apm20yvd3jzwsv1rh570prrj15ba552alm",
-    "tree": "016f75b88ffb77530b6b58039d84238c213c31cc",
     "url": "https://android.googlesource.com/platform/external/libdrm"
   },
   "external/libepoxy": {
+    "dateTime": 1613828159,
     "groups": [
       "pdk"
     ],
-    "rev": "710155a7b25c57f078ebd491748dae2e7d7095bc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b9cc8aa70269e6ad2bcd089ec3f2af6419907848",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wdjlwf9cvy1wz3xymrxmjxlqj1w7zxd2vxy0g90bnpslwcngc7l",
-    "tree": "8fce3df72013af156b20531357aec0ab57ff24d6",
     "url": "https://android.googlesource.com/platform/external/libepoxy"
   },
   "external/libese": {
+    "dateTime": 1613591032,
     "groups": [
       "pdk"
     ],
-    "rev": "43914ce835688295bea1a36d6d1e5f500eec0fcf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "49fa5515fe5a7a8b753fcba55f998ad65adb5432",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g10bprh155ys18zvsxs0annjzh39cnyxfldy9zbxcpcj5dlvirl",
-    "tree": "225d9f8207cdac4736967397a0a186d8c2a50bf3",
     "url": "https://android.googlesource.com/platform/external/libese"
   },
   "external/libevent": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "ee54d46990ea245a502a7ac1d988f58befa4408e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "722848c75aeafd568655533771d4fe7d0a906f4d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03gjyf91xycyd2g8nfkvvjg1kibvdm1dlzxn9x50sbhbig43i9gx",
-    "tree": "f2118a5914ece04d72e5053ebd1d2148e0cc3bf8",
     "url": "https://android.googlesource.com/platform/external/libevent"
   },
   "external/libexif": {
-    "dateTime": 1613865863,
+    "dateTime": 1613823967,
     "groups": [
       "pdk"
     ],
-    "rev": "77dee021f45c1a97d0452ee04f875bec7147d56c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e1fae2ed9ca24f3e6ed15b753135af7ff0f56915",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ppfmlnbh8vmhicdnvs4vfmsfg608pvmq60g8yylbr44c2bg208a",
-    "tree": "27f5103e68a972bd82cd44555f2fecf659711942",
     "url": "https://android.googlesource.com/platform/external/libexif"
   },
   "external/libffi": {
+    "dateTime": 1613835389,
     "groups": [
       "pdk"
     ],
-    "rev": "6eec951b656493c26dcc2cb83f2b6c70d46fd828",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c598060921bd572eb12d735faf4876c3c5911dcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kfagm0922z80061324a4w74231aic3p9wsw6qi67nasf7f1fbjs",
-    "tree": "9243fb80a4f9f9fccf873054ec277219c2b92d65",
     "url": "https://android.googlesource.com/platform/external/libffi"
   },
   "external/libfuse": {
-    "dateTime": 1620954233,
+    "dateTime": 1620922263,
     "groups": [
       "pdk"
     ],
-    "rev": "c8eb3dc25898e92f7adf31f98200e092f71e8330",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f5647225c85bf36ebe8530901bbc7e4810037109",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10c514vzj2mihk97d69zxzdqgxc65fyqkllyx5glfsqhsr156lwy",
-    "tree": "3e5075efec3f16265f9fe0bdf93d9bb0cdce7107",
     "url": "https://android.googlesource.com/platform/external/libfuse"
   },
   "external/libgav1": {
-    "dateTime": 1619139800,
+    "dateTime": 1619126646,
     "groups": [
       "pdk"
     ],
-    "rev": "4954d3ad4d9e5a8fedc6d6bcb9770a3dd1c80a38",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "560f2c896aaf0076f4632cbd34f1226c319c545d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0w3rkagg3c83rf8j0i6409jxx0wya7yxyx5xx3kgq89axymlb7gx",
-    "tree": "bb6cfe790af703e0d9b8f59b9a2578fd3b879cff",
     "url": "https://android.googlesource.com/platform/external/libgav1"
   },
   "external/libgsm": {
+    "dateTime": 1613830649,
     "groups": [
       "pdk"
     ],
-    "rev": "c1f61d6e3d022fa6b27be2632f447272b7a36147",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a5e37c49dd3a2c066a49f14d46bdc8811c795d2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13np111m5nqvzza0mllnvmm0frvazy1nmlhp6lfn31d00vdrn936",
-    "tree": "63eb2263408829f915a3d3ff51a276574dbb6f4a",
     "url": "https://android.googlesource.com/platform/external/libgsm"
   },
   "external/libhevc": {
-    "dateTime": 1625187885,
+    "dateTime": 1625160832,
     "groups": [
       "pdk"
     ],
-    "rev": "47f3d995b13dcdb16184970b55d6f08a4226efb5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9375fb8da8453a66fbd19305c63cd68f3c16d4bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pwsmr437jags5xyxpsdiqg4axjp3n9i5fpcfcp1d2mha3win6ry",
-    "tree": "d5ca5b056740d79e3ec14a47fefee2f87f22a690",
     "url": "https://android.googlesource.com/platform/external/libhevc"
   },
   "external/libiio": {
+    "dateTime": 1613582533,
     "groups": [
       "pdk"
     ],
-    "rev": "2f36c354a0b4094675f6e93cb7562cc5eeb44f35",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b5255983a4d5f3aed0815c79e08434f9be6232e5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "049lcsyzmzympsk6s3rphcmql3y4rs2c1fsh6bfjpg4sdqjcf5w6",
-    "tree": "f07a31d8b7d475a17c0ad202faec7e03af948515",
     "url": "https://android.googlesource.com/platform/external/libiio"
   },
   "external/libjpeg-turbo": {
-    "dateTime": 1620443039,
+    "dateTime": 1620402017,
     "groups": [
       "pdk"
     ],
-    "rev": "b10b3c8e613c235b798d05e31ab601deb94b1b42",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6a8a5e020389ab2fa0af7e9e49ba6cca8f3b94e5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "003d689i5zbmfv9xqqi3bfc1fb0q9xl37x8k0lb5lv4pxr27i432",
-    "tree": "6d3824158f373f4684d67f316ec715235fcb063c",
     "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
   },
   "external/libkmsxx": {
+    "dateTime": 1613832777,
     "groups": [
       "pdk"
     ],
-    "rev": "df100fb9f036ebac09d622c2676e0de46eca0918",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "86c909970721e4035e6848c0e2914fcac9cc84ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f3vr8khghmcw1pr9kn71ql7s1a0vwnclmqgm2dl27cbkfzf4qmx",
-    "tree": "8ac1a7266fc264022adc90f0839f652add01ecbc",
     "url": "https://android.googlesource.com/platform/external/libkmsxx"
   },
   "external/libldac": {
+    "dateTime": 1613834298,
     "groups": [
       "pdk"
     ],
-    "rev": "02aac60dfb40273dd29315f440e82da85bdc0e50",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a47463b3ff1ced85921cb3c362af052050ced836",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wsy4g8bllsnhdca0s4kh7g986qixrqc3x4pn0jlwg8hnzdc26bg",
-    "tree": "8e139861b6d5bbed8ecef6cf5761d17aee160c92",
     "url": "https://android.googlesource.com/platform/external/libldac"
   },
   "external/libmpeg2": {
+    "dateTime": 1614986265,
     "groups": [
       "pdk"
     ],
-    "rev": "f6ddc76ffe853dfa19b8fdf945e50242873a3684",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "178791c15d899d3b8e4e8d16ef5eed3e5bb1578c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04qb3lvjnizsyzs59zdxw1i9ng1dibnn3a15szzw8dmfrdwdfjv9",
-    "tree": "4269021fa00fdd3facad44c0d45138a9e5da3f83",
     "url": "https://android.googlesource.com/platform/external/libmpeg2"
   },
   "external/libnetfilter_conntrack": {
+    "dateTime": 1613516547,
     "groups": [
       "pdk"
     ],
-    "rev": "8a5c5dc68cf47ae6f0ec78400dcb794f8ed604a5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b62e8c73f75f95f2a269e70896f80b732043b227",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v6lpqqw7h19l9jzs43apw4kws39av9bhikarzlvym5xs3b6jhm6",
-    "tree": "4956c4a230984487df8d8cd415b312c51843c60f",
     "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
   },
   "external/libnfnetlink": {
+    "dateTime": 1613516544,
     "groups": [
       "pdk"
     ],
-    "rev": "d9e01493ef388653e6d0e96468e4355cc368b57e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "69c4d8aa3e6bd8d9f98feab0c9cc8409867b918a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c6w4mi3xc6gxly949fh30ni84yk5w0bwqmipv857hpbq4cl3p9n",
-    "tree": "3c2f385975bc0411738fcebf86d18bd14b088b2f",
     "url": "https://android.googlesource.com/platform/external/libnfnetlink"
   },
   "external/libnl": {
+    "dateTime": 1613823690,
     "groups": [
       "pdk"
     ],
-    "rev": "51f8ce06af5fdc01ab37108a9f58cf8bb1d994d9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c81a827c3fa0fb9dfac5d8e8aede6f22d512d2de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f54wdvb46iwmm725yx2hj6nmfh6g3sfiar27m6qd2i01ah8fb8i",
-    "tree": "9de29e54cb087ea356d39c0f52a95b15fdfea20e",
     "url": "https://android.googlesource.com/platform/external/libnl"
   },
   "external/libogg": {
+    "dateTime": 1613582542,
     "groups": [
       "pdk"
     ],
-    "rev": "bb374f5db944a4d95ebfac2b6a2e3e1e5ad9305c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "031cb41644627356e2ba25cf059b293c92966cc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rdync9bnrw7gxwn69nkk1y8vn42il7145jlq9ry247qskd06hg9",
-    "tree": "ec79ed2f94c424e0cf789b7c90c96f0916e68fe4",
     "url": "https://android.googlesource.com/platform/external/libogg"
   },
   "external/libopus": {
-    "dateTime": 1633050190,
+    "dateTime": 1633072478,
     "groups": [
       "pdk"
     ],
-    "rev": "0f2248962fa5e07505ec42a66bac431dc89e3e89",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6a81af01b817022ff58c8f40c9b8944394ba857d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0z39qr4nd2cgsckhzif4dbjchxqgq72xrql7ckjwyp769g599pz9",
-    "tree": "00451145e6200d31a516d1fc672d0892fc9dff52",
     "url": "https://android.googlesource.com/platform/external/libopus"
   },
   "external/libpcap": {
+    "dateTime": 1615009313,
     "groups": [
       "pdk"
     ],
-    "rev": "b3ff1c145dc90f679fdd0256c99b2852cb481e1d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9e0035071e1bfed10946265461218f9da36a6566",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16pjxifk3vmzkb66ga85ngcwmx555nzbms57fwm66k19v526m1m7",
-    "tree": "65cc8bb75106cd58b78ef321935000aa2851f8ce",
     "url": "https://android.googlesource.com/platform/external/libpcap"
   },
   "external/libphonenumber": {
+    "dateTime": 1613821288,
     "groups": [
       "pdk"
     ],
-    "rev": "4b7a2bfc3c586db748163f0b629523ddb35f8c83",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "692a8b7c379f0494d97d3c09564c423f2f1ed5bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rn08wi8q4b6bb00rcchiv4zida0i7dz9vryfkadb15k4mqh79d4",
-    "tree": "eed50b5e022d54b627509c70ed4d5912d0c7ffab",
     "url": "https://android.googlesource.com/platform/external/libphonenumber"
   },
   "external/libpng": {
+    "dateTime": 1616512499,
     "groups": [
       "pdk"
     ],
-    "rev": "e70eba1f923a5a5ba57672b35c055d27b02d151e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "46ed936d06d3cfd8ba40769d0dfdd2965bb685f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "177jf1vizmmkp7zx4kh99jp66zaqqxkcj6zgk3n080qc91jh3xbx",
-    "tree": "6e1c1fca27986c75003dd1339570b8aa13498b64",
     "url": "https://android.googlesource.com/platform/external/libpng"
   },
   "external/libprotobuf-mutator": {
+    "dateTime": 1613835196,
     "groups": [
       "pdk"
     ],
-    "rev": "65a14877bdec723d444e85f350d275c8936471db",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e96ef0c9ff1f31410f64f95dbf484e9d472dd74",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qd6v41shmz918cv8h2jbgh3pvg65mk7c9m03afzz8gy26zl6rai",
-    "tree": "f6e1e64a91647161c26338b6205f3f9655476a01",
     "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
   },
   "external/libsrtp2": {
+    "dateTime": 1613834439,
     "groups": [
       "pdk"
     ],
-    "rev": "28f29829e8e20407213075a625d5043bec103c93",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8b54f73d9908bb0e374ebde1bc969dc08d92a592",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mr1gb60ryh71makvab277w1lrwlk7bv6alhh369jikm5sj78dyw",
-    "tree": "66ea024e880269f96944ce6d67c0a078b40f0d6a",
     "url": "https://android.googlesource.com/platform/external/libsrtp2"
   },
   "external/libtextclassifier": {
-    "dateTime": 1627095844,
+    "dateTime": 1626946953,
     "groups": [
       "pdk"
     ],
-    "rev": "e66e670f47eb5e07d95894b6177c729f40726621",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e28f99a0b4bf610672d8cf908bed7700e2b730e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0grqsvf1zk2658a346pbrfv4mcc65j49pq4061wqfhsxad0gipb2",
-    "tree": "572b42eac97af62bb5f19764d10ec9251ed93489",
     "url": "https://android.googlesource.com/platform/external/libtextclassifier"
   },
   "external/libusb": {
+    "dateTime": 1613823922,
     "groups": [
       "pdk"
     ],
-    "rev": "1bc7351bf6b74a9bcd1f02bd4c9d055dbfc98fd7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e17e1c5f65fe61840fcf26d2e14329e5bfcf350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v007hjbbbs07mq2y84511mv31b8h8hhac7hp2lqmrwp8f2jldxx",
-    "tree": "15eeeb43c7bbd77d23f5e9f0af837722a7737e34",
     "url": "https://android.googlesource.com/platform/external/libusb"
   },
   "external/libutf": {
-    "dateTime": 1624496678,
+    "dateTime": 1624322936,
     "groups": [
       "pdk"
     ],
-    "rev": "53a41fb3254f17a605a38d7859a037e15e311482",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bc83ab3574993e31a192c8b775bcb07cd050b5aa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d0d5ljsb4amc6a8xwkx1hmzy712gww5vsh4fq0926nnl195vp8s",
-    "tree": "027714aed2ec42a5cfcdc00f92ccbfbf952bd8a5",
     "url": "https://android.googlesource.com/platform/external/libutf"
   },
   "external/libvpx": {
-    "dateTime": 1626224669,
+    "dateTime": 1626119494,
     "groups": [
       "pdk"
     ],
-    "rev": "5361d5eb62b0897729e44a795a0ae0a01c828524",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7a0c68aedeab57e515b0276092f0e0ba331d8192",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y883jrkywpy64xay77kxh1j2ijc77lmggyby8860y608a1227f4",
-    "tree": "2bb892d71caf976167223d81e692319771f72860",
     "url": "https://android.googlesource.com/platform/external/libvpx"
   },
   "external/libwebm": {
+    "dateTime": 1613822832,
     "groups": [
       "pdk"
     ],
-    "rev": "ed6d6e9fc91861352a71f74e425a68ede21db4e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "aba1e4df5a8e700acb0ba3d726eb376aad43a735",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kkb0mm6vqbv1ri6br6d4xisvbgx947r8d9vynbbw9bl03g2fbpp",
-    "tree": "cf4d7d5f7a99032031c0f56cf7b49b6df8deea93",
     "url": "https://android.googlesource.com/platform/external/libwebm"
   },
   "external/libwebsockets": {
+    "dateTime": 1618528182,
     "groups": [
       "pdk"
     ],
-    "rev": "43bc22941b183844b8c54334a8fa1a49c68dd7ba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fed801d283c393360d7e2a954993d79a7be5dfcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "14l852ww7vwc5vpi0b5vdqall31afz743qyqs67kdy1xdzz906mq",
-    "tree": "c9f2aa6ff169baaf3ce8f031fbf1364cb8c9b07a",
     "url": "https://android.googlesource.com/platform/external/libwebsockets"
   },
   "external/libxaac": {
+    "dateTime": 1614986306,
     "groups": [
       "pdk"
     ],
-    "rev": "88c1c08340653c4e3e8c33bbb783f5ffc6eaca32",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7a62b0fb2760ddb4a86ad3076f2460b510f30eed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k85nq28kwa9jhma9xypm9i3p1317njryhcsvmiqk0w3cn5xxlr5",
-    "tree": "9c75bea06f8ec8bf4beeeafa70b36add7a0c1d02",
     "url": "https://android.googlesource.com/platform/external/libxaac"
   },
   "external/libxkbcommon": {
+    "dateTime": 1613814458,
     "groups": [
       "pdk"
     ],
-    "rev": "21532d80e1b85465ce575c7cc72fc6c2daf68c67",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "26e0ffacde55c1521587d4450cdb6a43ee65308d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ffqp52cwhvb7kkkvr993sj0z63jk7cx0jkv4fb3apjczp8rlnlx",
-    "tree": "ffd302aa88cc4fdaee4f50de64e524c19ef2e499",
     "url": "https://android.googlesource.com/platform/external/libxkbcommon"
   },
   "external/libxml2": {
+    "dateTime": 1620938495,
     "groups": [
       "libxml2",
       "pdk"
     ],
-    "rev": "ae58bc32ff715ebfe9bebdef6224a1e9ec8a6428",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6fc2026f204ce12bb232567cc67b6f79fdacc946",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kni8714vrwwrrbh3pg3fa5q7fillik22qzsrgy2i2d8y1jsbgp5",
-    "tree": "e489e59c92bdb5e0b1edf9d7ee7a2fc7622ca0f0",
     "url": "https://android.googlesource.com/platform/external/libxml2"
   },
   "external/libyuv": {
+    "dateTime": 1613821661,
     "groups": [
       "libyuv",
       "pdk"
     ],
-    "rev": "8596f58ca14eb0978574c979e6edf304fbd77e48",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bc7cad0280b6aec240415e4a683d78e3712e92ad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wqd724hbmyk1nqyz2ixk14dq074897raqnb72h8zfbshkxrdvp4",
-    "tree": "899183b8d4e59769a299cb0475d17f8e125e8954",
     "url": "https://android.googlesource.com/platform/external/libyuv"
   },
   "external/linux-kselftest": {
-    "dateTime": 1619838264,
+    "dateTime": 1619820969,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "511f2efa2c96b4ff0f5c143e8e353d8f7a9dc9a9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b0979367624399237e1085f3f17919e9ad100ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wfr5vcjbswirbk0dla14bkz7q34imxd7l7r311c82vqf4wdk04b",
-    "tree": "202c2c2c79445480d24bdda25122921d34ee6768",
     "url": "https://android.googlesource.com/platform/external/linux-kselftest"
   },
   "external/llvm": {
+    "dateTime": 1613814421,
     "groups": [
       "pdk"
     ],
-    "rev": "b1e92951322ff237e6fadc155bfc3be30ada3b66",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6b56e54f6a4e2159c397a61c9fcec624396614b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vsbyazjkpdd4gpmr9cbj94bl4f3ddhqx56rz9apyd50bzbi8dnb",
-    "tree": "5212842de125d645fea163644699a8a60feb25c8",
     "url": "https://android.googlesource.com/platform/external/llvm"
   },
   "external/llvm-project": {
+    "dateTime": 1607536677,
     "groups": [
       "pdk"
     ],
-    "rev": "ce2752e0eeaad56e368ad783b6dd293b17702657",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8cb28bc3dfe43a8ed95cc56046af070c8647b486",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ikzmd238agp9ldng39y1yn4yj2nqah251h5nrsp3b97qvd05wk5",
-    "tree": "639cbcdf289c6a8a9cc98c94d398c8d9ad1f6a4e",
     "url": "https://android.googlesource.com/toolchain/llvm-project"
   },
   "external/lmfit": {
+    "dateTime": 1613513328,
     "groups": [
       "pdk"
     ],
-    "rev": "e99350f245e9aa692ff16d2566ed37943335ffdc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "eab2bc745e2489e080ca2e16b1b3b99b117fd3cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11nb4xcnbnqgq0b15hqdyppixhyri8kwymbvaznfi1y370jw66bp",
-    "tree": "9e2dd9c5c62ab3bfd30231d32a84a88eb686b663",
     "url": "https://android.googlesource.com/platform/external/lmfit"
   },
   "external/lottie": {
-    "dateTime": 1623891880,
+    "dateTime": 1623838088,
     "groups": [
       "pdk"
     ],
-    "rev": "029e72c232edb41c2d04c4138b5a2f9e7945ef8f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fada85ba3f151721b433fc579306c3f023c49617",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xbfmzrpj7j32s4m7ygvhbx4x4s3gdvzqn07jkh2bmi7r3kws8nz",
-    "tree": "05fe4bbf03603703931670dfb2e19f7173e88ef9",
     "url": "https://android.googlesource.com/platform/external/lottie"
   },
   "external/ltp": {
+    "dateTime": 1628888010,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "8b18f9e9f9f73fc41d0555ee146d7223f310e237",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d4ffc6dae7916cc53a271ad5d57fff5c2bd1c4a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mqyz806pbqm0m40p3lnxjnbnkh7y4rasymk1n8c2a48dm6crxdf",
-    "tree": "dc99b8d2649bf2bbdb34cad32c778ac254a47634",
     "url": "https://android.googlesource.com/platform/external/ltp"
   },
   "external/lua": {
-    "dateTime": 1620867868,
+    "dateTime": 1620326634,
     "groups": [
       "pdk"
     ],
-    "rev": "74d18bec0370a53c10f1d6bf940ddc99979d0667",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "41afbb0a718ab8682298918c65c0dd06445d9d27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pr4np5di8pj7r1yaab4nrvh4bb5fkakr4ddlv2f9h0jhx32y2yq",
-    "tree": "ed33129c61836a437584deab1f52df6d21532060",
     "url": "https://android.googlesource.com/platform/external/lua"
   },
   "external/lz4": {
+    "dateTime": 1613814590,
     "groups": [
       "pdk"
     ],
-    "rev": "8580222416617decd2d274e75f4ec2e44df7a302",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c91c377b9fd83f149d7de820b6992bcc58a7b22e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z9qlmhzzd6zssc897sy2yz2iqpq812qfpyszxv5nsmj9ml48swq",
-    "tree": "aa44ea0975fc0f37e5b624c1d051710d436015b5",
     "url": "https://android.googlesource.com/platform/external/lz4"
   },
   "external/lzma": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "6e832e2259c2de53a6fe30f94740d77968482b2c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ca5e1dbbe851e6545304a0d30a530a2d05bde693",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08wi3bisnknkz26iw3r3lna9zxwnmbql6iz550793nbq8bnkvci3",
-    "tree": "48269b553015dd591fe5f742a7f5e3f66131d418",
     "url": "https://android.googlesource.com/platform/external/lzma"
   },
   "external/marisa-trie": {
-    "dateTime": 1613865883,
+    "dateTime": 1613823730,
     "groups": [
       "pdk"
     ],
-    "rev": "89228e301b76dae48f9f95f2adba7c66477b128c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ffec643eeceeb3bf79142ed95718f04ff0ffd0f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "131spy2m80s752028pqqkhylnd2y8ibz1bajdssxjhw6ybhfh4yc",
-    "tree": "f36e0f9da5855a1abb42f107a4e0733d79080e65",
     "url": "https://android.googlesource.com/platform/external/marisa-trie"
   },
   "external/markdown": {
+    "dateTime": 1588189365,
     "groups": [
       "pdk"
     ],
-    "rev": "fe83093e8ed87dc34011ef763d3668d3cc2856a7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f5c06cd8812bf961ef1ec2a289e5d6c511210ad0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1g8ziq2pf7gnyqcv6cbpigs7vaghd269lxzqvq3gkmqq5nvvp51k",
-    "tree": "684dae92395ec05a6684410960f7b4b6b5fac175",
     "url": "https://android.googlesource.com/platform/external/markdown"
   },
   "external/mdnsresponder": {
+    "dateTime": 1613814437,
     "groups": [
       "pdk"
     ],
-    "rev": "d5eb997e48316627e52737f9386f36d1cf17d482",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "03b24cad4c8d5be848e6a1324aaec5e92888d0a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11fw71ghxij6q9zrn3bp7plz05yrw0a8w9yjkdcfjiicf4may28f",
-    "tree": "6eb0369981268c07ff9b815b3fdc0d689761bcbc",
     "url": "https://android.googlesource.com/platform/external/mdnsresponder"
   },
   "external/mesa3d": {
-    "dateTime": 1619305438,
+    "dateTime": 1619228223,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "b141db68ccbe23d72bd380bb66c37ec2516ca668",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "15c21526468d152b3f53f7ecec4e0a8e7873ec09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gj14c9wnhqpfpf3wkvfpf967rcsf151clamr6d1prf36m917a43",
-    "tree": "b85b01604bce00aeb9d908ade413b08baeae9f20",
     "url": "https://android.googlesource.com/platform/external/mesa3d"
   },
   "external/mime-support": {
+    "dateTime": 1613516532,
     "groups": [
       "pdk"
     ],
-    "rev": "05aea1e97d00dfa9a284891d201c373d4d5d3044",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8b7ca4e3cf396d9ae0c2678458a68ec41afefbc9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lkwshpnbp0hgz4azb63c83xdk8hrqywcbh501frjc8d5zgxvm6s",
-    "tree": "59736b7911058790078030c9c6923de4f0acbfc9",
     "url": "https://android.googlesource.com/platform/external/mime-support"
   },
   "external/minigbm": {
-    "dateTime": 1623805478,
+    "dateTime": 1623701689,
     "groups": [
       "pdk"
     ],
-    "rev": "57001b34640b76b1e864c11b24cb02917e7662bf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7d0468d096574f00712fe0062d007ff9461ebff7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lbk54q5w1qad1qjyjn2rzkvn6ab85ibx7ixqxhkha3lm2i33k5q",
-    "tree": "2c241a7ad325d9ec00b7dad5881fcb0111269335",
     "url": "https://android.googlesource.com/platform/external/minigbm"
   },
   "external/minijail": {
-    "dateTime": 1620954255,
+    "dateTime": 1620941758,
     "groups": [
       "pdk"
     ],
-    "rev": "cb449943517f6bd9ce5ae2c79c7ec8f306236553",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff37dce5f0b3f7103e79e6097f869bab429cf7d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18341lkx5k0svyj3z60cdv153h8aq0fvc00dssxm3rssim4ax3gl",
-    "tree": "832aaffc3276b8ebfc0960c3d4bc4138ad8a6490",
     "url": "https://android.googlesource.com/platform/external/minijail"
   },
   "external/mksh": {
+    "dateTime": 1613822581,
     "groups": [
       "pdk"
     ],
-    "rev": "c938ff504de4537da3633af5621dc413426f2783",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b4e674b9db2ef87a3ee31a444fa9999d6190e94f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d8xqv9r3qa7vvwqs6ifpl77j5whvn67dk0b4xgfbsqf2rryrk71",
-    "tree": "e35b585bbab023d0a99d4e7aa4e4734bdec55da4",
     "url": "https://android.googlesource.com/platform/external/mksh"
   },
   "external/mockftpserver": {
+    "dateTime": 1613516542,
     "groups": [
       "pdk"
     ],
-    "rev": "b390cae4320b6363ac5408e167e6b39bbccb9144",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a312b549d6a63d8fd82c7a304272993b5d7dba68",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rm29k2285ibqklbgijdmi4mp694pzg7pgj8n9zl9a1ar1cjv5nf",
-    "tree": "09c0b4321fec3c07016d3d7bdc86e27143f80fad",
     "url": "https://android.googlesource.com/platform/external/mockftpserver"
   },
   "external/mockito": {
+    "dateTime": 1613821600,
     "groups": [
       "pdk"
     ],
-    "rev": "197290eb39c13272cb694abc5a2f6431b4595a2d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "71d3bd6f1c0bd98679f07e6f74b714e9394593d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0fvgaw450rhb5cmq2blh2y4zi86x23jjngrskprz9k4is3yw8zn9",
-    "tree": "282ecb140139a5cff47b139b1d2b936c92fefd72",
     "url": "https://android.googlesource.com/platform/external/mockito"
   },
   "external/mockwebserver": {
+    "dateTime": 1613504481,
     "groups": [
       "pdk"
     ],
-    "rev": "37cd028775b12255d81323d7d26468faf6e182c6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ea7607fba2b8e3cdeb69811d17001bcc1abaefdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yxf1fgfkb7kgzz5pqac8171952gfviv2043njxnxbaysmy5sn1n",
-    "tree": "0f42266fe9967fcbdd3eb94b2458a5b3d123173d",
     "url": "https://android.googlesource.com/platform/external/mockwebserver"
   },
   "external/modp_b64": {
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "f34ade19a05dd26548b73bd4ba6ed32d2483a90e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2827c23395b93cb6649347485e9929798d05811d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l11d9qw0qlh6ab2ybwciscspqscdydj23q5998va4qxpapdcrjg",
-    "tree": "d9bfebeca9c2fdc867d14da1518fadc7c74c30bf",
     "url": "https://android.googlesource.com/platform/external/modp_b64"
   },
   "external/mp4parser": {
+    "dateTime": 1613516543,
     "groups": [
       "pdk"
     ],
-    "rev": "a0041d562c1f40a1d52cc24dd74a148a58094c5c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5e6e66a4c28b15830534d216635e7ab493610630",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "167wv822ssx9n3z0bnbk72p532wy7ck7a0ayi0rrppz5whilg262",
-    "tree": "9172b09d71a2a30fb1c48861403df4f5cda5cec6",
     "url": "https://android.googlesource.com/platform/external/mp4parser"
   },
   "external/ms-tpm-20-ref": {
+    "dateTime": 1613829521,
     "groups": [
       "pdk"
     ],
-    "rev": "4edf6475c44635a7e295e68d82efdf86ce58dd65",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fd40c19b94c2d1d1316d5b8b7333855963b9e656",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j5gdirvbvqr3kw0d212s35awisanlmc1avyfk2ky7rqa82yqp85",
-    "tree": "9e269ab40c0e1df3d9f9653943c5e5dae5d117cb",
     "url": "https://android.googlesource.com/platform/external/ms-tpm-20-ref"
   },
   "external/mtools": {
-    "dateTime": 1619139828,
+    "dateTime": 1619086133,
     "groups": [
       "pdk"
     ],
-    "rev": "bb48ff768e3ec03c115f76242c1a6cc9707a6dcd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5a5e41d1eb00bc3e20b7c056677a93533073004",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0i0dbrkfj889qx63dz0iwvs6klablp5ydyria9s4j21bp3zmgzp4",
-    "tree": "1fd507de107704ebd9d0d7baa7062947dd21a9ee",
     "url": "https://android.googlesource.com/platform/external/mtools"
   },
   "external/mtpd": {
+    "dateTime": 1622589542,
     "groups": [
       "pdk"
     ],
-    "rev": "cf3a63433500522c9fa6cb3a8cdbf6904e06e720",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c6508c390fe329609c5eb383519c1acb06d32c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kgmcl1ll4mpzfwnl95y2qhv7d825s4i3rkd36wgvg5h6jkf9zjv",
-    "tree": "b1ea10db9dbd3eaeb82ec62fa94cadd82413a19f",
     "url": "https://android.googlesource.com/platform/external/mtpd"
   },
   "external/nanohttpd": {
-    "dateTime": 1613613860,
+    "dateTime": 1613582547,
     "groups": [
       "pdk"
     ],
-    "rev": "1807b1b35e5ac816c398857cd3e8529ede48e898",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9a79b74bd23da48b6179594585cbf95c270b8a4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gq2hhgy0rq5ws42vjkqjdawn6dns6kl8cb5h46lx8psvh7pdgz4",
-    "tree": "b8f8f988ccda09f844ee3f15de0c535f23c81930",
     "url": "https://android.googlesource.com/platform/external/nanohttpd"
   },
   "external/nanopb-c": {
+    "dateTime": 1613701680,
     "groups": [
       "pdk"
     ],
-    "rev": "0cf482be48debb729bb941edd7a6ff2fa95aa8ea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "123c0ef2c35b7138c25e8ed9ecee314c52f1ee4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1089qzm6713npyb6q1zx1lmapjlhww36rc4b6lmzwgxv39afk5ii",
-    "tree": "e813bdb690053a9fe4a9b575f4969dc361621800",
     "url": "https://android.googlesource.com/platform/external/nanopb-c"
   },
   "external/naver-fonts": {
+    "dateTime": 1588181530,
     "groups": [
       "pdk"
     ],
-    "rev": "9fe84dec8a691fbe2c0e6748e05e52c9e22dd805",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "100c4663421ff989ff800f35ce7cdf0f9a506281",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ihcg6mpzf8lnygnn82l5z8pv6m8iyw0mzsc76wmyn9j7wdyhg9s",
-    "tree": "88c733fec6d470488bb58176c677b57cd14d43dc",
     "url": "https://android.googlesource.com/platform/external/naver-fonts"
   },
   "external/neon_2_sse": {
+    "dateTime": 1588290974,
     "groups": [
       "pdk"
     ],
-    "rev": "9969895667ad08bc260d3fe35e71f0e92b390ed1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "965188421aadd92b93ae738ab16ad2b5d68e054d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12ivga8rnf1ibchrwczfs38n8kpjrjkyrfn9hav2w8z3xdrhz8p2",
-    "tree": "b74594106b475046ac4ad9c234fd111463760f16",
     "url": "https://android.googlesource.com/platform/external/neon_2_sse"
   },
   "external/neven": {
+    "dateTime": 1613504480,
     "groups": [
       "pdk"
     ],
-    "rev": "b2e43abaea9bb7301493222737b7231e51451e70",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "11b0b3df8254b595c1e4c045ddf1bc1f6e4738b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wl4zg5zkcgnrj9lzvm6l49awpar07hny1admj6hi06k0w2id3f9",
-    "tree": "d84455aa657dde0c9c3241548ceba55a4f2ca4ce",
     "url": "https://android.googlesource.com/platform/external/neven"
   },
   "external/newfs_msdos": {
+    "dateTime": 1613582532,
     "groups": [
       "pdk"
     ],
-    "rev": "2e1185d8ab416c2179a3ca24e9c6276a2612f5dd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5fc67e7d870a8b06fe0ee4cf7219041ae740503f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0shrw82gl4bsvsdyk21fwmjvdk9mjg24ylng2jbabki63xp4dmgw",
-    "tree": "a3968e4970cfd41c7c3b6852dee67840b000f2be",
     "url": "https://android.googlesource.com/platform/external/newfs_msdos"
   },
   "external/nist-pkits": {
+    "dateTime": 1613516536,
     "groups": [
       "pdk"
     ],
-    "rev": "e600d449a4aed7bf0e5bd334d893f446bbd51e84",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7dbb70abaf2e98538206c4ad4e57773d52171090",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xdr99aqr4g7drh4gmr88ah0q2im8aq5cs8w834qanygpg694dr1",
-    "tree": "aa24bc870948beb87a8bfa746517da453f102b93",
     "url": "https://android.googlesource.com/platform/external/nist-pkits"
   },
   "external/nist-sip": {
+    "dateTime": 1613582534,
     "groups": [
       "pdk"
     ],
-    "rev": "1f6d822906a2007e8e884fb4078a9bb8e498b591",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1aea3baf6865e5d2c3c14e1364654ab57e673e96",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0k5qg8bbg2l6g3fv9x4bikpa7b0sf08lacayxgm3pnpyn2bmai43",
-    "tree": "37ba896f7fc2bf66bc24ea009cb7a7a2878f4735",
     "url": "https://android.googlesource.com/platform/external/nist-sip"
   },
   "external/nos/host/generic": {
-    "dateTime": 1632611087,
+    "dateTime": 1632270120,
     "groups": [
       "pdk"
     ],
-    "rev": "e2ef31f5d322847ee55f7e621d27629ed215306d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a2b1771799f7f074e454a13cf5070a255ffe2a65",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jwxahjz1qib7l5bsjzinjl0a1incqvns2msrl469gszdawvix7a",
-    "tree": "c7566fc6b36b42899f632ad5dfe0843da19031f8",
     "url": "https://android.googlesource.com/platform/external/nos/host/generic"
   },
   "external/noto-fonts": {
-    "dateTime": 1625353458,
+    "dateTime": 1625069473,
     "groups": [
       "pdk"
     ],
-    "rev": "351dec69feb51d94f576a64bb314f845c4c6d37b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e62d0476e6220126ed893fea27f967f82f1126c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p0r230lik5kbmysq0ahwdsdj9qg8h8p8305651aw3zmn9ad23g9",
-    "tree": "156d5cda848f267bb3e6b95b73dc63e2bf186a8a",
     "url": "https://android.googlesource.com/platform/external/noto-fonts"
   },
   "external/oauth": {
+    "dateTime": 1613504473,
     "groups": [
       "pdk"
     ],
-    "rev": "0de9ea84a236753f5ca25d921e008897e4366917",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6c31648be6d1b6572a1ff4796b09bdbe1f66348c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1iy7n0krrann5fkm46znlm1q598wzr4jlxv17d5xw4dwc5jp6p5n",
-    "tree": "7ca28bee4e2cc212ca14689a20c7beda95d53d34",
     "url": "https://android.googlesource.com/platform/external/oauth"
   },
   "external/objenesis": {
-    "dateTime": 1613865896,
+    "dateTime": 1613835417,
     "groups": [
       "pdk"
     ],
-    "rev": "e2f6e08667dad68b4525f5e7d5a96eb629785b1b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4fc5a9a9185388c74ae174bea32166f5402e9083",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cvmp0wrf5lqag44wfjil3bdq4zkdc3dm4fr49g6qcchd7h65gmm",
-    "tree": "3d0569d6e9382915afc2f591f0f8531a6855acfc",
     "url": "https://android.googlesource.com/platform/external/objenesis"
   },
   "external/oboe": {
-    "dateTime": 1627002270,
+    "dateTime": 1626885362,
     "groups": [
       "pdk"
     ],
-    "rev": "f0894b00add24d95830dfd5d6cf8dbc35727292c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e6f19927a874c00ae290f91ee4d5773ac62ffcc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z95091yv1akx277a4fsy0hxdlav1b7kn969b6cn5z6cnzm66fyl",
-    "tree": "2f734112fc33c8cd2296a0ac5c15342a1d341c43",
     "url": "https://android.googlesource.com/platform/external/oboe"
   },
   "external/oj-libjdwp": {
+    "dateTime": 1614856107,
     "groups": [
       "pdk"
     ],
-    "rev": "3ec2cab054d4246cec3b3bba3949f4ba5f5113fc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "312a813e8597153ffb0f006c9fbfb7d5e1c6e78f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l4l046zxwqw991qadiawlwsrbv2chwh0rapbqry93l4ygikmbqf",
-    "tree": "54b99cb24fcf8b51ead1df6de6f422f77cd95103",
     "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
   },
   "external/okhttp": {
-    "dateTime": 1626915899,
+    "dateTime": 1628888010,
     "groups": [
       "pdk"
     ],
-    "rev": "bdf3d0111c997cdaa5bfb910613471029ff36de7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5cc4e8c802f75a20bbf2e4df42856d64acbfbbd5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "097dqcz04kxb379dvrhzkgn7w3dm65lwpq0g9hadqaq6pv1ymf9r",
-    "tree": "639b7105d88707c56681b42e879c6ba129998b11",
     "url": "https://android.googlesource.com/platform/external/okhttp"
   },
   "external/okhttp4": {
+    "dateTime": 1612297295,
     "groups": [
       "pdk"
     ],
-    "rev": "b0c8c12f7f9b47845b67585b06257ff95cd39f30",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "82727b44d508352c5a7c2dca7a88a151df2ff651",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/platform/external/okhttp4"
   },
   "external/okio": {
+    "dateTime": 1619035267,
     "groups": [
       "pdk"
     ],
-    "rev": "5358e8c2f95085a41e6e23ebd58ca8f2ded8cb50",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ab29022d6d948873c2ba5f5e1c72884c1f34ed30",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ln8mr5cr324v8dzjk35hhy0333sa74j9ay3xns35yk7g2pprxbg",
-    "tree": "7940fe7cde69ccd8f9d88cd286336d4ea8d28909",
     "url": "https://android.googlesource.com/platform/external/okio"
   },
   "external/one-true-awk": {
+    "dateTime": 1617391809,
     "groups": [
       "pdk"
     ],
-    "rev": "3ee878c3cfa65e1557216ab391cd2906d7b5e394",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "375403bcf36f35eff75fa9eae38c72f1c5d10b53",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1g7v3ayb691jhr8fpcrdz5a5396qbilf9gkddx5wvl52cxrfd72j",
-    "tree": "a2c4655ada2f9fca785ba57990d414fb9a023b3d",
     "url": "https://android.googlesource.com/platform/external/one-true-awk"
   },
   "external/opencensus-java": {
+    "dateTime": 1613830444,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "33ec62a95aa0be6e27062866c8326603c1f9a2ba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3b3f1d41d534a0c359c8415f8f7d66037099fe8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1i22bm033fn223k4hjiqn55aj1xr3mvcgl6880cqhr2i8cnw7ij2",
-    "tree": "c8d8b8f0fe9e29739c1befe0762e4a90dbb618a8",
     "url": "https://android.googlesource.com/platform/external/opencensus-java"
   },
   "external/openscreen": {
+    "dateTime": 1617743515,
     "groups": [
       "pdk"
     ],
-    "rev": "b7ebcde66b20d7c8d1db62d187153e7a67413709",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9a4440d900c07cf08dc688bd54516809a5588300",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v1y1ar5ak3mn893gi7jxrfkly7wl45m84gyj33pspcni831bsfc",
-    "tree": "4f552c06b6d628ad0c33313ac0c59356d2fee81e",
     "url": "https://android.googlesource.com/platform/external/openscreen"
   },
   "external/openssh": {
+    "dateTime": 1614024003,
     "groups": [
       "pdk"
     ],
-    "rev": "b499c3a9c2a5efc072e93f7b0d5c37d95749547f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "36f96b6377ce44e9b5f5a97f98d50e9c5750c494",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ch7jqxxw4cv80w60k9nkfpxjp3i60xd575rchlyizvlxka6zwjq",
-    "tree": "510211ad5600141a8274e8b6d9af61b48a0c4296",
     "url": "https://android.googlesource.com/platform/external/openssh"
   },
   "external/oss-fuzz": {
+    "dateTime": 1617393061,
     "groups": [
       "pdk"
     ],
-    "rev": "c9b316b7632d2070842aead6d57ccfd98a1aa772",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "30c3c9062c945537f60274e8da7ffa2eacb13981",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12ysv0nncqlx7gry6m10ac6x34y1kqs3y9jg5bzkb6dsb677mi6r",
-    "tree": "328e6c9629b196cec1de3a94ee804d9fee3a0524",
     "url": "https://android.googlesource.com/platform/external/oss-fuzz"
   },
   "external/owasp/sanitizer": {
+    "dateTime": 1613516538,
     "groups": [
       "pdk"
     ],
-    "rev": "cc670b05ba4cea64238fa1acacb47e28dc709215",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c0492b8555b6c5d1fc54896b08e54ed19cbb7a92",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bw90dnh8irryj7sn0n0swlx9vllvasxj8r01gh7prmawi97lh9r",
-    "tree": "596125242888e084832d4da98329b7e14a09b430",
     "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
   },
   "external/parameter-framework": {
+    "dateTime": 1613516537,
     "groups": [
       "pdk"
     ],
-    "rev": "e605a2d4e4679403b354de0dd21ee9d2020c1774",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "250cda028b3db08a860cae084a1b64aa2da28447",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bf4fjy9p4fz7rp2plga2zam62s2k8jcwgn8mg0qka7jkddf1qrb",
-    "tree": "0b3c1ecf76735ce7636e1359ad4e262540fffb54",
     "url": "https://android.googlesource.com/platform/external/parameter-framework"
   },
   "external/pcre": {
+    "dateTime": 1613814679,
     "groups": [
       "pdk"
     ],
-    "rev": "7466953a5f2cd4e6f4c0bbe6ddd481573a05bac7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d2a480d370a1e85c602320113ffe343a547b365b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dpm303wwx264bc6hxqlrfkfmavqwzb1k914gpxmdgfn0iv7hn2m",
-    "tree": "6a87a8e100def2a9eb90995776a41c42d6045331",
     "url": "https://android.googlesource.com/platform/external/pcre"
   },
   "external/pdfium": {
-    "dateTime": 1616461444,
+    "dateTime": 1616064242,
     "groups": [
       "pdk"
     ],
-    "rev": "2b8da20361f14ffca953476e838a8c6f502c7ae1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1e5fe6c9fcedbd4320739a2aff38d77a5e043322",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1g50kxs8y74bklsmnjzazd4nk8ajhksyapm5r0g2qidb3nmx3cl8",
-    "tree": "670b2008ff8484c5b755006915334d675da27b4d",
     "url": "https://android.googlesource.com/platform/external/pdfium"
   },
   "external/perfetto": {
-    "dateTime": 1624676668,
+    "dateTime": 1628888011,
     "groups": [
       "pdk"
     ],
-    "rev": "b47dcede6fb39aa478ac138bc40fbd79fe561c10",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "92c29f3ee84dda0408ef8a0c698350af517dccdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05k7j5ynnfr7hpa9320jax8yiaka3va8q5v1iwzjpdln7bmi8jp7",
-    "tree": "5b7c6a440f3cd0889923523e294b8b809cea0122",
     "url": "https://android.googlesource.com/platform/external/perfetto"
   },
   "external/pffft": {
+    "dateTime": 1613821464,
     "groups": [
       "pdk"
     ],
-    "rev": "868769122dfde37298471b475c297952cb5aa9da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8dc7e84864a0537b02b0c43f44c361f3c5fb9f0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qgf52lcq58ixhrhqnwcpixkkbrd586n23r14yikvbqhspdfar0s",
-    "tree": "8b0baca83287611c14e509990074d53aeae4c028",
     "url": "https://android.googlesource.com/platform/external/pffft"
   },
   "external/piex": {
+    "dateTime": 1613828455,
     "groups": [
       "pdk"
     ],
-    "rev": "3b38e5aee001576535b51d836ff426a2fd5354e7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ffdd3f9653b9439632791f1043eb22ddbf9452d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05lyk7vmhf7kq9bcwpg07nwvx1pdadjv1g3c1ny2wq2l2jchbps3",
-    "tree": "cdcad40f946cee5c4e7c28d76947ec0bac0d78aa",
     "url": "https://android.googlesource.com/platform/external/piex"
   },
   "external/pigweed": {
-    "dateTime": 1619053481,
+    "dateTime": 1618948488,
     "groups": [
       "pdk"
     ],
-    "rev": "c16832c7dc81dc0830afc5932149dbb8e0357ce4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a274820f23ab694ddcb3c54d8b86933472a0791f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zh25gjyykp19xpg9jh5xjqaz87j75nb5qzqg08gf7smspb34rvz",
-    "tree": "6c9a1ece6500a78795251a847a3f9a432672abb4",
     "url": "https://android.googlesource.com/platform/external/pigweed"
   },
   "external/ply": {
+    "dateTime": 1613513318,
     "groups": [
       "pdk"
     ],
-    "rev": "1aa380bce895200b2a90a13cc76743225b8a3867",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ac9c5dee9bc3f229b6b44b7a5c2ce78dde293ce8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04ran6mcqvfm06d2pqw9x62vwdr782h14xmn9zw8c7pw0hqzkqfz",
-    "tree": "8b90af24b050e079b876d4bbe83a5ac8e2144634",
     "url": "https://android.googlesource.com/platform/external/ply"
   },
   "external/ppp": {
+    "dateTime": 1623048795,
     "groups": [
       "pdk"
     ],
-    "rev": "a4605c564e72cbe8204b95d1a5c9d808c0f658c6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e08297fcf7114df93fa4611ba9d8522634bac7cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x8kmf219svcclr8yv94f06y9m7i4hf1sshs4vw557l7g0c56rs5",
-    "tree": "ef1d608c30858143c48a34242fcfb72e1a4a58c4",
     "url": "https://android.googlesource.com/platform/external/ppp"
   },
   "external/proguard": {
+    "dateTime": 1588698674,
     "groups": [
       "pdk"
     ],
-    "rev": "5d3a04b725266b18eadfb9108d1b90c122b61095",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6078cc0cd98a40d2127b959bde9e3e7f23423011",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0y15jn4kysl40rgbgh68z7gy9d1g5jjhkvms6gz1jz0vql7a0izc",
-    "tree": "226070048e2c10b57bf25dca5d314722f3d1a38a",
     "url": "https://android.googlesource.com/platform/external/proguard"
   },
   "external/protobuf": {
-    "dateTime": 1625706581,
+    "dateTime": 1625626921,
     "groups": [
       "pdk"
     ],
-    "rev": "6ae1575d80e1aeedec08867ab052ea7e269759c1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b2dfd2492c59836da39e1936eef51b8a7dcd1acf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ikjv3r0yg4iffq7s13l87va3f8hhhbinp4bb37kl26wb6wdjkzx",
-    "tree": "c67f0727cec3e28530571f10eb0af02e20499476",
     "url": "https://android.googlesource.com/platform/external/protobuf"
   },
   "external/psimd": {
+    "dateTime": 1613504482,
     "groups": [
       "pdk"
     ],
-    "rev": "f446aa2917fd74781614e14af509808ffba84104",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3c44bfefbb0f99eb1d7b381a45db9acb052a7627",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rq4alzwxxvls4pb4jb02sapag63jpvijjpjh2g2gb3rxnh9kg8q",
-    "tree": "fc5a7925c288e9d559087d191bb68853f2a2fa9d",
     "url": "https://android.googlesource.com/platform/external/psimd"
   },
   "external/pthreadpool": {
+    "dateTime": 1613835472,
     "groups": [
       "pdk"
     ],
-    "rev": "3d483e97e9e65aacf47f767322e2fb4745cf50da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b6ff981f1d6fb1e1ca4d0107d84d7af17e7a7eb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ixzpaa6335mcn3sd2kqxrbfr3835fxnfrz2afdyq17h65nvx3b2",
-    "tree": "0a031ffb45338947eace1b5a83c67c16c196f968",
     "url": "https://android.googlesource.com/platform/external/pthreadpool"
   },
   "external/puffin": {
+    "dateTime": 1613834272,
     "groups": [
       "pdk"
     ],
-    "rev": "17e91a451051dd29241ca0bc6e5e858eaeb8469a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f43e9eb4403dfc960977fe533ddc8954ecb9ac97",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02jrnkqcr9jp2s6igb1nz3gbcr5zsb28x1983p5la5wq8cvykvf3",
-    "tree": "72b8f46dd035d6d0debc64ff5ba6f6146cc29daa",
     "url": "https://android.googlesource.com/platform/external/puffin"
   },
   "external/python/apitools": {
+    "dateTime": 1613934270,
     "groups": [
       "pdk"
     ],
-    "rev": "d45ebc8b3e05a1056540214a6d5aa24943adbf66",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7245ecd6abd522fccdda22be3bef16db09d89d70",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17caach33h2m4a25fwbdkfab2kmj8c5gbv3wf5zfzh84k27v18md",
-    "tree": "ff0103fb1fd73a90d84d82c1a66683bd36b8607a",
     "url": "https://android.googlesource.com/platform/external/python/apitools"
   },
   "external/python/asn1crypto": {
+    "dateTime": 1613832640,
     "groups": [
       "pdk"
     ],
-    "rev": "c0e3e71447b81bd46608b6a8bb4c95781d4544b0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3ebc4daa8e4a46e1dce2617fc0f78e166a42e4cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00a85gygijpclgdcpp6ggr9zyamxval6k6pkq5ps97c88d2av40h",
-    "tree": "29fbaba9fc6fb7ee5bb5dd7d093ca084bc00a3b0",
     "url": "https://android.googlesource.com/platform/external/python/asn1crypto"
   },
   "external/python/cffi": {
+    "dateTime": 1613934277,
     "groups": [
       "pdk"
     ],
-    "rev": "4d5ac9d38d4be9bbe2a3d0cdef2372f5fb196b35",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "31e6e50836f8a4f1e1c2aa834f1e51ced4e1797a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m4cr3zy22iahhiskp5vpn0b60rp08a368vkg4jzbkvwcap1z6ag",
-    "tree": "ee2d0182d9611b11c7d1e2229bce499e812480f3",
     "url": "https://android.googlesource.com/platform/external/python/cffi"
   },
   "external/python/cpython2": {
+    "dateTime": 1615254126,
     "groups": [
       "pdk"
     ],
-    "rev": "2a5be748e616a4c32ccf28ba7145725c12a7f439",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "735b5faef27cf08c729566d4d2a867bdfecde98e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jki6h7sgdaak46rff8iijzdcdf9phrdi5935j86595xk5a3d9vi",
-    "tree": "a585dec70bf1ab6a9316cd1b27fa8404c605af34",
     "url": "https://android.googlesource.com/platform/external/python/cpython2"
   },
   "external/python/cpython3": {
+    "dateTime": 1615252816,
     "groups": [
       "pdk"
     ],
-    "rev": "54b6a3740ec73d79b96c66119b3acbb1b3d4a320",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "71b8fd4f439edd12be14ab88ed8ba260921765d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07asjr9d3wlbphfy1l55xbvkxdilc6wzm8fhjqkmha70a7bxj7vm",
-    "tree": "9ab311e6a68903d71826396b24e91aeb47af8e3f",
     "url": "https://android.googlesource.com/platform/external/python/cpython3"
   },
   "external/python/cryptography": {
+    "dateTime": 1613934265,
     "groups": [
       "pdk"
     ],
-    "rev": "4af62e2a7b1c1ff356f8acdc5455af1ad24da9c3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5a76dc3832fb2ee39943296b74d35fcb81f1004c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10dgm0mh4ljqaj3b5wl39a2v0lgch1jcsrsxbjzx3n25alph1cpw",
-    "tree": "5021105a70589c0df99879487aa8f030760d81d7",
     "url": "https://android.googlesource.com/platform/external/python/cryptography"
   },
   "external/python/dateutil": {
+    "dateTime": 1613934273,
     "groups": [
       "pdk"
     ],
-    "rev": "8dd28602fa0f544252d2081cc4ac8cd1b2614c52",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c4829ddf97d49e997c031b422c9f67c1cbccf3e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pjs7hnd3yd3wqqacxis72jyzjcwd0f2bq967ysg8j18vzwjsx0q",
-    "tree": "93dc371f7cbb4cd8fc2d52442b0bb55e97300c0c",
     "url": "https://android.googlesource.com/platform/external/python/dateutil"
   },
   "external/python/enum34": {
+    "dateTime": 1613582536,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "9283ebb7dfa64a2e46d1a75a6ead921a68a2c70b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4bafc66ea3a0412bad85715b6143052e2d1fbe6b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xzl7iybydjfwj5wg6bmxzzmdxv6zpl6qn4w6aw0zws3mra6jhk4",
-    "tree": "f0cae81da75729a93819b488b7c7abf67998b7df",
     "url": "https://android.googlesource.com/platform/external/python/enum34"
   },
   "external/python/funcsigs": {
+    "dateTime": 1613582545,
     "groups": [
       "pdk"
     ],
-    "rev": "554f7eb93ddec0811dba50dc5f2ad13a2e6bf100",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "71b1b530420e7d71ba1f003b97271964bee7ac2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05v4kd9697gpxiyh83gsghh8c2vwc2gn9zlc9naj8k3apnc9k2j4",
-    "tree": "c0af63b824828d22b0fc978f526e31d2c8dc688b",
     "url": "https://android.googlesource.com/platform/external/python/funcsigs"
   },
   "external/python/futures": {
+    "dateTime": 1613582536,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "0a47f49212a49210b65e4bbd2999c31960e79bde",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bc38daeb69a24b91b7bf8103bd8543182ace88c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y2dviz6khx9as8kk3fq1dci62mi08yddpqfcsca79nqsfwf6rig",
-    "tree": "d3339b925f3d369af5003e6efc2b88ac462505a7",
     "url": "https://android.googlesource.com/platform/external/python/futures"
   },
   "external/python/google-api-python-client": {
+    "dateTime": 1613934264,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "9d5b5737065e4af32624ecf34a583bef9c05577a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "be4ea189ee019a20de22aeb93cc3f7185012b63a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hc7mrg2sjghznm5fysxqwq2rq8wy55rw1r66g57ripnzrn8xbqm",
-    "tree": "ebf54d8b9c222afd8d6d8c9461fa1b682df3284d",
     "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
   },
   "external/python/httplib2": {
+    "dateTime": 1613934268,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "2d14927d2b2dc891e3d9f4effaa62f939c92fec2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d70e5c374c354d0aca00d5123166afa5370f45d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jfbxrd2prjm3nv3bmwlqqwgx6iqna777ydd430ljki9dymchj4h",
-    "tree": "b977619bbbb98d1db7c5f422e9b679560e923023",
     "url": "https://android.googlesource.com/platform/external/python/httplib2"
   },
   "external/python/ipaddress": {
+    "dateTime": 1613934273,
     "groups": [
       "pdk"
     ],
-    "rev": "cc541c146d98ca6cb166c63553af0081c1a45070",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c885fcfdcc0926f66805d110871ce855b14e992b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rvld36ky44qc8yz64a5k6g52qsss96dadvsdd8yqmrx8zincd0b",
-    "tree": "994f7da7a7f4f482fcf3528bbe7ba101c62806b8",
     "url": "https://android.googlesource.com/platform/external/python/ipaddress"
   },
   "external/python/jinja": {
-    "dateTime": 1614737035,
+    "dateTime": 1614662752,
     "groups": [
       "pdk"
     ],
-    "rev": "e6ec5ec83e7b862907c951677815c9699295be0b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b4b7eaeb80ac4e7da9735ae1d1997cc3b172ff93",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0syg2yndr59f4mf3hvw6vs43fx8hf60678ky4ha2liypymazf2kf",
-    "tree": "9301db9a5406faff4cf81fc2f54ad93525725b24",
     "url": "https://android.googlesource.com/platform/external/python/jinja"
   },
   "external/python/markupsafe": {
-    "dateTime": 1614737035,
+    "dateTime": 1614663431,
     "groups": [
       "pdk"
     ],
-    "rev": "5d59935258f40d27d7e43fc4bdce7ae5a60378ca",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "588e78ab17dfd3da5cbd68ac44e72d2d65ea4c28",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18qjh0xrnc59w7divzjrriz7ppclhhlisypzlgd8b8hbd4ali3rz",
-    "tree": "e8e17f067c15766a28f4dc2bb379ba824f77d50d",
     "url": "https://android.googlesource.com/platform/external/python/markupsafe"
   },
   "external/python/mock": {
+    "dateTime": 1613934273,
     "groups": [
       "pdk"
     ],
-    "rev": "25b6f2b8ab8e9f68fd878658ef0f6cfc69eb7b0a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c7ecb5d681f2a1a7c3af31e1db86c7fc00482b48",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1c8fbmxnl0h00dnwqywba008lm6bs8zrmvhagnp7gpr84if60gr7",
-    "tree": "33748269e3bac6ecc26d25ef67785d5139a37e63",
     "url": "https://android.googlesource.com/platform/external/python/mock"
   },
   "external/python/oauth2client": {
+    "dateTime": 1613934275,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "173110ca5a9f98714593e63853c42a9d97dda63f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8c31ee8ba8a4dcaa070906cbc6f1e1e09785e5fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0snxs8dzmx5farizh7dk6kyw3pnw9dwq4lgjf55pz57zdw4w5h7c",
-    "tree": "02b48942983026efaa429875f2dba10e6c88dd32",
     "url": "https://android.googlesource.com/platform/external/python/oauth2client"
   },
   "external/python/parse_type": {
+    "dateTime": 1613934278,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "70d573f6310f68d27179c230e505b7298d86c34b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "eebfe042b753b24c1e55e8d97ca7635c3217ecc6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jl9ij257zg68c3vbb8wnkpl9cqyr0k115374hh0xwl86cc38x5x",
-    "tree": "ab8818fc180867e28ab5658ea201e2b713fc143c",
     "url": "https://android.googlesource.com/platform/external/python/parse_type"
   },
   "external/python/pyasn1": {
+    "dateTime": 1613934270,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "22817368f221e864e757590bcf38b18ec05934c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b297b6125a0b3b9944b0f683cdf68f7e266771d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0m5fjmifgskidmbvnnq4rvbqkwzkdmvhpi7pya6b58s3cwmrwc7x",
-    "tree": "5318a90167704a21b695cb23b3cde0f9bb219900",
     "url": "https://android.googlesource.com/platform/external/python/pyasn1"
   },
   "external/python/pyasn1-modules": {
+    "dateTime": 1613934265,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "e67e2ddcbfeb0a9de35aece0a92f4cdc606adc0d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6d264d9fc12b94d305c1c17a11ec9ad043f114d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0n7isv62gq7h7i605p3lpkp67hqdbmcnmzzv30jr2m0g8bb52fjr",
-    "tree": "0112f0dbbb6d332f757d6c9deee9c9529c794771",
     "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
   },
   "external/python/pybind11": {
+    "dateTime": 1613582540,
     "groups": [
       "pdk"
     ],
-    "rev": "75bc51c3ad4f171aeee68028fb44612549e5a546",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "de5dcc88c433df119f3e066585df6f7452a5d8c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r4s6cadrw8g60zhq9nh2cyzvbc52w1amj4ydp5apz2z4hz24fmf",
-    "tree": "c22ff54a72357f1e127dc6af3aa83c7f7306b6d7",
     "url": "https://android.googlesource.com/platform/external/python/pybind11"
   },
   "external/python/pycparser": {
+    "dateTime": 1613582546,
     "groups": [
       "pdk"
     ],
-    "rev": "5da532751602c06f511898a79fce35f75ff3095d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "65d708b4cc4a66b2dbb52ee4c68435b629de5852",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "120qdb67ag3yy0cgwdxijjc32s54irpvyid8dgmkd4jdl3jii7ry",
-    "tree": "88b0e3cf201d693022d426fb483dec59a8a27b06",
     "url": "https://android.googlesource.com/platform/external/python/pycparser"
   },
   "external/python/pyfakefs": {
+    "dateTime": 1613934271,
     "groups": [
       "pdk"
     ],
-    "rev": "562d198ba3a6ef81f04498f155170909acbb978b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "80ee2ec0a73d5da1ddd0c72a58eb2fedc6c5d623",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jw07iqzrjac1p3vfs3r2g0lg4nsfqxxi6vkk67as939ggkas836",
-    "tree": "b302880b9860a99a7439112e17985aeaf6326335",
     "url": "https://android.googlesource.com/platform/external/python/pyfakefs"
   },
   "external/python/pyopenssl": {
+    "dateTime": 1613834234,
     "groups": [
       "pdk"
     ],
-    "rev": "c3f6d79199d12dbc206354bd56998709e8aedcc6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4e19c452d036d4dfbfcaebd148864b0872a0d34f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0h50kdfwm9wp4c6vyhf34p3lirz0r69dckdm6hjw45h4piqafdwf",
-    "tree": "4195657bf56b22ecb695311439478db9c13822b8",
     "url": "https://android.googlesource.com/platform/external/python/pyopenssl"
   },
   "external/python/rsa": {
+    "dateTime": 1613934472,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "d4b715e97e94a91eb5dcdc773b839710521c389e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "712dcbd5c410ce46977d1fb94c0fcc08b00562ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x7jflip5dcbxd4z9ax3pzlqd0lw1dmgbjjffrrrjbq3ms5vg88v",
-    "tree": "fe1e4af20b56b0cfd0b77c2e3d7a8fd11b41a1fe",
     "url": "https://android.googlesource.com/platform/external/python/rsa"
   },
   "external/python/setuptools": {
+    "dateTime": 1613582545,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "fa01838327bbb5a399ae0ac4b05676cc6e2db0b0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f76ef766004d7f957067f3c80687482275d43e47",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ypsmnmng16c8sqx8g3nsiybw7qfxyykpd74i1nqkx0x8qdfs9pi",
-    "tree": "50ac4be42d5d5d613782e8b97998d856b2a4b85e",
     "url": "https://android.googlesource.com/platform/external/python/setuptools"
   },
   "external/python/six": {
+    "dateTime": 1613582546,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "5600bf354320d86e16ecc8109346fe69392decd5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "742a35d89132afc6ffb4b89452eed847bbe2cff5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j9sx6jph7hz7axrmrmd2wpyvlp8d1gn16ph94vnwcm3izx9a7vr",
-    "tree": "6c2abc200c227597d4fac93edaea6674cfb41673",
     "url": "https://android.googlesource.com/platform/external/python/six"
   },
   "external/python/uritemplates": {
+    "dateTime": 1613582540,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "d64a70792c9f85dc7aba2f4a3e6ff7e05ce0836e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ef5dc04bb2c49485bfc6228dbde42def61a6c1f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mzkgmy5lxgsbd1az98lvqz50z12l862zgqhrak5jvmgxy33asm5",
-    "tree": "b51bf96a5584f2b7e46a8f1bac35dd64e9b36ed2",
     "url": "https://android.googlesource.com/platform/external/python/uritemplates"
   },
   "external/rappor": {
+    "dateTime": 1613591031,
     "groups": [
       "pdk"
     ],
-    "rev": "4746c310ab6ad71e4ca52ba95172d97d81110ad3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "138ce469d5dd30dc6ed74afaa675df9911339500",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0k2pwhs721qh0h3x77z9jzl9vww7gvfdqf9ypxlgia2mha9m2y97",
-    "tree": "64f402d10e4c15382a80284407bd56e01692a250",
     "url": "https://android.googlesource.com/platform/external/rappor"
   },
   "external/replicaisland": {
-    "dateTime": 1613531788,
+    "dateTime": 1613504475,
     "groups": [
       "pdk"
     ],
-    "rev": "279721857fa48fc92381ff174b3c9947067d8eec",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b475754e40212a60f13956d617a39aad02578e67",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16bi4iv9ya7ylwhf4qm7rnymzzcl6wjl68rrrjqrsp9my28h4mrx",
-    "tree": "d519826c0676ac004f98ff2c794f2bd0b57d7902",
     "url": "https://android.googlesource.com/platform/external/replicaisland"
   },
   "external/rmi4utils": {
-    "dateTime": 1619838309,
+    "dateTime": 1619753674,
     "groups": [
       "pdk"
     ],
-    "rev": "d280115ea835394c7360ea95d1b92fb471a220f8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff530931a4b6d48a8f7b08d2bd0537b130bbf189",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lwxkzw2xl6mssvzivzgrnn3wmxkpbm9r3hpd0iif8124ha02zq1",
-    "tree": "e41ffd529be9c380ae237650e3818e86a67d0abe",
     "url": "https://android.googlesource.com/platform/external/rmi4utils"
   },
   "external/rnnoise": {
+    "dateTime": 1613828074,
     "groups": [
       "pdk"
     ],
-    "rev": "fc5a329acef4e20cd723ad789cbbcf5437aa9932",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9f9cd9cbce2b7d366c0fe89726e7b6debf7d6804",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1flgs86w4k7vrrq7mh962rf7y2vxnzfwsd12hpa44375rc06lrm1",
-    "tree": "fd4fed1c0133decab06843bd0f98b7326cd760d6",
     "url": "https://android.googlesource.com/platform/external/rnnoise"
   },
   "external/robolectric-shadows": {
-    "dateTime": 1622768715,
+    "dateTime": 1631203424,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "c78c7369703f5a0b36bb0f908c929efa84e52b94",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "36d93a2f87bd9d540b53a437148372fdd1911def",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p96ghpc1ffq7mk4k81y346h2ky1x87mnv80c359mvl71ip1ai1b",
-    "tree": "379110a63dc18cab24c0f5f3f2f99401c60b8b5c",
     "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
   },
   "external/roboto-fonts": {
-    "dateTime": 1623200730,
+    "dateTime": 1621977525,
     "groups": [
       "pdk"
     ],
-    "rev": "d5ef452b19f484be074db15280e44ff50e4a2af6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "819e55c583cc01fda911c8ecaa696521c170a4b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ygzmkkp1nj8c4spq3rgbdjx40vgmhkivkywikrab3wp3c469lw4",
-    "tree": "32ab9ea9264135ec9f89e54e41a6bea9e8717ba2",
     "url": "https://android.googlesource.com/platform/external/roboto-fonts"
   },
   "external/rootdev": {
+    "dateTime": 1613582548,
     "groups": [
       "pdk"
     ],
-    "rev": "9fe710f6f83410791358131a2493dec1647f3854",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b6d8821375fad1ac73042655b543ae71dcfdb387",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kyqrr4lavpbqz47ajvf03vylgxs72l1nhxkx93hpl52w1kyqih7",
-    "tree": "32b31bc5033b70bcd21dab5291d47bbd4e36f0ed",
     "url": "https://android.googlesource.com/platform/external/rootdev"
   },
   "external/rust/crates/ahash": {
-    "dateTime": 1619233495,
+    "dateTime": 1619214482,
     "groups": [
       "pdk"
     ],
-    "rev": "4a70f0d22aeb0d03c33c20aa2edda4d908e7276c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "eaf747cb5767d348d66f6ea7c1513f2d9a8358a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hq34bv8dhqq4dh16bqlv49fsszfp1y08llsycpv8wwxhjwjbc1f",
-    "tree": "e2e393cd7adb04f018f30c8a34836270d7421276",
     "url": "https://android.googlesource.com/platform/external/rust/crates/ahash"
   },
   "external/rust/crates/aho-corasick": {
+    "dateTime": 1613834112,
     "groups": [
       "pdk"
     ],
-    "rev": "55e12b6fe7a352cd31dd4e6faf0930663b3dd033",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "aa8c618a2ef09173ea82c890e77441d2f8a326e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pjnv2f5g34fd8qrzdkhqi9fz1x5mrcg4539gjrkr3kfrwbxsnb4",
-    "tree": "067bd8d88a42cf1cba9aef1e69cfd2faacd3e0e9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/aho-corasick"
   },
   "external/rust/crates/android_log-sys": {
-    "dateTime": 1620867918,
+    "dateTime": 1620818112,
     "groups": [
       "pdk"
     ],
-    "rev": "6cd08ebec75c1a20e1ae75684f90d9355fcf3766",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6b34665f1ba0bf6162ad6d12abe8d16c0285969a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1j5zn9ckhs1l9n8wgq1j5r4ahk7z5wny7idxqg5zlpf4nn0m6kr3",
-    "tree": "77bb7a1a67ab1b11c1f1612694b5e424e3e78d5d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/android_log-sys"
   },
   "external/rust/crates/android_logger": {
-    "dateTime": 1620867917,
+    "dateTime": 1620820365,
     "groups": [
       "pdk"
     ],
-    "rev": "ab873adc9a4b244a198ae8a7a0f0c25fc6d9985b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a23af341934244fb26f9f31c1f8e4117b9b14eed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xvwcn8dy0nas0kx33k8hhxvirkngyd8rn5d37bl07xr8lnqw82y",
-    "tree": "01432fdf137ba521d2106ea865a50954da41d5ae",
     "url": "https://android.googlesource.com/platform/external/rust/crates/android_logger"
   },
   "external/rust/crates/anyhow": {
-    "dateTime": 1620867918,
+    "dateTime": 1620819446,
     "groups": [
       "pdk"
     ],
-    "rev": "9ac1ff1581d3618b06eae3325062ae55c9abfad9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "825f0b9db9b370fb5b7fb1761c48b770a754a084",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xp7kx5x6kfi6ginshvg605h5zg3x2hldjfr36y4y5qj899039av",
-    "tree": "7f2a61c0777d7dfa833c17d02e20b094a121a63f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/anyhow"
   },
   "external/rust/crates/arbitrary": {
-    "dateTime": 1617757482,
+    "dateTime": 1617719150,
     "groups": [
       "pdk"
     ],
-    "rev": "f16380bfc3a6c48ac37c8b84974c172f6ea54b26",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "465ec3dd77631bf35e30a72023e1d867bb2d8325",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zw3zrfzlwaidbzsl0d166jpmi2hywk1gfjrs2b9wr2dln61dg2k",
-    "tree": "dca177db23ee93c5942c4b6c35f44c4edc00271f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/arbitrary"
   },
   "external/rust/crates/async-stream": {
+    "dateTime": 1614577053,
     "groups": [
       "pdk"
     ],
-    "rev": "b595c5b8fb0a9a286c44c44220e789201bd9affd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f88c063d656a7903697f725feadb9dc969bb4beb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1s0h4zsr8bkygz1d4i78cp5897yvm0bz5iaffbph53n1gryh8ddf",
-    "tree": "c7cbe988b0a96fa0391216d9d311bba201d37564",
     "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream"
   },
   "external/rust/crates/async-stream-impl": {
+    "dateTime": 1614577053,
     "groups": [
       "pdk"
     ],
-    "rev": "38124c2829daff51d5352a887064c76159427d1b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cf624248e30452fe0913f28579345c33798ede72",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d30bmadkkr0hjly1033l7f3jr0bl1a30q8sdz1l58nx93c2sayp",
-    "tree": "6311ae1a2128d46d1c3a9aa1ded2688ac3a067e3",
     "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream-impl"
   },
   "external/rust/crates/async-task": {
+    "dateTime": 1621014737,
     "groups": [
       "pdk"
     ],
-    "rev": "281f488a722508ae57b921bfa92b57717e0b9da8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bef9bab47cc75d1285bf7dfbf0d1513eeceb09ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1a0j7nxi30zng0i6q2dkqqkg70a8bxgbspl3pflv98bsxjhcnc19",
-    "tree": "a3acf4ff2edd7c51a897225a12fa5a5290aaa408",
     "url": "https://android.googlesource.com/platform/external/rust/crates/async-task"
   },
   "external/rust/crates/async-trait": {
+    "dateTime": 1619027637,
     "groups": [
       "pdk"
     ],
-    "rev": "4a3d43c0086e743abaa7e0356df5b42e48e2e372",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0905ff1c17d89586e0eda3e41a9a9e9c9f37a5c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rfbqsx81bhz1arfgzgql5kggqgfqq13yc65h69k44z91lq18227",
-    "tree": "9739f4bea3e54934e235716a483b610f81d2504b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/async-trait"
   },
   "external/rust/crates/atty": {
+    "dateTime": 1616512499,
     "groups": [
       "pdk"
     ],
-    "rev": "755dd2d6d6b0c5b58fa6bccbac3b29fe8e293b94",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "80697a14738a31b22867e7ff30b5976297fe930e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ypvk3r03x00sq5qxd7c358049mzv2f0z364zkj2lr15yakp40f0",
-    "tree": "505dc9520d1851452ff862429424cff9418e96d0",
     "url": "https://android.googlesource.com/platform/external/rust/crates/atty"
   },
   "external/rust/crates/bencher": {
+    "dateTime": 1613587987,
     "groups": [
       "pdk"
     ],
-    "rev": "67c4fbb25eaeffd79eff9975b910b0e4f7364180",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bb7f2d77e55ebcc72aeb96828aba76bef289fb2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d7skrpb2ipsqlcdsrl46cgdf8q7jf8bv5izmxd6cnw733zf5sv3",
-    "tree": "8f7e9d0f7caa4b382159fa8c8c9caf1d1f58af51",
     "url": "https://android.googlesource.com/platform/external/rust/crates/bencher"
   },
   "external/rust/crates/bindgen": {
-    "dateTime": 1618880713,
+    "dateTime": 1618845744,
     "groups": [
       "pdk"
     ],
-    "rev": "0b927d412130dfed53d3adfb8b2f5a35ed70c381",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "42d165e000830486bc4cee6976d5cd0681c777b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "185wjwx64ldpyk4y3w67jjqd8q54pgy34pi0cif198zk6wjz0v11",
-    "tree": "194e88a2399cee0d737c1a4b2106ed6d8ca3a602",
     "url": "https://android.googlesource.com/platform/external/rust/crates/bindgen"
   },
   "external/rust/crates/bitflags": {
-    "dateTime": 1619744768,
+    "dateTime": 1619647840,
     "groups": [
       "pdk"
     ],
-    "rev": "ebe75b8819996cb0b1ab51a70b52df86ab82e38f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e2f52d4c035046d2509bda6f73565070e731aa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ahjp9jmjwm6gm9wgfi4znwvpjpyfkyixk9pjrkx88v7d5c3jmdj",
-    "tree": "79f389b1c65ee3eae9d26f714053ca0f19be4752",
     "url": "https://android.googlesource.com/platform/external/rust/crates/bitflags"
   },
   "external/rust/crates/bstr": {
-    "dateTime": 1617419063,
+    "dateTime": 1617385032,
     "groups": [
       "pdk"
     ],
-    "rev": "b1f787512e6c7557d92706b9838eaca18dda7a78",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e0f0f525d6fbfe4705f936229440e91bc7544a6a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sri0n70g1iak5831zqmkh00w90kk3g70cypy86g4zpzpafyl250",
-    "tree": "f115e489fc4c165ec9a575b2f69de53585b2f571",
     "url": "https://android.googlesource.com/platform/external/rust/crates/bstr"
   },
   "external/rust/crates/byteorder": {
-    "dateTime": 1617419064,
+    "dateTime": 1617385051,
     "groups": [
       "pdk"
     ],
-    "rev": "023de4c406015a91d755260b37754fda865a428a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1eb52397318f093e26f8d969b0be543c198bb0ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z56bdlmm8jf5bvb88ddk95b386xlc6hdaczm530jrzi07r77xjp",
-    "tree": "c73b9c36b54c610427128761545e6fb08eff13d2",
     "url": "https://android.googlesource.com/platform/external/rust/crates/byteorder"
   },
   "external/rust/crates/bytes": {
+    "dateTime": 1620818125,
     "groups": [
       "pdk"
     ],
-    "rev": "47837c9568b2f1acba121b2309fbaaade941f5d5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f10d955e2243701d96939aef13909110784a1370",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f7g96awyhi3sj71rbllbsq9c64j228r2g4wabnncrl99clma441",
-    "tree": "b542d91c6067bc477d8e7c59882c3e7db2a7ce25",
     "url": "https://android.googlesource.com/platform/external/rust/crates/bytes"
   },
   "external/rust/crates/cast": {
+    "dateTime": 1616512500,
     "groups": [
       "pdk"
     ],
-    "rev": "e9593abb0cd75ac29c11159c2267a8948f72fe69",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "efe4f9d6764f07b8afd83fbb335a47625264b97e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17c2z30zxyfqni9b9j1778xxjc1lvrhafhzlaw6jajp9a6kwn61r",
-    "tree": "9348b0e0d4617d9e3bf58aff6a2a2d0db3e56b29",
     "url": "https://android.googlesource.com/platform/external/rust/crates/cast"
   },
   "external/rust/crates/cexpr": {
+    "dateTime": 1613815682,
     "groups": [
       "pdk"
     ],
-    "rev": "4834f35036628891575a326c1ee633f1f15a16f2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b43d851c3dca9473c607eafa2cbaedf2b9a7ef7d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xq9rrmn61yjwzjv61zad20b5irsznvz5w8c7pn5hnjw83aa64ac",
-    "tree": "3499aa8558094da40037a517b111c2efd6ea6847",
     "url": "https://android.googlesource.com/platform/external/rust/crates/cexpr"
   },
   "external/rust/crates/cfg-if": {
-    "dateTime": 1619744770,
+    "dateTime": 1619647842,
     "groups": [
       "pdk"
     ],
-    "rev": "975e7281d58239ff011ba8da5ec96cbfd3a13eeb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "70945680e8e37350beb1fc9d3c206d9e63cfd7ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08666bjm2z2hagfmwbhy7nxa00fprq4dbv1si5slhi6mlkmhhxf3",
-    "tree": "18fc2dad0caf21a0589f5e2622ba8c4e83b6031f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/cfg-if"
   },
   "external/rust/crates/chrono": {
+    "dateTime": 1613587992,
     "groups": [
       "pdk"
     ],
-    "rev": "8d2e4fb7b2818f9716f08c79e94f89cc74b80f14",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ad3c9d62917a3aeaa681d35ea534da1f95fe0cb5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x8si59fb4z6xpmn5kg48lamfx76s76vd443pl0qgc37jcdxx0wy",
-    "tree": "c95ebaefb1e97f6660f1aa95084efabbf06b515b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/chrono"
   },
   "external/rust/crates/clang-sys": {
+    "dateTime": 1614577077,
     "groups": [
       "pdk"
     ],
-    "rev": "738faf821f86dd083a27ca35af39f6b59590aacf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "23997cbdbebf8b27a6bda275da2722821cd14264",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "15x52kc16ak83l3l08x0crp2rk5x594bj6jkqbjkkws4728d14xa",
-    "tree": "d5e2f7181bd9c53349fc833a43987aacbb1a721f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/clang-sys"
   },
   "external/rust/crates/clap": {
-    "dateTime": 1619744772,
+    "dateTime": 1619647841,
     "groups": [
       "pdk"
     ],
-    "rev": "2962d6eb5cb4a3b51d84a52a2e8c99ae6b83d7d3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a80451c8482e6e880c6fc04f5111372b96c16bae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wwiss20xa3x2dxznfglzrkb36v0x38c651dbhl9h15swjirwqf4",
-    "tree": "1c1e122603b15be120f3543d316e8ef57b8b4420",
     "url": "https://android.googlesource.com/platform/external/rust/crates/clap"
   },
   "external/rust/crates/codespan-reporting": {
+    "dateTime": 1617345393,
     "groups": [
       "pdk"
     ],
-    "rev": "b3950f1791c0057f7e3503ea3cd2c05ffbdfb247",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9c3d67fec2f90f974af73a2470b970c716824293",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zsiq4anwyv212zznq8cm32rcigvf5xjvn817zav4pmwnq0gjqci",
-    "tree": "89ab9e60d48848bb5acb8f454042572d52c45f54",
     "url": "https://android.googlesource.com/platform/external/rust/crates/codespan-reporting"
   },
   "external/rust/crates/crc32fast": {
+    "dateTime": 1614631699,
     "groups": [
       "pdk"
     ],
-    "rev": "4d8549922a8c13ccb614ea75bf12f4b278b7d070",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bed02bdbdf380cb56bc2a94e2443a97af385db8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0w1knl6nfgsbvf7syqayrs86hlqvx16giyg9pmi2gqvf03b1dfqg",
-    "tree": "9b2cbd69510a7efd07a471b995ac5f099c2c6904",
     "url": "https://android.googlesource.com/platform/external/rust/crates/crc32fast"
   },
   "external/rust/crates/criterion": {
+    "dateTime": 1618268703,
     "groups": [
       "pdk"
     ],
-    "rev": "397b98e916713ce3cf23c6a8dfca6e183cc7a7ce",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b9242a02c4f576177f11687957347c70f87012e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rv1c32p524j7v0cn0lhin8g1qy0v8nnnn7670ak6w3vb3lvxb12",
-    "tree": "305abc2cbce5f7faefdcb154d24bfeb5eeb18ec0",
     "url": "https://android.googlesource.com/platform/external/rust/crates/criterion"
   },
   "external/rust/crates/criterion-plot": {
+    "dateTime": 1616512495,
     "groups": [
       "pdk"
     ],
-    "rev": "1ac641032cc81a2c880593b9db196be659d9de8a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d1e2a7c9d6613e6a7916bf28523e79875b14e080",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0a72appa3mnq7rjpv4q3kpnmrbmvv3hrk14yai12qbzw72v08syg",
-    "tree": "45d6aad7209cf21b60af88ad59cb38f9966e9b64",
     "url": "https://android.googlesource.com/platform/external/rust/crates/criterion-plot"
   },
   "external/rust/crates/crossbeam-channel": {
+    "dateTime": 1616512498,
     "groups": [
       "pdk"
     ],
-    "rev": "a05bb3fbc1371a5f4ddeacb250688c0a4ea1a09c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c083e029baaf7c663c80ddc88ad0a5ec5a2594d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nj6qicjbdkdrkycc43fgg0w7gyskmy3ahl6r9zhsb0dpqhys6c7",
-    "tree": "fd1908ce800fdc636ba92341b0ddc56efce57d9f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-channel"
   },
   "external/rust/crates/crossbeam-deque": {
+    "dateTime": 1616512501,
     "groups": [
       "pdk"
     ],
-    "rev": "f8fdfddf9d4acfbe77fe913439dbc50352a01991",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4d9e45eb26463d772f166ffd992949c1344df454",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q88z0w823ap29c1qv6fqy9bmgvb82zs836332hpka1lbrfw0c0k",
-    "tree": "048a394b1b0781fc24475e632c353d36a982f439",
     "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-deque"
   },
   "external/rust/crates/crossbeam-epoch": {
-    "dateTime": 1617930310,
+    "dateTime": 1617898941,
     "groups": [
       "pdk"
     ],
-    "rev": "38542cd612f32279a8130e11a2b111268328695b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ef84a7c629e7af669d5412fd2d112d26dfb90057",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gwdzc4f1p0ch46zbfdbmrk59mg9848nj1acas9x91xcrn447j77",
-    "tree": "b2f6376d7ac86207929c4a9b338b4313e06a8585",
     "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-epoch"
   },
   "external/rust/crates/crossbeam-utils": {
-    "dateTime": 1618880723,
+    "dateTime": 1618819104,
     "groups": [
       "pdk"
     ],
-    "rev": "5ee58f871eb9c3b284b0bf965a92e764ed24ff68",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7dec3d9d191ebada7ccd966c4785b9ad9b88c281",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0n97x42nmc8mmwraz879ld6nqdgsq613wiahq066w5j8jvsn1ll6",
-    "tree": "daaf08af737e70ccff84d0af339162a544fead0a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-utils"
   },
   "external/rust/crates/csv": {
+    "dateTime": 1617385069,
     "groups": [
       "pdk"
     ],
-    "rev": "9488f41cf19230f6536633c83fdb948027d5bf56",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3762be60d7e7c5f9d5af000e06508da562152a46",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10z3nh974sckbcfdxw8ah7h8mxvx1c6mfcjvcfr6pw8vzbq84mdc",
-    "tree": "b896b61a088e21510b50d6937f858254dc4beff5",
     "url": "https://android.googlesource.com/platform/external/rust/crates/csv"
   },
   "external/rust/crates/csv-core": {
+    "dateTime": 1616512500,
     "groups": [
       "pdk"
     ],
-    "rev": "0dfcd6a839bd32ff630cee897fe62b5db1581a67",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c3920c720c5369f821b9f886d94f9d4092ece621",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y6kq025hkpl5yl4vakqd3h08ipbx15n2yayvw654k3vwl9290da",
-    "tree": "14c820bbcafd38ae9b23cf34dfb45f0ebdb1dde6",
     "url": "https://android.googlesource.com/platform/external/rust/crates/csv-core"
   },
   "external/rust/crates/derive_arbitrary": {
-    "dateTime": 1617419073,
+    "dateTime": 1617345405,
     "groups": [
       "pdk"
     ],
-    "rev": "f5cdabf39847bde598f45bbd381d176df7906caa",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "172c12e405368a2c7aee2b8b2eaa5c3383981a34",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d83srj03644dvy59r5612779gcp8g9dj3r6c1gf7c03vlfpdm8k",
-    "tree": "e00f7efab9f4fff7f4bb24bd4ca0ef7e0472662f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/derive_arbitrary"
   },
   "external/rust/crates/downcast-rs": {
+    "dateTime": 1619647848,
     "groups": [
       "pdk"
     ],
-    "rev": "43f82ac62b4637e758cebbb04fc80eadb71b61af",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "07cf2119b18a9a2be8cc5646783945bd277311d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1325khrkxyr04bzypvdf44azyq5fvbgf3rxxygyfwx8567vyjhcg",
-    "tree": "1bfb5c3bad55986b16c190ba08073be6d4a2b4cb",
     "url": "https://android.googlesource.com/platform/external/rust/crates/downcast-rs"
   },
   "external/rust/crates/either": {
+    "dateTime": 1616512495,
     "groups": [
       "pdk"
     ],
-    "rev": "bf413ed490bb68e538b42e9e6bfeed7bb09c1aa4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b724317f5039307e95e04336f42d509ea9646842",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jbnwc9iiiyyyf5pa425ysnjv14awhpzylc1f65xiw4zg16l8d6l",
-    "tree": "87b6e8aa359d043ec29e66cb372f3a594dd14a55",
     "url": "https://android.googlesource.com/platform/external/rust/crates/either"
   },
   "external/rust/crates/env_logger": {
-    "dateTime": 1620867954,
+    "dateTime": 1620818082,
     "groups": [
       "pdk"
     ],
-    "rev": "bd2a7d361b783db889f0e929911c007501e778a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e43227a56990e590b5e33f7b92f578d71c42d28",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j8s6pp9l87lpj5cx73cqkwsbxgza1hjv376h35sdf5zznv8gp1a",
-    "tree": "eef2ec65079ff67e3a48633154e928e560e9b8c1",
     "url": "https://android.googlesource.com/platform/external/rust/crates/env_logger"
   },
   "external/rust/crates/fallible-iterator": {
+    "dateTime": 1613821539,
     "groups": [
       "pdk"
     ],
-    "rev": "109f84ba2943af0eb6851645d7276e4e3c73e514",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0fa4e5fc9c5bc9521bf1d01d825b29df6fffb6f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wwq8gzcwmwn8nd25m0p7s165d2fpm3gd0bh5qvacca5krdwbapx",
-    "tree": "40756bb27f22283893d91b3ed958a615ffb63589",
     "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-iterator"
   },
   "external/rust/crates/fallible-streaming-iterator": {
+    "dateTime": 1613821447,
     "groups": [
       "pdk"
     ],
-    "rev": "1e9c9542f44976a2f6bbd3d01313bacdd2a25042",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e6aac860ea74d8ac5ecbebc40f74e3689a4190b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0934fiwj33yqkyya8fxlbkwncpm1p48xcvs4058nc8xz92jxms59",
-    "tree": "df662fed7d99ed2b633e9438ecbe874ce6c61cfc",
     "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-streaming-iterator"
   },
   "external/rust/crates/flate2": {
-    "dateTime": 1621991165,
+    "dateTime": 1621898069,
     "groups": [
       "pdk"
     ],
-    "rev": "a75ba00500fab3a736c2f4933e7ec117918279fc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4a6712c40c100dcc796705be3583aaec33009653",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1j5kchixqzs9axz3k0k27mp7bwayjln4xks52r59rmzp1vxnld0q",
-    "tree": "0ed9500851d7548799d42a2971e53738c825ff6a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/flate2"
   },
   "external/rust/crates/fnv": {
+    "dateTime": 1613829189,
     "groups": [
       "pdk"
     ],
-    "rev": "4de8c66c4a7cdbf9222af85e8085d8d6904cf557",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "003e24de6b3b3e41378e5b76cc902317988331a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "176wqsijl9f64scdjgj92r1q4l9bb96s2wapsgj6ldg5d4sh04q7",
-    "tree": "6dbbba641a2d90f06fdc582379a9d43be23e930f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/fnv"
   },
   "external/rust/crates/form_urlencoded": {
+    "dateTime": 1619647848,
     "groups": [
       "pdk"
     ],
-    "rev": "5af62a49fa0e7e56765a7b1aa964eb58c0516811",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b5b5e795707ce6feb89beb8d869146ad2bd102a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bm74vin0rx5h0ihgzg258ihkxvmx2dsrac7wj76y8xgj99x2k0z",
-    "tree": "4297b239b54575afe47bb731eb0e534b35425af6",
     "url": "https://android.googlesource.com/platform/external/rust/crates/form_urlencoded"
   },
   "external/rust/crates/futures": {
-    "dateTime": 1619744780,
+    "dateTime": 1619647848,
     "groups": [
       "pdk"
     ],
-    "rev": "4d7b9f0db9674947e64170255b5083dd7bfe0698",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dc08b4f8ae97e3a085571bbe4642a0b6f3715525",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0d0w7s3rbb90x8y6sxzg22cqqlfy2zabcbbzyllq40dazg5f0rzi",
-    "tree": "8b6893cf49a6d131db38944751abec54b1105e6d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures"
   },
   "external/rust/crates/futures-channel": {
-    "dateTime": 1619744781,
+    "dateTime": 1619647846,
     "groups": [
       "pdk"
     ],
-    "rev": "bfcd56412c51ba677b0855bb45de0de14e58f938",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "435eedfac831e67bfb0b4bc32f577a29fafa929a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mjrc60cjhkfx1s4qzd7xjwb44wfff41p1vh1l2ibvmq3f80z15a",
-    "tree": "e6f627a343a242df90b3dd569500d6b6ca938fd8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-channel"
   },
   "external/rust/crates/futures-core": {
-    "dateTime": 1619744781,
+    "dateTime": 1619647842,
     "groups": [
       "pdk"
     ],
-    "rev": "ee913e58d1f6d6f6f0246366d098b81c0b365021",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "821151551ba25c35fe7cc46cec66402bd66b31b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07fp7v1lcln8v4ajyafq71s80z0904i5xrmn5zqn4mv4q1az1r8v",
-    "tree": "d565c719f12061222647889c560594307a4af3c9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-core"
   },
   "external/rust/crates/futures-executor": {
-    "dateTime": 1619744781,
+    "dateTime": 1619647850,
     "groups": [
       "pdk"
     ],
-    "rev": "c6c254a715cea149300d592b43211f0df0b93735",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cd67735be90a0263177d696657dfca4e5c41c2ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0myqw6i9ckl72hdb1yklxjn1ay4zs81pflshy5p8336lqfw7v7ly",
-    "tree": "7438235c8339c95bbe4ca7466d8e0bf43e80aa6f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-executor"
   },
   "external/rust/crates/futures-io": {
-    "dateTime": 1619744782,
+    "dateTime": 1619647850,
     "groups": [
       "pdk"
     ],
-    "rev": "a3334bb185ba5a5ff5acf61b0c24eb9f9b183fb4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "15baf73f5a00b0cb608b723ed92f044df2aead9d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d573cpchcpahlcbgfjkmqj1mdlbn70p2yxhzzgnna6a931h358c",
-    "tree": "6f836c829a9a6efeff9c0bf12af5d96d86331353",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-io"
   },
   "external/rust/crates/futures-macro": {
-    "dateTime": 1617419078,
+    "dateTime": 1617385035,
     "groups": [
       "pdk"
     ],
-    "rev": "4d6b365b4b7954c0636e2f5f32688a70b503e0ff",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9f92236882d3ad3e17e2581851c30aae20bcf0d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p5z0scaqqsngwgwgrmy1m1dzavalj8al9566q48pnrsj6xr8lbc",
-    "tree": "a824d9c34c1b085db872226d38a844536a99d1d8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-macro"
   },
   "external/rust/crates/futures-sink": {
-    "dateTime": 1619744783,
+    "dateTime": 1619647844,
     "groups": [
       "pdk"
     ],
-    "rev": "2b3062ac1fd2270d94483daebaecdf3c972451dd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "84b146528059ab2a5b1bda18ca978a65d88da1bd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sm91gkcaif1qgalfv8pakak3jaf6x9ryy63w9hcb6vv1rj599k8",
-    "tree": "da2c1c8ccc04febb2db96fb78408a2f1335d4656",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-sink"
   },
   "external/rust/crates/futures-task": {
-    "dateTime": 1620954321,
+    "dateTime": 1620937860,
     "groups": [
       "pdk"
     ],
-    "rev": "cd877699c056c61b37484d67c43284db042412f6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1f357518d48737becd8c8c0ef3ea89377ba8be12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19p56hy20hrs8b1pd1ba6cpnhf3pcbpy1vz5hqsrnzhca1yb7mfr",
-    "tree": "861fe62b38ffb72f976272d5359f8992a06366c9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-task"
   },
   "external/rust/crates/futures-util": {
-    "dateTime": 1619744783,
+    "dateTime": 1619647845,
     "groups": [
       "pdk"
     ],
-    "rev": "1cd6783fb34027f71b88c43fc41d87f43957df9c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "86465087a6b412a7ddb8a1ffdfe59ec6a124d4bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v5rpkakmi3yqakzwmyn3n9dvla3phwjq2y1h5rn7qm8ymvkfgk9",
-    "tree": "893295c925ce2ed08dd855e1b29f9b9b48bfd701",
     "url": "https://android.googlesource.com/platform/external/rust/crates/futures-util"
   },
   "external/rust/crates/gdbstub": {
+    "dateTime": 1617399235,
     "groups": [
       "pdk"
     ],
-    "rev": "b414ab337148ccef5669b6f6b40c8ae76fea3769",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "61a2a6ffb4d35b30e251ddfe0ee660f7d1cf5523",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05s1b54bwl1fa4hgh9kr4ip8513vccg8bppbkpfqcjqlr68nh31y",
-    "tree": "1500d46718fb1a9b7a31aedf6a4f3aa7d68b849d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub"
   },
   "external/rust/crates/getrandom": {
+    "dateTime": 1616512495,
     "groups": [
       "pdk"
     ],
-    "rev": "25752137d4f70d081fa5eac98ef85f8b0d14e4cc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "50fc1cd6d6e2db76a70f324c324341acb5d4b1cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wzp0cy89g8kvsn2q5kxsfqa5bq1319kvcs6wjimm03zd9jpsbq5",
-    "tree": "78413dcf697346c0e15e4615d70bce99e4175794",
     "url": "https://android.googlesource.com/platform/external/rust/crates/getrandom"
   },
   "external/rust/crates/glob": {
+    "dateTime": 1613822555,
     "groups": [
       "pdk"
     ],
-    "rev": "2bbbc6c0567970cd67f27c8fa12157fd1bd0127a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9a2c7e8c67a733120902ec0a938d5a13bf8987d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sd6b3y7w2lhma4d0y4930sv3adi97pkyq6szd765mxzaxm5dh55",
-    "tree": "28ded3e268f7970c9b9a5b9e1dfed07c37063f29",
     "url": "https://android.googlesource.com/platform/external/rust/crates/glob"
   },
   "external/rust/crates/grpcio": {
-    "dateTime": 1617419081,
+    "dateTime": 1617399198,
     "groups": [
       "pdk"
     ],
-    "rev": "09f6d87c3c975875dc52d49fcf9b732c0f07412e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9bcf0093bbea5fd198efc634ca72cd5a32139014",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dc2x1jl20lb93833dkrjksszkqnjlwh9lzf2z34kjib5whxyicc",
-    "tree": "a54e24d149f00ad487d9da00d4ded4043d6d1787",
     "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio"
   },
   "external/rust/crates/grpcio-compiler": {
-    "dateTime": 1617419082,
+    "dateTime": 1617385028,
     "groups": [
       "pdk"
     ],
-    "rev": "cde4d8cea9fad544f2e87447899dc0dc74de9807",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "337b514f3110730ecea29251512e03a001819376",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xd739ka5f56zywd9xnm934z472c7drqiz6hqg64cw9qxgp96fyc",
-    "tree": "2534dac935c52ffcd34b029bb5cf0b29bce5d406",
     "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-compiler"
   },
   "external/rust/crates/grpcio-sys": {
-    "dateTime": 1619053531,
+    "dateTime": 1618950341,
     "groups": [
       "pdk"
     ],
-    "rev": "75251cf2b267fa519fca7c95a9579e5c2061b497",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6c648fd1971998c18179f735aa0914fbaf087b2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hmydw85ih7cjdb3rdmpv1hmfqqb6wvz24z4ba9kwxn2y4vf2hnc",
-    "tree": "334e0af0074b51a11b6cbf4b733ced7d067a9738",
     "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-sys"
   },
   "external/rust/crates/half": {
+    "dateTime": 1618255956,
     "groups": [
       "pdk"
     ],
-    "rev": "f0e7e4dc4f8e0ca8fae926b5439858d4cfacf48a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b1eb07ed5166495f2135d5caa45a41c95632a8b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08l0jgdfi6qmbqp5v2q8hjpf9rwqmampl9ki7qramhin3p6c620f",
-    "tree": "57181f2bea0fd16753c94981147761bdc4b79542",
     "url": "https://android.googlesource.com/platform/external/rust/crates/half"
   },
   "external/rust/crates/hashbrown": {
-    "dateTime": 1617671125,
+    "dateTime": 1617642892,
     "groups": [
       "pdk"
     ],
-    "rev": "132dfe8223bd274f2eb194d8cae72dbed822a5c8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "88e88e3c5f8897e62b60abbe9bdd957169bd4924",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0lkksfn0kqd6sqjlm35m4h6nv8bx78fw4c1dbkj2q82sqy63r88j",
-    "tree": "a6caf250f8bc9d3ac3958804fdf9a08e1ea5504b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/hashbrown"
   },
   "external/rust/crates/hashlink": {
+    "dateTime": 1613834491,
     "groups": [
       "pdk"
     ],
-    "rev": "f925d847d09de050852893bfb8a8f08e05e9659e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "adbe343c2ab291f8b64bf8480a8a6dc9e5818c45",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m1zxa9kcq561wckji7m2rsrp7h32zcsl67nz8sm3crmfiih89p4",
-    "tree": "69609eba0194af44d59844c6df753b5c412889ee",
     "url": "https://android.googlesource.com/platform/external/rust/crates/hashlink"
   },
   "external/rust/crates/heck": {
+    "dateTime": 1613832769,
     "groups": [
       "pdk"
     ],
-    "rev": "1297212bdf59e32385fca3cbb0d2631d8b4814dc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2f350461bb9f923a8847095ddcd13a110ef96303",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0x4djw1sjsl4p906fpx8davjlrnxar843aiap7qph620fa8f5p92",
-    "tree": "f18e9d550e3389a6daa24962b2b82be5ddc7081a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/heck"
   },
   "external/rust/crates/idna": {
-    "dateTime": 1619744789,
+    "dateTime": 1619647846,
     "groups": [
       "pdk"
     ],
-    "rev": "015a4cc08a38e78d726f516d7e8f4f49cc448083",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cf1b1e4d733113609d93e86145a18d1b9e8272a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ymmrdxp31wpqwhfcaan2rjfhcj0gv7zigshhpcai1xv5zfb9ax2",
-    "tree": "e17a4ce161430b07e289f79f4ebc6181dc97d89a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/idna"
   },
   "external/rust/crates/instant": {
+    "dateTime": 1613822781,
     "groups": [
       "pdk"
     ],
-    "rev": "c96de95e8f08df8cc13cd858618c0b969e8c32cb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c647a9181cf7628e3cedab3df143bdb9fd8e6c35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07w1pii8i6qkfnwvhsm4iivflxqq6hpbmiyq7jsw4qbigsrjjrc9",
-    "tree": "cca5bb2f710f5667d61900a53bea9e4dacef32a3",
     "url": "https://android.googlesource.com/platform/external/rust/crates/instant"
   },
   "external/rust/crates/intrusive-collections": {
-    "dateTime": 1619744789,
+    "dateTime": 1619647841,
     "groups": [
       "pdk"
     ],
-    "rev": "42241abed0cadcdd30b9fc3c0bc0500d22f00e9a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "30cab3cc54694886abbaf1e2d6af6c812226744d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06rv3d12ds3kdnsxlzv4318i1nykvsmh9hcvcapvhpxc8av9xj9q",
-    "tree": "8cab78e20c4344228f35b5aa8a47039926a4f317",
     "url": "https://android.googlesource.com/platform/external/rust/crates/intrusive-collections"
   },
   "external/rust/crates/itertools": {
-    "dateTime": 1617757511,
+    "dateTime": 1617728067,
     "groups": [
       "pdk"
     ],
-    "rev": "09777917954ada65138822f9b873667696824082",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a4e9608cd5141665f10a758097921c380811563f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0w0h9zdc938l057zjbsvai9s5mnhyx9nga55agwarflg39gr12xw",
-    "tree": "70e883bc01ba2b4d8dd07e0347be18a2fbbd2c18",
     "url": "https://android.googlesource.com/platform/external/rust/crates/itertools"
   },
   "external/rust/crates/itoa": {
+    "dateTime": 1619647845,
     "groups": [
       "pdk"
     ],
-    "rev": "b267e6111ad8c70bd0a109e4d7a38f76d3f17305",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d3f7755c4a0052cfafc1caa05eb602d949d9a96a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rji01a0sfkfh18jx243hbm69mqjx9i013df0zwisnvq4680536i",
-    "tree": "a37d77a527c577f11a2c00f84694c9fd47b5617b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/itoa"
   },
   "external/rust/crates/lazy_static": {
-    "dateTime": 1619744791,
+    "dateTime": 1619647847,
     "groups": [
       "pdk"
     ],
-    "rev": "cf6178357a67b918f90fb29bc061393a347c3290",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "72848d1888cc2984b50dd45fa18c0e3bae798456",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wbi944w289ihsvirwzy9y0casx6xfnyd6vlbrlp6mrly8i9f1n8",
-    "tree": "d085eaf52ac4c533290ddfff287cc1632b2bd74f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/lazy_static"
   },
   "external/rust/crates/lazycell": {
+    "dateTime": 1613815618,
     "groups": [
       "pdk"
     ],
-    "rev": "93614056f8ea4f8679ff1fac237fc5ba2c88b777",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "045ad574f678072de3c6cadad60b85cc41b73e6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06di56bnsz4msyj77nwha4g1mi08k19ymh15isd79wc6x44z9h5h",
-    "tree": "8427b39add9086a50d82eeb647256704ba2c3fd1",
     "url": "https://android.googlesource.com/platform/external/rust/crates/lazycell"
   },
   "external/rust/crates/libc": {
-    "dateTime": 1620954331,
+    "dateTime": 1620937861,
     "groups": [
       "pdk"
     ],
-    "rev": "36b711d9364f8f587f34303b5e49654b46a528f9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d28cc9fc2ba931d2045ff7f6e26061de0081ae77",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zx4l0w87azhy1pc6mnvzw0ksbjbfrv6gvbvnn2d5g2plp3ssja0",
-    "tree": "b63bb3578266975d3cce7442325eaa5bdf684362",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libc"
   },
   "external/rust/crates/libfuzzer-sys": {
-    "dateTime": 1617671131,
+    "dateTime": 1617642881,
     "groups": [
       "pdk"
     ],
-    "rev": "da2efab010e3ae168cc88c587fe0dd940c7c71bd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ffff0a6e67e400c2ed1aa90068b7a1bcae9ca1f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0f5a2zl26ydvffwzfw3yk2mfpy63qkhc97vbmg6nqp03jd3gxdhv",
-    "tree": "b40cfd9e8802b2879a81663220a69c0d24691ebf",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libfuzzer-sys"
   },
   "external/rust/crates/libloading": {
+    "dateTime": 1613822738,
     "groups": [
       "pdk"
     ],
-    "rev": "8673a58de36f3e5b4ebc01ac5ef0a9e4bd612f7f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7e8d880a18bc879de6ee809189f8497a17d87ef3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "125hn4cvm7d73y1caagf2vm17qzrkl6hppw8icibiwzc3cvq509p",
-    "tree": "42b59de035f0989e3c3bd61b637525689abae76d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libloading"
   },
   "external/rust/crates/libm": {
+    "dateTime": 1619647846,
     "groups": [
       "pdk"
     ],
-    "rev": "f035ba65e5e0b02231e7f4f5fa5667466d6b567e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f529b930a56210851f291c370f449cb69d6498af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "111agfhx3rid2cgg0va4rblsdvr5xa0lpzwqbbk15nh184ckbn14",
-    "tree": "936efc6c35aad8c3b35463bca23ef4bc2601647a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libm"
   },
   "external/rust/crates/libsqlite3-sys": {
-    "dateTime": 1619053539,
+    "dateTime": 1618938801,
     "groups": [
       "pdk"
     ],
-    "rev": "a0bd6c90ad092d412a043edd93764a079ae262a1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c9c5de4bb1e0b0448b09ed99ab4b79ff8469c18",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zw7ak9v8fayazqi33nvy6laysh2rxd424l2c8sxb5sshp9csp8m",
-    "tree": "5893099480ba2ed264eb1a7c609f2e533a00af0e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libsqlite3-sys"
   },
   "external/rust/crates/libz-sys": {
+    "dateTime": 1613814632,
     "groups": [
       "pdk"
     ],
-    "rev": "a487310a5905d36c6f30cd7689ca8739ae04abc8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "13817a29554d94d741592c83a06b8804f9022781",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1snrdfqxghyiwd3w7yxbp0vl0kpx6w1ciih3hhvwhfg83yh754h1",
-    "tree": "a82fa5d617db8c153971ff79e282ccb8a7de9548",
     "url": "https://android.googlesource.com/platform/external/rust/crates/libz-sys"
   },
   "external/rust/crates/linked-hash-map": {
+    "dateTime": 1616512493,
     "groups": [
       "pdk"
     ],
-    "rev": "7573c7526500bbb6514faf34ec8ea5f065e45aac",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "900b8c2f6a57257fe9bbc855401ce141027ae742",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10avx3pavwvc6w9pwwbkazahbrjffkq1bw4rd48fwbapsx2c1axj",
-    "tree": "1581bee08dc44fc7d06bb49ecb559d4f087ba093",
     "url": "https://android.googlesource.com/platform/external/rust/crates/linked-hash-map"
   },
   "external/rust/crates/lock_api": {
+    "dateTime": 1613835275,
     "groups": [
       "pdk"
     ],
-    "rev": "c6bcc038325c3091b5eb36050bcc370ac2886b6d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "be5c6062e0975334a62596341b9c7c240469a70b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18m7p6hd57zbhc4nr0l63i38zk9riw8vkrs172j5zzwfc086v3vy",
-    "tree": "2463dc1fc3604e2b96a0e336af6b3d2cf0fff867",
     "url": "https://android.googlesource.com/platform/external/rust/crates/lock_api"
   },
   "external/rust/crates/log": {
-    "dateTime": 1619744795,
+    "dateTime": 1619647840,
     "groups": [
       "pdk"
     ],
-    "rev": "8b4eb1a2f655311864d5a2b62ac947696ffa730d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "84327b4e38afb1667ae5a397fe4700929980e64c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zzb335rk5bpi75jm4sb5pf8rmnpf6dznbd5n4nzl1i226zfqvz8",
-    "tree": "031b9a1439a080028cca7242477294509db7c906",
     "url": "https://android.googlesource.com/platform/external/rust/crates/log"
   },
   "external/rust/crates/lru-cache": {
+    "dateTime": 1613822940,
     "groups": [
       "pdk"
     ],
-    "rev": "c36837e3fd431e86c63d0822ee296426c9bda0c1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "908860cb15788f07dd27bfe6cf002051d833e4ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1cba2cgnkp681l5dhppipfidlj244mzzv0iwgi0qmaja99cdyzfz",
-    "tree": "fbfacb8577124d735b7a802d486828a01e3b4582",
     "url": "https://android.googlesource.com/platform/external/rust/crates/lru-cache"
   },
   "external/rust/crates/macaddr": {
+    "dateTime": 1616512498,
     "groups": [
       "pdk"
     ],
-    "rev": "ab47fae90ad88c8c71d75a0be03ee97200c64127",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "122b5128ad498bd5cd3f5c3dd2f8a6e76c9d043e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ih34msm26vya16vkqxsvf0zrxxhbdgm3gbxb80md6wlv4vmskjm",
-    "tree": "7abd48419fd15ceb455806e87b4b18624e992c1e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/macaddr"
   },
   "external/rust/crates/managed": {
+    "dateTime": 1616512497,
     "groups": [
       "pdk"
     ],
-    "rev": "1ce474ccaa1fdbd4618dbfb0f8dcc2c982f584cc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a6a7c1a255e863ef9f961d35755c9ff142a798ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05a90v3jq9yw5bj547qjx31l5fm6fafdl1mbngbkglmmw0i2bzmk",
-    "tree": "2c80002f995035bb3feb85345490087e831f48f7",
     "url": "https://android.googlesource.com/platform/external/rust/crates/managed"
   },
   "external/rust/crates/matches": {
+    "dateTime": 1619647843,
     "groups": [
       "pdk"
     ],
-    "rev": "17d78d751e898223705a8b66a9089cc548123829",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "71fe727fe054b7e82c5d89c9b6243bf783afbc54",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sp2ddidbl3h0hbrkbg194jpqpdb1l74pi8kdga3sxczp3dlmkyd",
-    "tree": "3ec477d7b01067633da10d4b2a1808b463f2e281",
     "url": "https://android.googlesource.com/platform/external/rust/crates/matches"
   },
   "external/rust/crates/memchr": {
-    "dateTime": 1620867976,
+    "dateTime": 1620818120,
     "groups": [
       "pdk"
     ],
-    "rev": "4aff86949e12b92d2affa07653d35e9d4ee687a7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e0051f410abc504e3c75cb6c141b791a1b0a0fd4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hwsviz4jz3c7n7lcf95m6brifngx1r6s3h57d1xkqqz6vz7y716",
-    "tree": "c7576ffdf6b174ea01726b8a6e014d415a109294",
     "url": "https://android.googlesource.com/platform/external/rust/crates/memchr"
   },
   "external/rust/crates/memoffset": {
-    "dateTime": 1619744798,
+    "dateTime": 1619647847,
     "groups": [
       "pdk"
     ],
-    "rev": "5b773145c31265233691ab0056545e4d0606d7e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "50a56cc0ca41f8fba604353af199930a74013175",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1vkrp3y4l7vxcsbgf8wxfl1w9icwnikb69b2jjw77cy3r16c43qg",
-    "tree": "a7d702e71f38ae1597839c01ccca8820999c02e9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/memoffset"
   },
   "external/rust/crates/mio": {
-    "dateTime": 1619744798,
+    "dateTime": 1619647842,
     "groups": [
       "pdk"
     ],
-    "rev": "dbbd52597e00c8b70040f18f63246842552077b1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9b54fa678bcb6940f7d683afa9700c772e3c6bfb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jhji521v8686xn5zzl3myy4q6jdnsw8wn3bh6fa0cnyl60gmpb2",
-    "tree": "d4331fc0ae40bfa56d8e3a9f2b73f914383f3447",
     "url": "https://android.googlesource.com/platform/external/rust/crates/mio"
   },
   "external/rust/crates/nix": {
-    "dateTime": 1619744798,
+    "dateTime": 1619647843,
     "groups": [
       "pdk"
     ],
-    "rev": "5b8c8f61ced9ab1b2e88891cba32924f73822ed1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a7d34193784879b8b9fabf36e48523741fc69aca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wvpj5950hvj55gajh3yp2pf514shscnp4z39h9md9rjzig9qwr7",
-    "tree": "1b2c9f243e281f08541d4e109f6c11247e4daaa3",
     "url": "https://android.googlesource.com/platform/external/rust/crates/nix"
   },
   "external/rust/crates/no-panic": {
+    "dateTime": 1613832651,
     "groups": [
       "pdk"
     ],
-    "rev": "3f567f859f392100f5f18a14daa951913f933869",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1ba9c29e1e27f4e2a6dc908a8f656d1e954d3a85",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cz0nj5d58s0p03pf4j3k14d9my2iss4gap87ln7fkx63kll7l9b",
-    "tree": "6cb6aca36ea809cfe8a91bdf8ea95d1620d787b0",
     "url": "https://android.googlesource.com/platform/external/rust/crates/no-panic"
   },
   "external/rust/crates/nom": {
+    "dateTime": 1613815575,
     "groups": [
       "pdk"
     ],
-    "rev": "5c0f46a0ca270673bc5b2ce6a858433fc103e62e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d4e86f6748b8901d9c41007a9f5c21caf84644ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00iz5lgxgdlshwmsbppiw509y574dicmk3zfyba4xz0scd564xnv",
-    "tree": "31a75c5e7da406ad8509f9b752485bc1053d8acb",
     "url": "https://android.googlesource.com/platform/external/rust/crates/nom"
   },
   "external/rust/crates/num-derive": {
+    "dateTime": 1613814599,
     "groups": [
       "pdk"
     ],
-    "rev": "3c7e7bd53a02d2ab3d326087ddba0d09c5cfea0e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f256e4d38372fb388641139475cb5910113a1c8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07l72iv3aikhcfywfll8rjh7ylclndxr7cidcq6a8i0klxfibiv7",
-    "tree": "c9a58f4fc6663d85c63dcb9f4a8cf00c85f3993e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/num-derive"
   },
   "external/rust/crates/num-integer": {
+    "dateTime": 1613587988,
     "groups": [
       "pdk"
     ],
-    "rev": "38cadee1609c772cdab78775c3e688252dfe3080",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "915de5875bfa1ead6b76a1bb9d366ccf0b855e1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b0i5j8vgn1xvp66dcwdvfcq8hymn7hx04411lrbcha9v1zrjl23",
-    "tree": "b848290708fb637982cdf87d4a2f6d5d4d26afb4",
     "url": "https://android.googlesource.com/platform/external/rust/crates/num-integer"
   },
   "external/rust/crates/num-traits": {
+    "dateTime": 1619647844,
     "groups": [
       "pdk"
     ],
-    "rev": "158b4b5cea8fa0fe8543bf9c25d56d332267f642",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c9cc9e6499065748f041e65644e55b93bfad7d6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05ar1k2x8pqqr9hn4cchy5kbv5cg80aaxq0k6xp794m3cn7j275s",
-    "tree": "b6030c920777b49632dce5c4ed4a1783329c9e3a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/num-traits"
   },
   "external/rust/crates/num_cpus": {
+    "dateTime": 1620820354,
     "groups": [
       "pdk"
     ],
-    "rev": "d7659f69ac4e81f9111afd83505d67ea25e7f005",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "42ff0bf2d87c178696e29b1cd298b99f0e235ba8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13l3ss2303qgx780ppsp7y8zkz5rh78mznml1mbnhk1j177zdjwp",
-    "tree": "384e51cab6b1186d6bfada666e744f0884b51d82",
     "url": "https://android.googlesource.com/platform/external/rust/crates/num_cpus"
   },
   "external/rust/crates/once_cell": {
-    "dateTime": 1619744801,
+    "dateTime": 1619647841,
     "groups": [
       "pdk"
     ],
-    "rev": "a8dbe94986a6ff921096196c26272272af7584f4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ae220bbc3384c0693f4267727f06d33fb2a2acb5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pn4aj49f25r5jz4dm9wmdf1rmmghzff2yzplikbgkx4kl31q5zx",
-    "tree": "71c77aba563c644c5294b9326b518692929b3d44",
     "url": "https://android.googlesource.com/platform/external/rust/crates/once_cell"
   },
   "external/rust/crates/oorandom": {
+    "dateTime": 1616512496,
     "groups": [
       "pdk"
     ],
-    "rev": "96b664214a0f340a0ee2600a084015a905789ef7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9cadaad3163c60f5dd5f66b8d995ec7c4c002b87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05xsrs0hvzh9z28lmfq3slmjzia6dg6nqlsx5qzwzn06qximykaf",
-    "tree": "74f9b1c6c94f0a1d3902b4ed0cacb80a50f97f47",
     "url": "https://android.googlesource.com/platform/external/rust/crates/oorandom"
   },
   "external/rust/crates/parking_lot": {
+    "dateTime": 1613829208,
     "groups": [
       "pdk"
     ],
-    "rev": "70dfa5d40f5eab2630180ca04254a6ad619dcc38",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "715cd6132911c309d125d307388c5c0281fe4dcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lfv9la7lm4m8k5wln2xv4ghv1yv4z99mgzl2rx5hz1rfrgg38g4",
-    "tree": "abaf3a6518cb6e59833b43a71a7fffd9eb7a0e5a",
     "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot"
   },
   "external/rust/crates/parking_lot_core": {
+    "dateTime": 1613822529,
     "groups": [
       "pdk"
     ],
-    "rev": "15ea6266b38661d00305058e10d369f2c75b15d9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b734a16d2409bb5cbab654598007d64cabb601f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rkzqb6is3c3s08m4gf16s17i6siy5xhcc77s25rwlvx6waq4k8d",
-    "tree": "33f2cece6b496f90ce8dcf1226a1d1c6b14a50f1",
     "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot_core"
   },
   "external/rust/crates/paste": {
+    "dateTime": 1617332493,
     "groups": [
       "pdk"
     ],
-    "rev": "88b31ebd8b30ef6acaeeff78ae4118adb2f411db",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2b2531f4269582c435619b02f02bd9f652e3907a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vy1knxk1rckadyjyl72dcyqc6wz8dvq0c986z3652cl0g0q1pji",
-    "tree": "4f65437682237a2c6bbafef186110d3bed2fd832",
     "url": "https://android.googlesource.com/platform/external/rust/crates/paste"
   },
   "external/rust/crates/peeking_take_while": {
+    "dateTime": 1613835297,
     "groups": [
       "pdk"
     ],
-    "rev": "85bc34fa2f9bc688d5de6f3e35b9c975fe481a8c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "50a35bc99be8e4c626c8d2165493b3c681d21aa3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12901vqlv7ciffpdq7bfdcfx2vpylwv16czvrm6174g7d9l68fv3",
-    "tree": "4c232123ab0931b735270e89e3c9c39e4a8f5ad0",
     "url": "https://android.googlesource.com/platform/external/rust/crates/peeking_take_while"
   },
   "external/rust/crates/percent-encoding": {
+    "dateTime": 1619647849,
     "groups": [
       "pdk"
     ],
-    "rev": "ac2d6e0a11be15e870d712b6871c92d308e395e3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2833dade6f0d56277e5ebd476fb55d17bd778b0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vrdcvkv72306calx7q3hxmsk2b0kcac9hjn9s92l01am2svpa65",
-    "tree": "81666efe5312581e144a03f9be6dc2f9d65ff7bb",
     "url": "https://android.googlesource.com/platform/external/rust/crates/percent-encoding"
   },
   "external/rust/crates/pin-project": {
-    "dateTime": 1619744805,
+    "dateTime": 1619647840,
     "groups": [
       "pdk"
     ],
-    "rev": "b42123201097167c63d47122074ff99e46c67d49",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a626d1dd8a17a9f643c3e9cc43a4a27ed7a3c096",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y0037f6zw4qyjjmb8qgxr15mdf8a36iym0r2in978bx6vickbyd",
-    "tree": "468b171d04d12d79930f58d6efc7ec3a45854589",
     "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project"
   },
   "external/rust/crates/pin-project-internal": {
-    "dateTime": 1617419103,
+    "dateTime": 1617399190,
     "groups": [
       "pdk"
     ],
-    "rev": "ff8f1217349c88e138bea20cc6d53795aa30c3e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "92b6db81914dcbc476b70e2e302f695b5eb7cec2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dyjczyl7rjyj3qlslhvks0cb5hfmiz98g6il06837sl7sa7r435",
-    "tree": "77450a57bcb113372069d89c0c322639805fabba",
     "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-internal"
   },
   "external/rust/crates/pin-project-lite": {
-    "dateTime": 1620867985,
+    "dateTime": 1620818116,
     "groups": [
       "pdk"
     ],
-    "rev": "0e82f980b6047e011e7fdb83676fcd363631a67d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5b3a761ced98a30a1cd6a50ca9b71cad456a2c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19hx6g9vkwl07f5d65irylb82dj96w9sfcrpk2g5jnj4q35991di",
-    "tree": "d6a3b347e26f065a3b2bdd0d9c2627e287f35fba",
     "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-lite"
   },
   "external/rust/crates/pin-utils": {
-    "dateTime": 1619744806,
+    "dateTime": 1619647841,
     "groups": [
       "pdk"
     ],
-    "rev": "8693cd8611ef3db1483d175e36298ae25a2b5c45",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8a4a475f3259e69b670811b650700fd5673b18e6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wc5x25b440l1qlfslhpvnm9yppwxjmx284wy7s0wz9jr9ikdn3k",
-    "tree": "588cd6bcab99f86ee21c4a232729119123f985a6",
     "url": "https://android.googlesource.com/platform/external/rust/crates/pin-utils"
   },
   "external/rust/crates/plotters": {
-    "dateTime": 1618362332,
+    "dateTime": 1618268703,
     "groups": [
       "pdk"
     ],
-    "rev": "a45744ddcf146e3b0ab580b045134671af1ae2b7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a1e36f62421a12cef0ba14811ee0e16204bfca04",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0w3hzsr0hz5zz7cyn9r6hscan9arf8nbiq6fbgjaw67vjzzgjamd",
-    "tree": "f5309a0441cebfeb180fa9e396526b41dc0ed911",
     "url": "https://android.googlesource.com/platform/external/rust/crates/plotters"
   },
   "external/rust/crates/plotters-backend": {
+    "dateTime": 1618268731,
     "groups": [
       "pdk"
     ],
-    "rev": "436ec10468ab3fad21ee6e6951b21a465c2d69a1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "78e2c56a727dd55853f36fc8e31555ee5447bed0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f6vxfgg2nb130cs0ykr4clhzwm9sd37hh87zk53v2yh1k2nsx63",
-    "tree": "417fa70cd53947cd95218cc87dd667de937a8554",
     "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-backend"
   },
   "external/rust/crates/plotters-svg": {
+    "dateTime": 1617719155,
     "groups": [
       "pdk"
     ],
-    "rev": "c576f0e02e37758f409f53c323a390dfd75b1100",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "558277bca89864c1bd380af5f5ad64b8ad9fbfb3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0knjd1657r31h5djbkacpiapax09adk2ryf8izayli46ifyx11bz",
-    "tree": "357909034922a987ba274a913e1841b749583422",
     "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-svg"
   },
   "external/rust/crates/ppv-lite86": {
+    "dateTime": 1613827070,
     "groups": [
       "pdk"
     ],
-    "rev": "589554d4080d023f3cddef19448497e0e04655ef",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bae304eb849488ab7efcc2265076e93487f53835",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02gkxcgik9jaw36hm59bs2pkgirrgz71ngsmxdda98h1ydip7i04",
-    "tree": "7d9f824e8baa7032c8f8bf51f965345a27a21cef",
     "url": "https://android.googlesource.com/platform/external/rust/crates/ppv-lite86"
   },
   "external/rust/crates/proc-macro-error": {
+    "dateTime": 1613823949,
     "groups": [
       "pdk"
     ],
-    "rev": "75c9deff9946cc582c968fc0c02991a34985cd28",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ee0fbdbe06962dc00731ceb2a41c7859e22a5fe8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1knxgc7r9x289qmm38vmrh6sdyfp06i4n4ajlknyirb7gkqmw2br",
-    "tree": "cd40f04f8279da220adedf0f4c12d69ce0bbe1aa",
     "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error"
   },
   "external/rust/crates/proc-macro-error-attr": {
+    "dateTime": 1613835426,
     "groups": [
       "pdk"
     ],
-    "rev": "fd31c47cadb71905a214824b4e16cdc541a924ab",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0300302853426ab77c92dd7b1469aada426da25b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00zdh0yjlvp8lfc55a9vpf30b1q4m5cnyqdd1sfxxjlfv5fjbddc",
-    "tree": "ef05221c0f24e4068adb5d1d41186ff2473b277b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error-attr"
   },
   "external/rust/crates/proc-macro-hack": {
+    "dateTime": 1613814642,
     "groups": [
       "pdk"
     ],
-    "rev": "79bca7d3e738301941fe828e526c4725c9f78111",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f885e797b15dffc2dc4a00352a7a20ca0998edb6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k1ljy6alvx8hq3ym48ajavdljr6199xfd75ql72926nwk9aszxv",
-    "tree": "63973525c2cdafb3066c97a9105e24d1f164dd6b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-hack"
   },
   "external/rust/crates/proc-macro-nested": {
-    "dateTime": 1619744810,
+    "dateTime": 1619647843,
     "groups": [
       "pdk"
     ],
-    "rev": "afcceab271dd7b4bfdddef69b16a2c669337d5bc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8dedf3e5c8c5b3890b2a35425588b91ecac1801a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1cm5csfpjbxbqs80javai4s0cdaz1d0a9i9mj45ck1dr1k9xzd5d",
-    "tree": "aa9c5fc45b7f8fd2b4b4925aa5a056befd82baad",
     "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-nested"
   },
   "external/rust/crates/proc-macro2": {
-    "dateTime": 1620954352,
+    "dateTime": 1620937860,
     "groups": [
       "pdk"
     ],
-    "rev": "6c5335b06772c69a9d3c2966dbc13e46a39fbcb3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4e8c743e2ba0d90a36903bf75ef265a3ac9c11ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01f5n87cdwhmw31b2433hv8fq9345haqhpg6k54as37g5pf4r052",
-    "tree": "44cebb73ced35debf89bc3554d7388321cd1a37b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro2"
   },
   "external/rust/crates/protobuf": {
-    "dateTime": 1619744810,
+    "dateTime": 1619647849,
     "groups": [
       "pdk"
     ],
-    "rev": "3ac87e023b49d1f930da11d9c8cdfd8b115c5efe",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c7db42165e762da79e489444d10092b270c8512a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v05llm5p3y1w36vnxlb58n0p5bdg5k2sr9vjrcq14biqapcm3di",
-    "tree": "9a6c316c8be8d38009d2fc5af7705b97ca0da5d4",
     "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf"
   },
   "external/rust/crates/protobuf-codegen": {
-    "dateTime": 1618023941,
+    "dateTime": 1617992114,
     "groups": [
       "pdk"
     ],
-    "rev": "7f587128b74bb0e205c331358be9aec4a80987d3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "32cbc1e8bd6b43853c9076574a1e9367307bff09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yp4dly0d57gcyh4jp76jkvwxrbnv5w8vdklfmdd2gnad3gg5qjp",
-    "tree": "9eeac22d97fb868a2a9113a2bc173486ded1c70d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf-codegen"
   },
   "external/rust/crates/quiche": {
-    "dateTime": 1621904803,
+    "dateTime": 1621584470,
     "groups": [
       "pdk"
     ],
-    "rev": "e5a655b7105f37afea1c271788310e8e26bf264b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e2a563bb322660011576793a79be3e31f18708e3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09r61vnj962kpz4s4r47mj21823244lnm60j0vnf9gp6yr10xv6w",
-    "tree": "2520972de69fdfa3e722d82b04cc5d8ce38d266f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/quiche"
   },
   "external/rust/crates/quote": {
+    "dateTime": 1613828379,
     "groups": [
       "pdk"
     ],
-    "rev": "eb34873a63bd3b1f0c46e48e7e5dae475935fef1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f120bd117d609d692ad23a5c635a96b7aa4df872",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lmnm2xvq7sqz0vqprqfgah04rwfgs3jga4za3ijpzmqr4bfqxbs",
-    "tree": "dfd15a994d01260db5255146bfd1a9a0284aa94e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/quote"
   },
   "external/rust/crates/rand": {
-    "dateTime": 1620954354,
+    "dateTime": 1620926622,
     "groups": [
       "pdk"
     ],
-    "rev": "d1a10cf261dd7e11ba3fc2df16cdfb846a1bb77a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1571a21cba2a11578c1c5e3e0f196456b7aa25d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1q0xgznpka23616c4c52jw87yf2yf1nqxk4nrbs37idvdax3370w",
-    "tree": "af497444c7e9b3ecbb902fd0585f12ab1f7e9b39",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rand"
   },
   "external/rust/crates/rand_chacha": {
+    "dateTime": 1613824026,
     "groups": [
       "pdk"
     ],
-    "rev": "0a7cd78dfef7dde9ff46e1d267a0cdeee7044ac4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5bb948eb0c9ba45eecfc1e3a17a2420b345418ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11nlq925r5jay7akqzimrk5lpr38cyi5izlpzmjqs73jv6j21n4l",
-    "tree": "40c7ef2eea2c0a82b12b1645c8ade94c411f5d77",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rand_chacha"
   },
   "external/rust/crates/rand_core": {
+    "dateTime": 1614390980,
     "groups": [
       "pdk"
     ],
-    "rev": "a39eb38f88a8a794b6b6babdef8ccdd4980afa06",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "27b8e0eff1875480615eeb20e4cde9dec31011b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yagpl8553a611mywlvf7zqdsqdgqh661y51lw0b9alh3m0dix5k",
-    "tree": "02226ab7d0aae65e8b9a942e87b48a3b889145d5",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rand_core"
   },
   "external/rust/crates/rand_xorshift": {
+    "dateTime": 1613615865,
     "groups": [
       "pdk"
     ],
-    "rev": "dfac48014bbf91b542cd9cf60d0d9e0f6575b4b2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c97af34bb7e17945a758a7fa556cc7d65b121f0d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pxla85gls4kib4ydlpzzsj3yw2s7ryk1yvljgjx7avkam3ba86m",
-    "tree": "fd1662d2dd877593a08cf3fa297a0806a431c305",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rand_xorshift"
   },
   "external/rust/crates/rayon": {
+    "dateTime": 1616512496,
     "groups": [
       "pdk"
     ],
-    "rev": "cf3675cd3078945256ffd5dc9027f0c466d448a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "64148297daec53566aaf3926246bb8d88f8e9148",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xffdyamd965vw93hl7zw6mgip01mybck8pfljr9msza39wfvp34",
-    "tree": "276308679073bbb5f034d935e9a617f2b09e5310",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rayon"
   },
   "external/rust/crates/rayon-core": {
+    "dateTime": 1616512499,
     "groups": [
       "pdk"
     ],
-    "rev": "880beb962d51349b9d867d19bd40227e6034f382",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "85d828fb59c13e152f7f8be2beb87b10897ee4c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kswciinmwn6f3xfgnxgqpnd6m3v6sm3m7d14vn2xp7938hi7s9w",
-    "tree": "94d4ebfabd135e1221ef63e678539ffb5acb6c19",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rayon-core"
   },
   "external/rust/crates/regex": {
-    "dateTime": 1617419114,
+    "dateTime": 1617399194,
     "groups": [
       "pdk"
     ],
-    "rev": "51f3d5e9cfb484d5bd7f7978245955da655f0002",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "861d4cb36bf7c4988d08d7a1f42354a46c4edda7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0liqpk6bqwdypjawgcgwpdiy76a6ab5vvhi249430spb8552rvr2",
-    "tree": "5f360a0d078f211e4938d8bdb073d5aa685ed554",
     "url": "https://android.googlesource.com/platform/external/rust/crates/regex"
   },
   "external/rust/crates/regex-automata": {
+    "dateTime": 1616512494,
     "groups": [
       "pdk"
     ],
-    "rev": "a1184379b789c8318ce8e776b69819dae1c27aa0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b535fa94cfda4d4527abc8b8f3a5fd51aa681b6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "060cvq9v43k2wca81bcyxyqspgyww0lw08xkiq0bznrql2vp7f04",
-    "tree": "75fa1da36f25642e72695c26cd507ac797d09286",
     "url": "https://android.googlesource.com/platform/external/rust/crates/regex-automata"
   },
   "external/rust/crates/regex-syntax": {
-    "dateTime": 1618362342,
+    "dateTime": 1618268759,
     "groups": [
       "pdk"
     ],
-    "rev": "b7c671601e5815b6598834af94742782a81ae2fd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff04e5ae2b51e2cdf1e295011cf16e376d5bc9da",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1amzxpm2072myiyzwqvipr1nsxbdikhz49pvm19kbzmasnnx7gin",
-    "tree": "c9777920ca2210c635d86dca9d0820c953448f73",
     "url": "https://android.googlesource.com/platform/external/rust/crates/regex-syntax"
   },
   "external/rust/crates/remain": {
+    "dateTime": 1613827163,
     "groups": [
       "pdk"
     ],
-    "rev": "5b383a62c5df7ebfc0cb5f384cc7787b04d7f64d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f0007d52adbcd9cba5ac1bd5c34e2c6b0e3f6de3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0d53xbgp935395b99anix9l3193ss2imi0dwzxqpr1b3x5imbff6",
-    "tree": "569392943172a9c10a478f649934e46de88a1c7e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/remain"
   },
   "external/rust/crates/ring": {
-    "dateTime": 1617843950,
+    "dateTime": 1617797211,
     "groups": [
       "pdk"
     ],
-    "rev": "b72cc2ccf70a26d4fc583deead7c89c0717d14df",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "330555e2947bc5078ef4bc115eb85d01ab6fe58d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1svc2bj08si0x9frpkz90i7zal3lxbfi4kgl20w8r4018hk30c28",
-    "tree": "ef6ac5e5e83f9eac484be47c563bd951d48608a9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/ring"
   },
   "external/rust/crates/rusqlite": {
+    "dateTime": 1613827206,
     "groups": [
       "pdk"
     ],
-    "rev": "a8315c458d66f17cb2047d7fc360d8148be8f5da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "17376dc7d10bc3df237aa74de5a94708b44605b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vq390rcdxx95pnj75j3dp393irh0rxsc0frz6mwpcfy7qvlkz7k",
-    "tree": "af09a0d512bc10a691b273f84025e1168f24aa3f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rusqlite"
   },
   "external/rust/crates/rustc-hash": {
+    "dateTime": 1613830762,
     "groups": [
       "pdk"
     ],
-    "rev": "ff26d5d9b8b53c0d3d395cbb787008f0deee042f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "822829f212c466c171e6318315adcf622ef2e88f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v30cz4b7ckpz4i6yzcz4xcnkjvvpfd9ijz2qf0xzfqjaybfhlyb",
-    "tree": "16244a35292a0f1c14f6fbc0d6998e7e774c4ad7",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rustc-hash"
   },
   "external/rust/crates/rustversion": {
+    "dateTime": 1614390980,
     "groups": [
       "pdk"
     ],
-    "rev": "63a323f431033c500525dbbee53049e97e9ac153",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b1fe9b300b2f7d8273b7bb0a62755e8ddb703028",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jjn769sm5h0j1g2ysxip2c3qn5fgiyklnc80kpwpbc8pz359vlm",
-    "tree": "ee785501b096808438284c8623ebf9f736577dbe",
     "url": "https://android.googlesource.com/platform/external/rust/crates/rustversion"
   },
   "external/rust/crates/ryu": {
+    "dateTime": 1619647847,
     "groups": [
       "pdk"
     ],
-    "rev": "5838b43a8eb910cca6b186de67529bb2ee9a1833",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1eefc0e81a57dcee102c12b0c74a1b6f051d0488",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0x7nx4w6pmy0bwbrlqgkdmjmbp4823gd1mfxxk240g0wy7zbpc8w",
-    "tree": "87a8aab98a66595cccf5a7c95c7db70e8d5d51a6",
     "url": "https://android.googlesource.com/platform/external/rust/crates/ryu"
   },
   "external/rust/crates/same-file": {
+    "dateTime": 1616512494,
     "groups": [
       "pdk"
     ],
-    "rev": "24a34d186fa7ff471cfe3a0fc7a07c874fb7ff19",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "619da2e2e7ef8e4e3c237eacbb5c56bb88ddf1ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hqv1pdqmjpnicwzmk5ysjicp552l61ppqv9liy201iz7bl2yagn",
-    "tree": "95044cb11346c805253cb7e8367f5b7dc946fde8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/same-file"
   },
   "external/rust/crates/scopeguard": {
+    "dateTime": 1613822862,
     "groups": [
       "pdk"
     ],
-    "rev": "d79a2a01aafc1e61122a7039b505e12b7d6ea115",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "43315394f224b6ceae302e840c37c85bcb48e3b4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0yc9w5xz3vyjyyw17la529kz4jy4ayk1s98js871ha4xkbjwh840",
-    "tree": "4bef4900c61e55af7b2f51e278c130861e7c4767",
     "url": "https://android.googlesource.com/platform/external/rust/crates/scopeguard"
   },
   "external/rust/crates/serde": {
-    "dateTime": 1619744821,
+    "dateTime": 1619647847,
     "groups": [
       "pdk"
     ],
-    "rev": "98580092c5ffe73c0d1db1b00d56fa00326958e5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4355ab871c989b6584b687d80d75e827624c421e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z74h4ir11fk52g0fs54mmalc4cd1ixycmngz3dam3li86hami8n",
-    "tree": "944dd49676b5a1fbc7916dd2f43ce03118ec1bae",
     "url": "https://android.googlesource.com/platform/external/rust/crates/serde"
   },
   "external/rust/crates/serde_cbor": {
+    "dateTime": 1616512501,
     "groups": [
       "pdk"
     ],
-    "rev": "b26a796dc7f8bb04fbd2d03c644d04ef651ecdbb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fc036af097bbb4d44427ba3ab5478b1dca57581a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hcd2xar0ymvly9qn9sxkwzg9cgx4isnks3v51dfdhz7np2rrj06",
-    "tree": "edc98c3f5b73937786ca2d28d5642b38ac420ae8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/serde_cbor"
   },
   "external/rust/crates/serde_derive": {
+    "dateTime": 1613834507,
     "groups": [
       "pdk"
     ],
-    "rev": "784e16600ce5958ca81a59265b04768fa34ed036",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "da718a0f44420a955aa80024bba7aab72d5642f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1api77r6ylamm2zlhl76n3jbfrzqkqbjq42kn9y3bq6akn7ixvw5",
-    "tree": "a98e98ba5777200bee83b5f134a74d2094ccc630",
     "url": "https://android.googlesource.com/platform/external/rust/crates/serde_derive"
   },
   "external/rust/crates/serde_json": {
-    "dateTime": 1619744822,
+    "dateTime": 1619647848,
     "groups": [
       "pdk"
     ],
-    "rev": "25bf1a0607c7a528178a21f3786d34c9aff806bc",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f2728575f485948232d0da452491532fe5ec2941",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qcw6skd8wqgy6mdh14am0wp30dlc7cwp09fg2ml0k3w6d6zrz62",
-    "tree": "7d8dd4827439b0ed2b64a86ed714755e31973f61",
     "url": "https://android.googlesource.com/platform/external/rust/crates/serde_json"
   },
   "external/rust/crates/serde_test": {
+    "dateTime": 1613513316,
     "groups": [
       "pdk"
     ],
-    "rev": "46fecbdfce9113bfb503c7495ff01c2075efb4a0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "30e1af9a30b5fe5c1e21c61de5054b895d451247",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07hdv8n29f5rrngjn7qxmq9dw37j1y5awlbpga204jzj52bg8sax",
-    "tree": "53eb080a95773b5f6a5c34960ceeef2f4246fe7d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/serde_test"
   },
   "external/rust/crates/shared_child": {
+    "dateTime": 1619647849,
     "groups": [
       "pdk"
     ],
-    "rev": "f91add31d5a04ab56df5d4bf612d53d49a3baa7e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b0243e16bd00d807283c7d0657a144612d4c13b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l52r5sxgr164fqmlhfhdk7hr5jwwqfrp558pk41h314y3pr1gg4",
-    "tree": "756dfc17a28ce25d3a44da77dad4d72e6979d7f7",
     "url": "https://android.googlesource.com/platform/external/rust/crates/shared_child"
   },
   "external/rust/crates/shlex": {
+    "dateTime": 1613823841,
     "groups": [
       "pdk"
     ],
-    "rev": "b6ad2613e4b5ab617c0dc9b13f5c201e42be5b1d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8564ff5e32aa99319d1e67987b35ef6b835d1d57",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "135jawxfirwgh6dh0k25bl1k8acmvpwwpah62dcr775x3g885srj",
-    "tree": "3e48ad25f19353665621be34bf45b92e33cc471d",
     "url": "https://android.googlesource.com/platform/external/rust/crates/shlex"
   },
   "external/rust/crates/slab": {
-    "dateTime": 1619744824,
+    "dateTime": 1619647845,
     "groups": [
       "pdk"
     ],
-    "rev": "53e3f27afd6f4d6b7dc09b62d1139a6418ff6116",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d7f7f173248e8df9238430d8498f748d932a9cb0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rvrph29d850l06wi8z0j3gzsnfbzlxnpgpqwxqwy3nqvvi90d9s",
-    "tree": "95d23281f1be722c5e7ff14d322b70b0a5120db1",
     "url": "https://android.googlesource.com/platform/external/rust/crates/slab"
   },
   "external/rust/crates/smallvec": {
-    "dateTime": 1619571956,
+    "dateTime": 1619480254,
     "groups": [
       "pdk"
     ],
-    "rev": "e7d6eda150fa76654cb98408b2aa47a72c989fd1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c8546456fb79589d0a242880b8a8479321fc1536",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02mvm1c3d9axdf9qkg2rylvhp7sgxcx9n338xfmaaq1c76wy0l7x",
-    "tree": "3ed4f71564f78fb702412335da032629712bf1f3",
     "url": "https://android.googlesource.com/platform/external/rust/crates/smallvec"
   },
   "external/rust/crates/spin": {
-    "dateTime": 1619744824,
+    "dateTime": 1619647844,
     "groups": [
       "pdk"
     ],
-    "rev": "f756d04bb23cf7d3493440fcf647f92b496340f2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "eacad1617de12955ab9d6023ef7e8551fd337964",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00kv0aicmq07y6i44hz382h4fzhz4gbl31ckbch0f9c6xyhm0g8a",
-    "tree": "8aa33bfe69d31d520c9f1aa0b31ed2e4683f5595",
     "url": "https://android.googlesource.com/platform/external/rust/crates/spin"
   },
   "external/rust/crates/structopt": {
+    "dateTime": 1619647842,
     "groups": [
       "pdk"
     ],
-    "rev": "ce316ed91a42f2a3ad2b9c07ce08e91022837b9b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "262c0cbc1ce62d5728d5be648a3ae4176e1d221c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0n6lk2i8z0brsrg8gilmlx58h58c6j02jhln9rm9x9r13vhy09fq",
-    "tree": "a1f2b136f0951447ee26fd070ec1044f092023a7",
     "url": "https://android.googlesource.com/platform/external/rust/crates/structopt"
   },
   "external/rust/crates/structopt-derive": {
+    "dateTime": 1613828504,
     "groups": [
       "pdk"
     ],
-    "rev": "26526d94e9431a5a5391747055c176c890baaa01",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c107e396223c54dc79db164cfffe4d94f05568fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16yjhl98qilspdi2rk0bhs3ckav3rysdccbq7nm6w6zpvn4jm4zq",
-    "tree": "2b7fbbc02b5ac2be4758b18848f2f47bd20f025b",
     "url": "https://android.googlesource.com/platform/external/rust/crates/structopt-derive"
   },
   "external/rust/crates/syn": {
-    "dateTime": 1620954368,
+    "dateTime": 1620937860,
     "groups": [
       "pdk"
     ],
-    "rev": "f94b0b113392f18353f4bd45c16406a64d0c36c6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "af8942f04a66575c4d8eac24f98d1681482f6476",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "086z6n4nkw8sdjwjfvnrzrsmiyahq2s6aw4fp776kgwg7lxl7shp",
-    "tree": "a9f5b49c1bcd5d7f11000a655eb7da788ef16208",
     "url": "https://android.googlesource.com/platform/external/rust/crates/syn"
   },
   "external/rust/crates/syn-mid": {
+    "dateTime": 1613834178,
     "groups": [
       "pdk"
     ],
-    "rev": "195d3a810945ccee74172470c7864a9e7f5d25af",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6daf34f029f68785adea4fce15596027f15ec286",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hhvqxhk4rkwm0qkfh71rc1h3p1naldxw11691igmn6rgr8q94in",
-    "tree": "ea68852a3b48b436d538623fc285812553ae69b0",
     "url": "https://android.googlesource.com/platform/external/rust/crates/syn-mid"
   },
   "external/rust/crates/termcolor": {
+    "dateTime": 1613815582,
     "groups": [
       "pdk"
     ],
-    "rev": "70f55e6e75f045df58c7fd1a34df1adfc6e12e08",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "476f054f1c23ccb04258dbc41d34168dfcb6074b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cqjgbwvccydjz2xrsrbsia3lmfzw275g1lmxw4jla1zfja4q9n0",
-    "tree": "b168e1675abf463eb4f238035e8cff5c0a23bff7",
     "url": "https://android.googlesource.com/platform/external/rust/crates/termcolor"
   },
   "external/rust/crates/textwrap": {
-    "dateTime": 1619744827,
+    "dateTime": 1619647840,
     "groups": [
       "pdk"
     ],
-    "rev": "f6c5671927d8f771d20258c5ef98250d4120055e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b3c2e54a3a06522213d1f5a94825e85ca8f9b29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hc46d3jlx6v5swfj4d0p9267snl4xx6wpwx26s3bb4s98z4bdfn",
-    "tree": "3bd9375068a14132a49e5f30afab363dd976f9d9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/textwrap"
   },
   "external/rust/crates/thiserror": {
-    "dateTime": 1619744827,
+    "dateTime": 1619647840,
     "groups": [
       "pdk"
     ],
-    "rev": "d983664c4f6d0ce006ecb2babb2b5ecf742f7707",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fe59753f0a5ea8975d17a1488a2d05d6f03b6cd3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02n6qiz8qpq972a06xdzgxs5bffpgs6mwx63chyxgnqy6726flh3",
-    "tree": "1bfe266a621b097a5e3abbed7b0cf00f3d2311cd",
     "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror"
   },
   "external/rust/crates/thiserror-impl": {
+    "dateTime": 1614577077,
     "groups": [
       "pdk"
     ],
-    "rev": "618bad9d0eeffcb822d010dcfb160f6426e1ca39",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f0790eaea25260ebd6de523cf6a446f5e0c416a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gg7s24ady7zlh46nffk7yh11rrddg8wvsdcr7c711dsbxxb5584",
-    "tree": "55288574ba91873099b9261dd61f9d1ab82b84e8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror-impl"
   },
   "external/rust/crates/thread_local": {
+    "dateTime": 1616512497,
     "groups": [
       "pdk"
     ],
-    "rev": "be172d3f73df6166b5b91196687567da00c4d965",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a4682be8e4de42d80923185cab50d0a5d05e3d94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ln79byy89kpxygpqd11bbi5xsjypy1n28wrp91hy6sx786hla85",
-    "tree": "d8039a1ffb11378c74b2287a975c5dec58c4c672",
     "url": "https://android.googlesource.com/platform/external/rust/crates/thread_local"
   },
   "external/rust/crates/tinytemplate": {
+    "dateTime": 1617990862,
     "groups": [
       "pdk"
     ],
-    "rev": "d4e75f074c77d1b45ba7413ded1ef862a8093c57",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "99bb6bcd8b90d9a8c0fd938d564c029a55a54fa9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10wg6wj3bzynr1z9pb50bmr6pc8i7xq56lwjydgwilhwi6p2g96w",
-    "tree": "410da5262bed94fc3bb0595021f9a25c4ef3b798",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tinytemplate"
   },
   "external/rust/crates/tinyvec": {
-    "dateTime": 1620868020,
+    "dateTime": 1620817038,
     "groups": [
       "pdk"
     ],
-    "rev": "4e44c1ad90fd6857749829ca5973a86dd0b223ea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ed150e3a9e42f9965d0292fc3d1aec29470302cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1iarzdmdck0f5fdwidd665m45wxl9aj32s1lm30nd5379cprmrwn",
-    "tree": "374e6263abc26a82e70c06ffcb32122ace1036af",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec"
   },
   "external/rust/crates/tinyvec_macros": {
+    "dateTime": 1619647843,
     "groups": [
       "pdk"
     ],
-    "rev": "d20fd0d3105eede2c5adc0af3d640ea005790459",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "396092a96d062af04c838035cd0711c4d49f188b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0y1c5xaq9nbiyi52zaapdbbhm7vmq6hizxmg0kd0nlyagd95smsx",
-    "tree": "8ce667ee5183e2c095c2c78b93c815bf3f1f7fdf",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec_macros"
   },
   "external/rust/crates/tokio": {
-    "dateTime": 1620868022,
+    "dateTime": 1620820358,
     "groups": [
       "pdk"
     ],
-    "rev": "a055ce1ab262a9401d39d573d7a44f2eb52bb7b5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "376464b75080c0925562920a76cb4a35ad98cb0e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zjh0cik5kwp6vfisza3bifjyplp8ymc52navzgqyf2zc5x4lnvx",
-    "tree": "e10d0a372aeefa84479d5977eaab1bacb259dba9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tokio"
   },
   "external/rust/crates/tokio-macros": {
+    "dateTime": 1613830805,
     "groups": [
       "pdk"
     ],
-    "rev": "a7463d92b749d0cdc8351ad61729c21e3a1aab92",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "262d7bab7aa20967ff5215c9173eee799e610c84",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0py405c2b4bci1gj7gf4swv8s80fzqncm8kppfv04xd78ph9mmwn",
-    "tree": "73ae6097756f20f810c08ea2dd034427514f2c82",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-macros"
   },
   "external/rust/crates/tokio-stream": {
-    "dateTime": 1620954374,
+    "dateTime": 1620928101,
     "groups": [
       "pdk"
     ],
-    "rev": "686ec13856ca1dcd2e404b5f9c6c34d7e5aa4c0d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4eac2ac9bbb8da8fcecae121b37532b7a69af30d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1369f0daiyy9yvbf9k3caifcnp7b2wjywy29if55kl0rb0pgs764",
-    "tree": "72914b796f12019cf957d8c75594407aa482255f",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-stream"
   },
   "external/rust/crates/tokio-test": {
-    "dateTime": 1620954374,
+    "dateTime": 1620935669,
     "groups": [
       "pdk"
     ],
-    "rev": "d9ff73b7b1a8f753a9d6cb950eca5743cfb9862f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0d3c9c6ec56e0adc1e8ad8b1c62de6993a8fec36",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r8ddxhlrqdi8qwwj9frqp40l8jzzp3jk2w3bmm31n97sp8ma0xw",
-    "tree": "5c0a2fa2837cdf578d6277ad34559ce9c0af7fda",
     "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-test"
   },
   "external/rust/crates/unicode-bidi": {
-    "dateTime": 1619744832,
+    "dateTime": 1619647843,
     "groups": [
       "pdk"
     ],
-    "rev": "b3c9141970dd0c7c5c2d75cd079d450237d9288d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "06a9ea566c592bb3a6088a79a68ca80e03b964a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r6bd31wn5nbs18rrgaf47gyrivlxd2rni86qm78f4r7kabzadhc",
-    "tree": "ba149378c00d33edf2b1f48ebf6763aeb08bc733",
     "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-bidi"
   },
   "external/rust/crates/unicode-normalization": {
-    "dateTime": 1619744832,
+    "dateTime": 1619647850,
     "groups": [
       "pdk"
     ],
-    "rev": "0aa16f00599ecac3038fa8c3179d11bd90c99e7b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f483a39b82ca2fd9f506c4b9010ea989063c3fa7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z5amlnpv23q5n01093rx4j6byjc58yg1r1y0f0lcxxky293r718",
-    "tree": "214b179b4ffa07c7969655088f3361f7650a1aa1",
     "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-normalization"
   },
   "external/rust/crates/unicode-segmentation": {
+    "dateTime": 1613829405,
     "groups": [
       "pdk"
     ],
-    "rev": "8740269c3972ea1fa53d5b0a448a31f9dfd1c373",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f4830f1565f4565d02f73a5fd352310641930a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07fp8jn2fm4jpy523ifpc7fh9gsb1dqja1x9f508ggigmklgxhic",
-    "tree": "47be3ea825e1446e093c3b760db7d40a4e4e55d6",
     "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-segmentation"
   },
   "external/rust/crates/unicode-width": {
+    "dateTime": 1613823742,
     "groups": [
       "pdk"
     ],
-    "rev": "a3d42968da0a94cbb41d9b67cd5b503d95194a89",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c5a3f99ffcb4be0422565ff03a4fc30a4acaace6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xqr3v1kq561xbw126kj4xfvysd47sfj7rz4ld9pr9vm1nxmgr46",
-    "tree": "0c972b8768dec8097b2470d65a90d403559ec404",
     "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-width"
   },
   "external/rust/crates/unicode-xid": {
+    "dateTime": 1613830797,
     "groups": [
       "pdk"
     ],
-    "rev": "93f832dd475bb72da54872604f2c9c0f510d9f61",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e5bfb995a8122e99b4af17c3120024a92f740b73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11j24rxm4r9zykcidasjhgiy37p1lqrmkpa7dl0rdb7c1hyj7lnc",
-    "tree": "61cbc999afbb44a39051d64970ec4715eba50b3e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-xid"
   },
   "external/rust/crates/untrusted": {
-    "dateTime": 1619744834,
+    "dateTime": 1619647841,
     "groups": [
       "pdk"
     ],
-    "rev": "5b1d9d1eaf80db218f20308fb496090c27efbff0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3bba28be5317f43f24401ed843083debc63ced37",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "135jcnwi4f8a5lx7lphdc9w9qsdv0xj63lxh7wxgkkz00d12hh93",
-    "tree": "9a0d8f711d29ef10cada1eca97bdda6252989cd9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/untrusted"
   },
   "external/rust/crates/url": {
+    "dateTime": 1620407240,
     "groups": [
       "pdk"
     ],
-    "rev": "0d1005f104ec59539bfe86877ff9633c2e13e145",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "67db174e2c303a65b1390cffe47737e8e0c380e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wm10msikrg7l999qkrwddiy6q609j07agddz71gk83gar6nfid2",
-    "tree": "1a6ded2c2ce9ce49062f522b36b4915644506edb",
     "url": "https://android.googlesource.com/platform/external/rust/crates/url"
   },
   "external/rust/crates/uuid": {
+    "dateTime": 1616512501,
     "groups": [
       "pdk"
     ],
-    "rev": "80cc18bd69613c51dc5abfd809ffd0578cc588b7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d8da5771d9e7a45ce53479e4ca2787f66a10f2f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yi08nmd74fiixrpsjgrafqsa8lrzwcg7srhbsnf6j5sx7bql2jd",
-    "tree": "2c81d2417450e4ac6588744054f58be341bdf31e",
     "url": "https://android.googlesource.com/platform/external/rust/crates/uuid"
   },
   "external/rust/crates/vmm_vhost": {
-    "dateTime": 1620868027,
+    "dateTime": 1620855832,
     "groups": [
       "pdk"
     ],
-    "rev": "fa0bbbf1949ab12aa336a613d611893f09049aed",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "47d072cd3d43a54598498d19780194ed49e02fcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vxy8rasfr2acj4p8hzg3ysaibfl4kz7f8sd8lp0frpph18v579d",
-    "tree": "e55aa736a659071f6ecb7ef1e042c0d8e4e70363",
     "url": "https://android.googlesource.com/platform/external/rust/crates/vmm_vhost"
   },
   "external/rust/crates/vsock": {
+    "dateTime": 1613822488,
     "groups": [
       "pdk"
     ],
-    "rev": "40259139587e97943760117e55242073076539e8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e1d7eb958ae7a53a54064e4e458e66bf8eb0ee1b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13x5kiyz72rcssg5ldfdq77ss5xq2q6ixixijcn4sq5411j75dmd",
-    "tree": "6568264214021f58808210f4dd283a07bafebfbf",
     "url": "https://android.googlesource.com/platform/external/rust/crates/vsock"
   },
   "external/rust/crates/walkdir": {
+    "dateTime": 1617399186,
     "groups": [
       "pdk"
     ],
-    "rev": "b6ded2ebf6f901af7a81adbca347814871052df2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6617d0b5e77e8ef25dfc597787f16cb200572be6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "081x2cvl8zh0xh0nb2402kgdv1pak1j5hijlh3iz3msndcsqgrmm",
-    "tree": "96e25337c7fa5779459e6923eace69c0d4199ca8",
     "url": "https://android.googlesource.com/platform/external/rust/crates/walkdir"
   },
   "external/rust/crates/weak-table": {
+    "dateTime": 1613821619,
     "groups": [
       "pdk"
     ],
-    "rev": "c51adc606957b0fe7df3986407bed3de238a649e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fd2f8c4a9fec3fce8f2968d5365f51ffe5e2666b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18hkrqykf2rh7hbwzvxmwr58ixybbi7m6sl9mvb3pwk8yf2qzq43",
-    "tree": "f32d89028ab9efbc8f60d4a24af0f7f26f270740",
     "url": "https://android.googlesource.com/platform/external/rust/crates/weak-table"
   },
   "external/rust/crates/which": {
-    "dateTime": 1618362365,
+    "dateTime": 1618268738,
     "groups": [
       "pdk"
     ],
-    "rev": "e69f5f640c7bc8d83c0a43cf73b6c310979aec3e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2dafa0403b0cf2006d9f3a8eede326c200180b63",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0svgz9mn1d6a14dnhghvw102s82bjyk3s9kh5ja6h08kwch2yzv5",
-    "tree": "cc218f809b980499efdc11c0902cd6c3b2637ab4",
     "url": "https://android.googlesource.com/platform/external/rust/crates/which"
   },
   "external/rust/crates/zip": {
-    "dateTime": 1621811177,
+    "dateTime": 1621664595,
     "groups": [
       "pdk"
     ],
-    "rev": "d3a1b55dcd27463f0d39e8e10883b7325c85145e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4d7475814fd03cb687e1bd19817c961435ffd0dc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07da00h2m2kar3r2r891jhc625d5z99jb03vb3c56135kiasnzqi",
-    "tree": "ef34c15fdec9b0fe81745d51d78e536c9c74a3e9",
     "url": "https://android.googlesource.com/platform/external/rust/crates/zip"
   },
   "external/rust/cxx": {
-    "dateTime": 1618023970,
+    "dateTime": 1617918922,
     "groups": [
       "pdk"
     ],
-    "rev": "13fbfa02ea50d1cf3aab830d560d4bbdda23f0b4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1a566790ce84c05459eed321cd3e932b2bb55f68",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jlw2bpzhynqzgdaw4f23j41njwxhd47gi3iy64g29z6hqicmdcg",
-    "tree": "9a2047c0d2430d59acc4534f49b6de28012d7551",
     "url": "https://android.googlesource.com/platform/external/rust/cxx"
   },
   "external/ruy": {
+    "dateTime": 1615997763,
     "groups": [
       "pdk"
     ],
-    "rev": "e3935f2c103f8006db17ee0e93e231425a01c312",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "54d025dab5d7835fb7a61584076aef43527f732e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sl38mw33dcla901rq0dmw98lvpdsnwyis8fsxr5qkvar7fsfai3",
-    "tree": "aa0ec83d43383d770e0db00bbaa4d59a16283304",
     "url": "https://android.googlesource.com/platform/external/ruy"
   },
   "external/s2-geometry-library-java": {
-    "dateTime": 1615341997,
+    "dateTime": 1615311019,
     "groups": [
       "pdk"
     ],
-    "rev": "722a4d68649107aec8dec2b9f3d413e7ea3aed72",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9fcb918f1d61c4533dd9fb99ea2f2fd8c731132f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x5lyg0jhcnyh647vyyhn28l7x3qgf3x7b5pasd732rqi6kkcibz",
-    "tree": "f27ea98eec2fed908651be4f993bf6d633cfe50b",
     "url": "https://android.googlesource.com/platform/external/s2-geometry-library-java"
   },
   "external/scapy": {
+    "dateTime": 1614822458,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "608ad857a2b1fb4f89bc280bc211a7b690cb670b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "81a4281f9e96199add9a12981a722d43cd7c94d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vq0sjbxagkkinxvzx77h6sxcvqlbl9fz9z5845q8kb9wrf2a0b7",
-    "tree": "a274051070970972d2bf68beabedebffa9b643a6",
     "url": "https://android.googlesource.com/platform/external/scapy"
   },
   "external/scrypt": {
+    "dateTime": 1612563984,
     "groups": [
       "pdk"
     ],
-    "rev": "ca2b7bf020edf8481e005ba66b9996c29ecf6a1f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "765ab9d40639c3881e1fc272aaa8446eb0d58323",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12y4bhrw9wbp470b6pzpwcnxgy8nvlaskwa13vvpskyydiwxwr4f",
-    "tree": "ef6e754701f052db4d354a169fb0de14fd8d1bd0",
     "url": "https://android.googlesource.com/platform/external/scrypt"
   },
   "external/scudo": {
-    "dateTime": 1624598603,
+    "dateTime": 1624562247,
     "groups": [
       "pdk"
     ],
-    "rev": "5e5b1b308264dfdae5a20a3de6adae3f291f6eb7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fa314c027aa5e586da717fb6bbee2b77761bbda4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02wxvm3fsg67aff80n5602ymxm45nwys3ygv7wrmifh1vk7rvbg3",
-    "tree": "0d26f928e69c023cdd3b312fd3799c05764556cf",
     "url": "https://android.googlesource.com/platform/external/scudo"
   },
   "external/seccomp-tests": {
+    "dateTime": 1612563967,
     "groups": [
       "pdk"
     ],
-    "rev": "11babe8830f65800731fa73cb974bd9f862ad26d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "efd0d1b53e86af3a00c127d88e391fb18b6834c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "150n3hfdna544dfxw4xcd74idcz1c6rzdfzpxz26pv88ki79nzds",
-    "tree": "f062d90e3448e9405f8bae7e3b46aa9c8c4ac478",
     "url": "https://android.googlesource.com/platform/external/seccomp-tests"
   },
   "external/selinux": {
-    "dateTime": 1621048009,
+    "dateTime": 1620996762,
     "groups": [
       "pdk"
     ],
-    "rev": "36fe36276854d7fe4f6f735acd4782a94287de68",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "90f71ab3bc71f757ff55ab8e3bda80a46bcb8cad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19lc7df0wygsx22iljwg3528vxsib78ancc1rkq7xjdkhcv8nz7p",
-    "tree": "dbf7817b634cf9b7c3f3b1286e9afc48954b83d6",
     "url": "https://android.googlesource.com/platform/external/selinux"
   },
   "external/setupcompat": {
-    "dateTime": 1623892022,
+    "dateTime": 1623813582,
     "groups": [
       "pdk"
     ],
-    "rev": "0e3ddda0fbbf2811f45c175eaf7d0fbbe63be5c8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d562f5bb33b2e3ee7d1709bc4fbaef567e864fa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rsphhzb4r70d2fp30q60d4zqpqlwcrdnvh3sg31m5nzrgljypmi",
-    "tree": "096454abf50a73063ca997f864b3d5f3255a5899",
     "url": "https://android.googlesource.com/platform/external/setupcompat"
   },
   "external/setupdesign": {
-    "dateTime": 1625015221,
+    "dateTime": 1624927300,
     "groups": [
       "pdk"
     ],
-    "rev": "05b30985c974e9a8822fabcbd946ce05a41e05d4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f8947d4120f1d2e66fa79e3be34a2c5b3b1192af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p528d0ilgj0hmbzb5mss0zdf6qlrlzhzias8ppaw8l3zv6yq28q",
-    "tree": "fa0429fae76936b9bc212aa5ddd323759bc005fc",
     "url": "https://android.googlesource.com/platform/external/setupdesign"
   },
   "external/sfntly": {
+    "dateTime": 1613934583,
     "groups": [
       "pdk",
       "qcom_msm8x26"
     ],
-    "rev": "2e4bc603bf48583e2d6429f96691ff3bb35313be",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bb24290d3b3bea5e7bce050030164bc86d99103b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kakd4icw5z61imziwk9xrvrmzr0kz0c3xkx7ajqf313jl9i895w",
-    "tree": "08ede597c95e1cf3681a88758d2b32d95d7841d1",
     "url": "https://android.googlesource.com/platform/external/sfntly"
   },
   "external/shaderc/spirv-headers": {
+    "dateTime": 1613582544,
     "groups": [
       "pdk"
     ],
-    "rev": "9ff545977319524308cd2da496d7b9d670830f0f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1363fd1ff60402eaff412bcfb50334e0afce0b6c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1krwchhxqhsgjkj701884g0b40dh0j0ys78psi5g1mzvllbcnpq1",
-    "tree": "07bf693a60dd3825f5701ba4c528f9e22a6c4d92",
     "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
   },
   "external/shflags": {
+    "dateTime": 1613821628,
     "groups": [
       "pdk"
     ],
-    "rev": "03b047e19dde5868619dc17a7b11d22a0a6c4a3a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4db863f11a875bd4236327ca759604363891bb08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ffv97gprb7a2j3apfj97ss1ddj4l6zhpjacr63kxkwd4cd1sx5w",
-    "tree": "936ae4ec0932db7a36591d2981c183520defa01d",
     "url": "https://android.googlesource.com/platform/external/shflags"
   },
   "external/skia": {
-    "dateTime": 1632272742,
+    "dateTime": 1632183124,
     "groups": [
       "pdk",
       "qcom_msm8x26"
     ],
-    "rev": "1ccb672d7ddd168b23e60f396e67603d8b329ebb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a4b0c916887704b201c75f5308fcb88e73b7cfb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06y1y8148wswb0y49ziax0yiw4d7v5glzp483dsx2pzn52ggkj97",
-    "tree": "3e7f9d545e51615cfd343fb0c8eca6f6724f8a9a",
     "url": "https://android.googlesource.com/platform/external/skia"
   },
   "external/skqp": {
-    "dateTime": 1613866010,
+    "dateTime": 1613821394,
     "groups": [
       "cts",
       "pdk"
     ],
-    "rev": "92c04709d497dc35cef4eeb2bb00cdccafeba411",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "87d185db6e17035d7c0df51afd03c2f2f34d9b52",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rbdbripv9gbym5rannpyjycz7jc02rdsnf92l3ji6xz1k962a0c",
-    "tree": "d6fc62600342d3117da115c58ad22ef995529ea7",
     "url": "https://android.googlesource.com/platform/external/skqp"
   },
   "external/sl4a": {
-    "dateTime": 1628816771,
+    "dateTime": 1628804796,
     "groups": [
       "pdk"
     ],
-    "rev": "a8e227bb74d859b6c2f5ff3df114efb7502345eb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7ec2a6f8e499b7352d34fc2d06a32a04836e10a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0arkj14xx0hjmkffka5v076y6lj9ikjyvf41y5qlb2aj15142n4q",
-    "tree": "f3bd96d28730606f07881413f470f8fcb15c2e5b",
     "url": "https://android.googlesource.com/platform/external/sl4a"
   },
   "external/slf4j": {
+    "dateTime": 1613516549,
     "groups": [
       "pdk"
     ],
-    "rev": "defef8d631c276a06939c115861330061f652233",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "87b8b5d24bddca51b7fe8f4ca41ec4e29096ff59",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rqxhr85x42h7nl59j3hg9zdn3f8wgv44dk8g2nmvgzfd3l63ymp",
-    "tree": "c6e3e2bfb6e26946f6dae89b57ba39bac69616e9",
     "url": "https://android.googlesource.com/platform/external/slf4j"
   },
   "external/smali": {
+    "dateTime": 1613832659,
     "groups": [
       "pdk"
     ],
-    "rev": "3afdda2594cf651b95e8ecf94d2c601ca4f396e2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "92d1f8c876ab97ee78a9c89459f8c7737b6b70d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m2z3hm7q7hyqfabnw21sglarig5g5kjhv4b12387ckx9lzyxz9b",
-    "tree": "5b6f5a3ebc94e897e7135e28a01bf37befedcecc",
     "url": "https://android.googlesource.com/platform/external/smali"
   },
   "external/snakeyaml": {
+    "dateTime": 1613582541,
     "groups": [
       "pdk"
     ],
-    "rev": "23e9bd003fe83cefedfaab5e5b647abf67d05b8d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e2d542c3495b626ddb8233039211f3e474bed3b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11fyx45gqx1rqbk9cghj8lliv7g7qhfrfdbif9r0zjrmq56ap128",
-    "tree": "289b69754270af6de699853100c06511a48cef2d",
     "url": "https://android.googlesource.com/platform/external/snakeyaml"
   },
   "external/sonic": {
+    "dateTime": 1612566436,
     "groups": [
       "pdk"
     ],
-    "rev": "c1a92c115e55343907576086f0f458437a3e119e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c9d99e1aec6e62ac825607ac2daf2ea57264893a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17yl2bd3zy8wf0s2snz5734w3appr33c5f3f0jayw9crzdb8kksm",
-    "tree": "bd32d9a20040c3c744295b3dd38b96d6001b78ab",
     "url": "https://android.googlesource.com/platform/external/sonic"
   },
   "external/sonivox": {
-    "dateTime": 1633395951,
+    "dateTime": 1633395939,
     "groups": [
       "pdk"
     ],
-    "rev": "226254ed87ca000122d0a320d8d0c8d27f8fd099",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a1a79d77efb2d06e1c223fb0b7e4e9554108779d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z3w30hz7782xww6qgk3l5h7j899cdbvmnxvrwq28hnpmdhqlmap",
-    "tree": "428cf3250154e754aba76813cdc10dc7e6e10ab5",
     "url": "https://android.googlesource.com/platform/external/sonivox"
   },
   "external/speex": {
+    "dateTime": 1613829372,
     "groups": [
       "pdk"
     ],
-    "rev": "c2b46de1bff06ffa5e99d7a9eff7546b107da322",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "038fc2a96f550ea061de87417d3ce1581c68fb31",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b4iafcxynjq2y0i6hh3j7wgqzr51bnqm09ngwql72d12g7pvx8v",
-    "tree": "36d04350a9a77e39efdcd5ef215b7019071e793a",
     "url": "https://android.googlesource.com/platform/external/speex"
   },
   "external/sqlite": {
-    "dateTime": 1628557603,
+    "dateTime": 1628891958,
     "groups": [
       "pdk"
     ],
-    "rev": "9cb7940775be106573ce195e9fe2c11ca4a45ac1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1008a44d384b174b03214778efbcf4b644a70e82",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0nfx4l4ip228y03p6wpd5rwyq0sl8101xscgr3nb981vn2b8nny8",
-    "tree": "227c2b5c7acc6a7ec1b528ed6b14bbdf97554f85",
     "url": "https://android.googlesource.com/platform/external/sqlite"
   },
   "external/squashfs-tools": {
+    "dateTime": 1613582533,
     "groups": [
       "pdk"
     ],
-    "rev": "9eac3eec762e91cd4ad85ec6731b0bfc8e2c7ff3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "025bfc5d3e64045b37416449f2430240e6906399",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18yry9s66q0569l6kgnavxd84lpgqqg2zh7wqad7i7ca8kppagqn",
-    "tree": "424af68aa46189d3228118b1d73557e014374ccf",
     "url": "https://android.googlesource.com/platform/external/squashfs-tools"
   },
   "external/starlark-go": {
+    "dateTime": 1618037818,
     "groups": [
       "pdk"
     ],
-    "rev": "88767aaa63eca16325913e988bd8bf8e2c0d45ed",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6534601415abb396c57346800d5379846be89893",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kq1npxz7skla11q33az976l0kk4n5wpf3djyrhw0kglcd176vi2",
-    "tree": "6f80214d2720b24c8dd1d3221e44a143e257c8c0",
     "url": "https://android.googlesource.com/platform/external/starlark-go"
   },
   "external/strace": {
+    "dateTime": 1613591137,
     "groups": [
       "pdk"
     ],
-    "rev": "13eb322319a50338dc1ab3e50365760308a7ad83",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1a670ce285a73e037a7fc89369e0fba185f9ebca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rx0660d6z6s9id9mh8kjbmalm7qj38qrc3557k817iy81ac6n3g",
-    "tree": "bf32099eeded9fa1f1ba42f3b20920fdc307d962",
     "url": "https://android.googlesource.com/platform/external/strace"
   },
   "external/stressapptest": {
+    "dateTime": 1612566468,
     "groups": [
       "pdk"
     ],
-    "rev": "261e6386f626b1113e6e46224bfa9aa04969d769",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4958a37113f1e49af89cb96f6107140169c00da9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q9kbldax37x783ijnbwsr052kmqb87hs0m6z0cpnw29gdkmfai1",
-    "tree": "365658e92cf59e3056ef3fe5a1e05c7adc353913",
     "url": "https://android.googlesource.com/platform/external/stressapptest"
   },
   "external/subsampling-scale-image-view": {
-    "dateTime": 1616029562,
+    "dateTime": 1615327434,
     "groups": [
       "pdk"
     ],
-    "rev": "faaaca349c1f29eb9ba86590504755214888a48a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "251fe56a923c2175707da7bfca7441c39d2d1482",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0brk3l0gd33d4h8rjb06r7vnlaz821yc3bhpsyskvfv6inkpxh1s",
-    "tree": "38a16ba8bc15938f242d8f0b7539f8b375375396",
     "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
   },
   "external/swiftshader": {
-    "dateTime": 1615856768,
+    "dateTime": 1615834135,
     "groups": [
       "pdk"
     ],
-    "rev": "0d7c5d9b048d2e6475ff88c307a5e56cc84d6172",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d1ae25c2a1ac9f604a2d86015048afa45db170d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19drp33i5ha2qlxj3xgv37s8lxx0h0gmzh834fga2ydiazc2lprx",
-    "tree": "eafa5e72dbb6ef5075d9560aaff642c96ecbc95e",
     "url": "https://android.googlesource.com/platform/external/swiftshader"
   },
   "external/tagsoup": {
+    "dateTime": 1612563990,
     "groups": [
       "pdk"
     ],
-    "rev": "c7202b5d8fbee66f412633c8a4c35ee6a7b8f983",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "06749bc5d1d1623772afa163af2e0206f2c0d96b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "092v7vx5md9lkgsnds9iaknsx7n1hm7daazy3icmahiwkq3fs684",
-    "tree": "68fcd2eaeea19931224489508d85daf2e0a0098d",
     "url": "https://android.googlesource.com/platform/external/tagsoup"
   },
   "external/tcpdump": {
+    "dateTime": 1613591197,
     "groups": [
       "pdk"
     ],
-    "rev": "06cabd09769d00ee1b1cbd92ec7102879b3009a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0d6ed158ab36b51666c18e0f55b296ac6c347ed1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sy5691a5g4lbdzq449jlywn2pl7g57bfc5a70238ivdi57351bs",
-    "tree": "08227c7efa809e34de1272d0c05a004f8550b647",
     "url": "https://android.googlesource.com/platform/external/tcpdump"
   },
   "external/tensorflow": {
-    "dateTime": 1616720754,
+    "dateTime": 1616627707,
     "groups": [
       "pdk"
     ],
-    "rev": "1c199f650b993ae14ab09cc419574bfb8c30e391",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dce31676bbf68acb6806c8d16e50133b2852e510",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "163p13dy1ghbpii05y2z2ljcnaf6w40i1cbd1ipv0wbf2pi57d7y",
-    "tree": "8ab5352fbebe88a96b9ef9c83134a063548a226d",
     "url": "https://android.googlesource.com/platform/external/tensorflow"
   },
   "external/testng": {
+    "dateTime": 1613516538,
     "groups": [
       "pdk"
     ],
-    "rev": "ab879258f8ba2354ec751b1f461b9c0d5db967f1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e840fdf90e074878009318caae490783ce2061cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06hxhlmx7958xbfj925xcmmzm5h3s16jxwqcahh5yp4zzn19af37",
-    "tree": "fdc7e326e6ac99b2dfdeec1f0b61859756ffe3b6",
     "url": "https://android.googlesource.com/platform/external/testng"
   },
   "external/tflite-support": {
+    "dateTime": 1616512496,
     "groups": [
       "pdk"
     ],
-    "rev": "fce63892235a4c68a1c8ddf0cbb248459ef2ffc7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6bafe671403d9ab22c37ac64c6d202b7dc5905e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00mj6sp3h53wpwgyfwmnxfch4j53sfbdijfrwg1n4g0ymafr2adr",
-    "tree": "63ba5a62524b5a035cee917ea4e3b7a06c6daf56",
     "url": "https://android.googlesource.com/platform/external/tflite-support"
   },
   "external/timezone-boundary-builder": {
+    "dateTime": 1595932940,
     "groups": [
       "pdk"
     ],
-    "rev": "340a788f8294ac67d8f45827b84f6f22f7db5b17",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "582fe290e64d938920896d5846e2b689c71f807e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09laamss9pk6q4fbl6gppz8d8ix47qvazqd3r8x4p36qga68n6wc",
-    "tree": "0539b5049b8d29df0549410582f811b2743aace8",
     "url": "https://android.googlesource.com/platform/external/timezone-boundary-builder"
   },
   "external/tinyalsa": {
-    "dateTime": 1625188133,
+    "dateTime": 1625043461,
     "groups": [
       "pdk"
     ],
-    "rev": "ddcf01dc8c07a79353c10200fcaf4b930f64e498",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1957af17f7db99aab016796b7433cbaf92969c2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ka8qwa9j78gsiygs7rlk78lf79yir26202rf0j26xwb5aq2rw7r",
-    "tree": "c1fdd4e6db06429e7a726e1453292e3179f810ef",
     "url": "https://android.googlesource.com/platform/external/tinyalsa"
   },
   "external/tinyalsa_new": {
-    "dateTime": 1626743227,
+    "dateTime": 1626438113,
     "groups": [
       "pdk"
     ],
-    "rev": "f374d9435e55444df85ca9693d6b2ef18e1ab075",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "73d1b1347fba03f2ce4421d30b90f9d70e3e85f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jjl611jjrh65kk92zdp5y5jar0qyfrcv2yz86wsf71rld5ljm48",
-    "tree": "dba9653c5ab26933a0a29a0a19f754f14e96fe89",
     "url": "https://android.googlesource.com/platform/external/tinyalsa_new"
   },
   "external/tinycompress": {
+    "dateTime": 1613582535,
     "groups": [
       "pdk"
     ],
-    "rev": "ae01b431d49f738da1d14ba08aacc26e0733ce8f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "59c0d2648019f634750ee5885503a312a4293250",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "148k9dgzbrrrpx8c1f8plv9zdv66m0kia8ijc0j4mgfz05cnl0wa",
-    "tree": "50dccb848fc9c0f9c9b0fd2ace4f33fa0aa32cc9",
     "url": "https://android.googlesource.com/platform/external/tinycompress"
   },
   "external/tinyxml2": {
+    "dateTime": 1613815717,
     "groups": [
       "pdk"
     ],
-    "rev": "73d55125b4c4abe07c8c5077f67356663f2225e8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ad28040d9dd954720c5c5850c9f5a508c0c7c6d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02cns5hw21sqy0vdd7601aj8v4cdi4rzm08fvpf8xav04xc6n4k7",
-    "tree": "db2f3acb55819b5b31864e66045594704678c02e",
     "url": "https://android.googlesource.com/platform/external/tinyxml2"
   },
   "external/toolchain-utils": {
+    "dateTime": 1615355841,
     "groups": [],
-    "rev": "ba187c4246da9156d7d2e9aed802360dbc1ba1a3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8c091064d3ca02f62d183237cbaee2032acf2bf9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pi0shn1aqwn59yxids5v0jnbbhn3gafplfhp5iy9waazwhl3pfd",
-    "tree": "73936aba47fe1dc71e9cc05af9747036e935608c",
     "url": "https://android.googlesource.com/platform/external/toolchain-utils"
   },
   "external/toybox": {
-    "dateTime": 1620515183,
+    "dateTime": 1620434600,
     "groups": [
       "pdk"
     ],
-    "rev": "05e673e5f54886cacd332a50e4d1c5b3333b5262",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4fbf4c014308be22199b3244e337670710efd1e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19msz3f8ggk2qy0xif0m92aa528phlg74ibssy2b447yj735vkrn",
-    "tree": "b35023430b0f74f46adc73b8a27b0622f7f51359",
     "url": "https://android.googlesource.com/platform/external/toybox"
   },
   "external/tpm2-tss": {
+    "dateTime": 1613516540,
     "groups": [
       "pdk"
     ],
-    "rev": "d1c5934b75ac91fe28ba68fc7f104559d87b2b84",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "08e6bb82bf4524881da2e2bfca28cd26bc6b457c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11niy75h4yrwp73sbrx24v36l20syyl77cvnfy8lnxz51khs73g8",
-    "tree": "ad9154664f53f009b386bc5cac7286a1a2d41f95",
     "url": "https://android.googlesource.com/platform/external/tpm2-tss"
   },
   "external/tremolo": {
-    "dateTime": 1633395962,
+    "dateTime": 1633395950,
     "groups": [
       "pdk"
     ],
-    "rev": "90718cc4e599574eb2c0781447ba7958fd6c4773",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bce535f9a9d105af7d02701708cc1a67c7f47d11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1aw5cmc27cclq7fb6mk5f3sljk7b5dplscmr0skh4wb6jwprgd80",
-    "tree": "759bfbdcc9f29d319413d92a19b70ab4b54dec43",
     "url": "https://android.googlesource.com/platform/external/tremolo"
   },
   "external/turbine": {
+    "dateTime": 1613516542,
     "groups": [
       "pdk"
     ],
-    "rev": "2b378c6d9605835bbc48d3dbc831eebce70a1305",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fd65cdbec2b6936cd4ce03bf25465b991ac769b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m3n7da7cg181nd9y80fm6zg7dr6i26baxg47yxkgls1agc0garm",
-    "tree": "a7fa8fc6aa0656abac95cb56fbde65706b79e78b",
     "url": "https://android.googlesource.com/platform/external/turbine"
   },
   "external/ukey2": {
+    "dateTime": 1613829431,
     "groups": [
       "pdk"
     ],
-    "rev": "ffc60809cf41d86d3686debd41d51947399632a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1c9bef63541fd544632dc9e84ab26fb6b085c68c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wprw0h3d5qvzikh24b019506fwmjgzah0j0lmdraiv24vqspldj",
-    "tree": "df40fdfaf3c7f073f2b61cae080cba5d5a906141",
     "url": "https://android.googlesource.com/platform/external/ukey2"
   },
   "external/unicode": {
+    "dateTime": 1613821250,
     "groups": [
       "pdk"
     ],
-    "rev": "5db4e5db0570c7d5b54a1a21b2d0fee4673f2238",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "349f46635625fa1dd95893e120dc97715313dabc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12d79gr4w732rz15dnqmgmfxs0kji8ih5sp1l5pksh3ak0z0syng",
-    "tree": "ffc46719d8d5ad4140a838af2f542766cd89e79c",
     "url": "https://android.googlesource.com/platform/external/unicode"
   },
   "external/universal-tween-engine": {
+    "dateTime": 1613582549,
     "groups": [],
-    "rev": "2ea0bde8118bd5da892225d41d3a65c10c03f21d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "35d9cbeb4444e14c5b3f610f7f6954292bb9f3a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ah027mh8lgrsdcqp8pbv1l6gcxjxaj8ksyji4v244awrqdhmpx0",
-    "tree": "0763d65507beb65700f1fdbcce31313a4e60d713",
     "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
   },
   "external/usrsctp": {
+    "dateTime": 1613934499,
     "groups": [
       "pdk"
     ],
-    "rev": "e229e38aa50c8159153e005b4554f15b1ec81d84",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "10485cbc0cfd402b1bbc38c2f14e58b9d6771145",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ys21xj86zc4rx0x49d3r62mdi8kwx4035xbyslxqs4qlrai618c",
-    "tree": "7b313d54b5216b9844764f8a2ae86085b54b6fa9",
     "url": "https://android.googlesource.com/platform/external/usrsctp"
   },
   "external/v4l2_codec2": {
-    "dateTime": 1620868054,
+    "dateTime": 1620787999,
     "groups": [
       "pdk"
     ],
-    "rev": "4dca80b8ef5fdc300dc5f7f162cd7a8abf26d340",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2be28169417c457ebe4c87deac7d749b14aeb7be",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10j7qfbd5dn5mycywxr8a6j19px7rz6nwwxijr8kdkkxkr2lsb4b",
-    "tree": "7951145509068d268b8fff7fc02070154ebf0501",
     "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
   },
   "external/vboot_reference": {
+    "dateTime": 1613504473,
     "groups": [
       "pdk-fs",
       "vboot"
     ],
-    "rev": "beed75b660b390c3ae11ff369e1a2717dc440778",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2a1ded27fe5a0a87276a42afbd116d25bedfe583",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0dbrh8hy96vrfdxs7p4vz6y7k256sr6rk9dn1d0nk69pzf58xssa",
-    "tree": "af0617635a45894ebe2e91ed29e892f6babc7048",
     "url": "https://android.googlesource.com/platform/external/vboot_reference"
   },
   "external/virglrenderer": {
+    "dateTime": 1614986217,
     "groups": [
       "pdk"
     ],
-    "rev": "a9cdbbe4da5b52e56ecf5b372d9a2035f364c5bf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f75841758bee9b9bf4d90ee113fbfe1b03a62a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m5588rz56xb42hghfkqw5qp5s4mcwcwy97hqnrxcl4sbngmmpx5",
-    "tree": "1418aa452ff3c020803ac1248aedd190ff7228ec",
     "url": "https://android.googlesource.com/platform/external/virglrenderer"
   },
   "external/vixl": {
+    "dateTime": 1620388241,
     "groups": [
       "pdk"
     ],
-    "rev": "48173e38d788fc496b46b1840b42f636dcc9fdda",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7ec619fe31f636cd58f2f13200353459edc7975e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kgrgqmprmiy2rha9idcqljy7xixgn9cs64vwx3b8swpb08bymar",
-    "tree": "73609591c1f956a112d34287dd9d50d2e583b2fb",
     "url": "https://android.googlesource.com/platform/external/vixl"
   },
   "external/vm_tools/p9": {
+    "dateTime": 1613828473,
     "groups": [
       "pdk"
     ],
-    "rev": "b7ead5e1890a63c53efcb9d7a2b9ee5b25c38e23",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "487ae2c69578867f99fcc9f49b28be83fc05054f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0iwq1zq7g03drxl6a8qn079a0ijc16s1yp6c3licqjdddqg74gx2",
-    "tree": "c9e3e84e694e9ec706b8052678d853bc2dad43c3",
     "url": "https://android.googlesource.com/platform/external/vm_tools/p9"
   },
   "external/vogar": {
-    "dateTime": 1619744864,
+    "dateTime": 1619700425,
     "groups": [
       "pdk"
     ],
-    "rev": "89236de3882b2f03e9f92cdcf16657304cc7c131",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b591cb9e0d75a54b37ca30bbd47ba7e0495645c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pzid6jal940rcrimdf22128c458rkjqalnhz56k8mh0i049pzgg",
-    "tree": "c17317e718ada6f5cc43e86d859522c5bcda6fd5",
     "url": "https://android.googlesource.com/platform/external/vogar"
   },
   "external/volley": {
+    "dateTime": 1613821503,
     "groups": [
       "pdk"
     ],
-    "rev": "39e8d40e8ff59975517e252f5ebe895f8f5a1ca8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d547971f33073ea4a3b6f9c908ce8e9b4daead53",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1679hx3m8h1k6q8c38pqam01dsbdvrb9y16ylxahi53cc1xqj9c3",
-    "tree": "bafe6d115be2559d39c73bfd437bb9d14e3d596a",
     "url": "https://android.googlesource.com/platform/external/volley"
   },
   "external/vulkan-headers": {
+    "dateTime": 1619578330,
     "groups": [
       "pdk"
     ],
-    "rev": "af4d24a8bf87ed8428e4e5f5bc03ea0d46e8d542",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dc71347b2926d5b7dddb1b3bfd473317f9a2f88a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04dgizyvxg2p8s46n8ha24yhjmxrzqvaqy8w9v6q5q9v62z2qix0",
-    "tree": "afc6b927e7433a4e1fef86c9c6a1e82ec20cec5e",
     "url": "https://android.googlesource.com/platform/external/vulkan-headers"
   },
   "external/vulkan-validation-layers": {
+    "dateTime": 1613821429,
     "groups": [
       "pdk"
     ],
-    "rev": "cd45f9e1a0d33594f0ad8557fcf4a038f3cc4fb8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a636bbc92901e3167b9dea7e5c64c60d5c057087",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b07rm2880j171mswhqmppf6mn2ijrdl3hz6bicaw41cixz4ckm0",
-    "tree": "3cd48d215b895dc3147ab91ba69dfedd762bca38",
     "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
   },
   "external/walt": {
+    "dateTime": 1613815827,
     "groups": [
       "pdk"
     ],
-    "rev": "ec2210fe11c2127f421694f2efc2dbb920d970db",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dd7f36ea3253647f10c8d2a1b5afa316e71d933b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04g2zdf06pyk0k6s9ss6yswannhjqhz2m60msq206nvl1qdz81l1",
-    "tree": "0e3b5815af1721855e158545a7b83536f826ba1f",
     "url": "https://android.googlesource.com/platform/external/walt"
   },
   "external/wayland": {
+    "dateTime": 1614986414,
     "groups": [
       "pdk"
     ],
-    "rev": "a0f45f8de02db002ab3a02d9323072195901cd48",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "77876c86c9219ad76f558169765029a3e51cb40f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03wp3x0k8lys9jkm4arkcf0zkc9xal2jx9yhi2j9j3qk4h25pi4l",
-    "tree": "c77b920bc24a35291358fb3890a2cc9a3c6782ef",
     "url": "https://android.googlesource.com/platform/external/wayland"
   },
   "external/wayland-protocols": {
-    "dateTime": 1624598630,
+    "dateTime": 1624415708,
     "groups": [
       "pdk"
     ],
-    "rev": "26155561bcfa617d1c63ed3c978cfaa61faf8567",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a370133c69b3400c407f70bb71a1673451b32db6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1znvrprlp128kakcp5f1zqdx0r619hnbia9b64cmfqibmqfdhplm",
-    "tree": "418df681d77ca0a22ecce5583b178c186848bf76",
     "url": "https://android.googlesource.com/platform/external/wayland-protocols"
   },
   "external/webp": {
-    "dateTime": 1613866033,
+    "dateTime": 1613824010,
     "groups": [
       "pdk",
       "qcom_msm8x26"
     ],
-    "rev": "d786a26f6317469e85252ce43a7eb84b527f4fc6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ecf17565206810a3d2966bed4490a0de9ac2c80d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "15zv6w3wcw11qwx5f95p5cxb1dbrfkyzlmcl6w5dx9wn0cyxjd55",
-    "tree": "d5d475510deb26fe06db4f8b9f2c531a3faf4bc0",
     "url": "https://android.googlesource.com/platform/external/webp"
   },
   "external/webrtc": {
+    "dateTime": 1613827215,
     "groups": [
       "pdk"
     ],
-    "rev": "8c5fe81ef459f0e9093af8c7cbad65fe58265a01",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cf74cacf7db81bdb7f25bb71b499e09edadc5cf9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00jjyl1zwgqdzmakvgsw6iyasiz1y9fwh2k3n2yff0050vk6499p",
-    "tree": "cb306ffb64819f95c080c3cb6bfcdfb45a7b3a76",
     "url": "https://android.googlesource.com/platform/external/webrtc"
   },
   "external/wpa_supplicant_8": {
-    "dateTime": 1633482410,
+    "dateTime": 1633482384,
     "groups": [
       "pdk"
     ],
-    "rev": "9604e4b8a97244695d428bb448d64fd822eb6f63",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2240fe9bf6333b18885998fb19ac7fd0ec44aac8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z177w56w25hmqdrhsg895cbqbb9d0wz7vyx91k7jqkbijgkw2aw",
-    "tree": "3fe38d22019587dcb28052e1103aa52bc547d59f",
     "url": "https://android.googlesource.com/platform/external/wpa_supplicant_8"
   },
   "external/wycheproof": {
+    "dateTime": 1613060169,
     "groups": [
       "pdk"
     ],
-    "rev": "24b52305573ee054e9085de2587acc72799a76d9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5250c8dfb5205571f3231e6e94e6b81f74be216c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0waib4n8k684l4nl339w9h1f5g52461qh51kk1inknj2bpvy78vn",
-    "tree": "c184b5392ea92544d6c05fac120fc540ade597d8",
     "url": "https://android.googlesource.com/platform/external/wycheproof"
   },
   "external/xmp_toolkit": {
+    "dateTime": 1612566528,
     "groups": [
       "pdk"
     ],
-    "rev": "04857dea50f64004b32e130c93ef1ebb32d37028",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9e51131c36cd84534c9d65a612d1fe194ec0523b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vni2h737zxzcd9lg7fgxh3vv88508kn1kli04nh2cqmld9a9x1v",
-    "tree": "1977aac3bc91fff51858ebf14a67191c9b3cd9c5",
     "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
   },
   "external/xz-embedded": {
+    "dateTime": 1613513319,
     "groups": [
       "pdk"
     ],
-    "rev": "a6e0ddb3bdc2539bcccec29292c903ec0f8099ef",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d4c875c23ca77276d44b377724575d5b2deac4ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "073plk8szhih5chpaf91jfi9w3f8sgx3s38y79zk9g11mms40dpl",
-    "tree": "25be5bb14dfc867edd537e18b3ee4fe6164a1ac1",
     "url": "https://android.googlesource.com/platform/external/xz-embedded"
   },
   "external/xz-java": {
+    "dateTime": 1613582537,
     "groups": [
       "pdk"
     ],
-    "rev": "93a6e2ce24f392e1c2279da8ab4f7a8db71d0f81",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "57316b5ce8c5d2bb5577f400e1204b0427704f9d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "106wni1mvkx7jjag4401v8dkmqrl7kyd17a8nlik0wqwai9akmbb",
-    "tree": "83f6a2c47a822addcbe9485c7d85fc1c826ac807",
     "url": "https://android.googlesource.com/platform/external/xz-java"
   },
   "external/yapf": {
+    "dateTime": 1588621644,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "f6b138e426edd9728e21f5b0f49f5b1c7e515c42",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a987369c65841b8db65e55f9cebacec4d02355ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04cxpdc46h0z75d2b8a73lx3x25k881qkps309sa7irxvqjlq4av",
-    "tree": "82121b22ee265142581fa4a7a73d81f91ff46e47",
     "url": "https://android.googlesource.com/platform/external/yapf"
   },
   "external/zlib": {
-    "dateTime": 1620443223,
+    "dateTime": 1620401991,
     "groups": [
       "pdk"
     ],
-    "rev": "90c22149afdb9f5fa59932a32a59cddf37c01811",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1e23ea5216900d92c42960176e5ed2e676bb1f9c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12640wzjmqgjdya2zdb14ir5d3q1fds04hs878wsw8jw84aw3jkp",
-    "tree": "28fbe268bf51b1364ab6c0f0266a6f3c775fcf98",
     "url": "https://android.googlesource.com/platform/external/zlib"
   },
   "external/zopfli": {
+    "dateTime": 1612566556,
     "groups": [
       "pdk"
     ],
-    "rev": "1aeb6fbbada487bd09fea3e462b9dd439e8c5d68",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e70b1bc83cf3839fa2a943e8a785c5b7f069b1b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y0lrn1mcw9233dr93361d0mjwpqlsrq4d31l1kgr1lyfdx2lf5l",
-    "tree": "066e3b713c82c0144e4ce24b77de5231b5b1b49c",
     "url": "https://android.googlesource.com/platform/external/zopfli"
   },
   "external/zstd": {
+    "dateTime": 1613815648,
     "groups": [
       "pdk"
     ],
-    "rev": "ad2a5801b7b3a6b57ebadc91e43f1cf6e843e2d0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d20c08c49c80f0a9f2be96282cf9febc6ed9f075",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0nc7pf97s580c66hyd11zjcj1ah7dd2ls3nkgdia3qmrfphwl74x",
-    "tree": "3768027f18b5ab3fd307da9f0e225d6df6792786",
     "url": "https://android.googlesource.com/platform/external/zstd"
   },
   "external/zxing": {
+    "dateTime": 1613582543,
     "groups": [
       "pdk"
     ],
-    "rev": "8bb4894a8c01d15531885851ea24433e6ab19c78",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "de657f14dfdb612a6b6b87e4e718bca345a6b9cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hn3cmj8msdwggbqzaqvscri38df1j35c921i2k518wikghi7wh0",
-    "tree": "e75c0d4423dd8df0066eea12d9f110efbd7e1261",
     "url": "https://android.googlesource.com/platform/external/zxing"
   },
   "frameworks/av": {
-    "dateTime": 1633568800,
+    "dateTime": 1633568823,
     "groups": [
       "pdk"
     ],
-    "rev": "b1c8d7197052a4a90c74433465fc00964106811f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8391b9bccd30d4969d1dfa3b0124cebd00339c17",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gg9ygyiv82lxrxbpvnlp4nxi7w0d0g420kck21ds9nxxhjk91z0",
-    "tree": "da8cec7951f264c777d072d4a4e58e3e14f003ae",
     "url": "https://android.googlesource.com/platform/frameworks/av"
   },
   "frameworks/base": {
-    "dateTime": 1637208613,
+    "dateTime": 1640531096,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "ad30407070fadfc91132ed2b69d2343839c94fee",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "1zakllri0j0q0xwv6bak1n6pbb0dahihk4b0qas60jylrkjpf9py",
-    "tree": "0cc35758492d2d0474f0afe572f9683b47137895",
+    "rev": "4dbac148afe0a6ac7f4ceebc5e4a1df79f4e1321",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18zbyhy1bv9wxc9qckwigdldbl0mxiyigsvd8pfj80bwi0lsj97f",
     "url": "https://android.googlesource.com/platform/frameworks/base"
   },
   "frameworks/compile/libbcc": {
+    "dateTime": 1613828095,
     "groups": [
       "pdk"
     ],
-    "rev": "23ffe811ac64dcc2abeece415e7568ae6975a0d9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a60a8975466f4848a0e81a24c1aded90145909ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n03c58wxfp76z0hk2y93r6jfhi7rvrbmv5iwnj6gy9aw6a5a4fg",
-    "tree": "e7436828b4d66f275c3baf15fe713fa1048fb888",
     "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
   },
   "frameworks/compile/mclinker": {
+    "dateTime": 1620748411,
     "groups": [
       "pdk"
     ],
-    "rev": "b5626ae3ab7d426588e24a5110a0529a73974703",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1d6d49df764ced3e97b6843003d27c2d59c15f1d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "162nkr6acndsx278g31ygazpv9raxigb69qnic1sv97n94v7yyvy",
-    "tree": "e90c882bb55d9c813e7cb71660222f2cb299c2ae",
     "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
   },
   "frameworks/compile/slang": {
+    "dateTime": 1620409385,
     "groups": [
       "pdk"
     ],
-    "rev": "2a5497a068f6e24a3bcaadba4df02fd691cf3eb5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a1e81eb7146f6ea588c40b4696161cc279cbb5a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16jzz2xrgipqlp8ixmssapxpqnhyz0x8rlwkv52v6g90psl25jl8",
-    "tree": "b77bdf0926442a5b1c72f42c10ae68f67f57afa8",
     "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
   },
   "frameworks/ex": {
-    "dateTime": 1629343346,
+    "dateTime": 1628875406,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "ca155be1cee318b9df079c7fa0f67e5ee191aa8e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "63c10bd46811bd24ba42acaf8c1a321c617ff4c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pr2k2a0hk47khbl1bp9ljxcw95k78b37qbkql9vh51r89hrhyis",
-    "tree": "f9a53d6a0137d05c0c68decf49697d5d247fe2a3",
     "url": "https://android.googlesource.com/platform/frameworks/ex"
   },
   "frameworks/hardware/interfaces": {
@@ -6955,103 +6705,95 @@
     "groups": [
       "pdk"
     ],
-    "rev": "1a18d3b8f9bb3abdfc1bfecde268c6e2ccb5012d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6da080a13df98d6f642637c94e7f0ae7ab9ee332",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1031nf3zchb7jgx4jr3qrmssjr6l5jb54iwdalx616avaj8c9wxs",
-    "tree": "421d67f1f4ca08006a5e10423f2a588a431be1ee",
     "url": "https://android.googlesource.com/platform/frameworks/hardware/interfaces"
   },
   "frameworks/layoutlib": {
-    "dateTime": 1619053628,
+    "dateTime": 1619018501,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "2d0a5861637530062d1c6e697329953bd24c6d43",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4365306d353a909eafbf7dc0a6e5186cd71a4e5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1cw2y7xcd3w1nzljvzgckli8d328y5xxj5ynmxpnszcrlyiymish",
-    "tree": "9e1a3d30b39c2c7ab4f6ff97be6aec9c808d4b89",
     "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
   },
   "frameworks/libs/modules-utils": {
-    "dateTime": 1623978465,
+    "dateTime": 1623778244,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "b4a40fa1e92273c569364b14dab30bfa069d512a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2e25fe41bf216bf59395896eae7e129b5aeeca09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0fsixxvkxw1g26jjlwmmrybbzzwgxl1gswbilyk73dmf1cnmx711",
-    "tree": "b604848d4716b964d68cd9a1114d7febbd772328",
     "url": "https://android.googlesource.com/platform/frameworks/libs/modules-utils"
   },
   "frameworks/libs/native_bridge_support": {
-    "dateTime": 1632539195,
+    "dateTime": 1632513319,
     "groups": [
       "pdk"
     ],
-    "rev": "b5398a7ef79f326d3fca4601bd5e17f056718608",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ed706257601168365401fdac1132437f086c6986",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lw018vdaf1imrgfz542752ddy9kz29x5lab3sgg1680r4fcw2s7",
-    "tree": "3861c59451000d4d47125abb10f71bb1a06d330a",
     "url": "https://android.googlesource.com/platform/frameworks/libs/native_bridge_support"
   },
   "frameworks/libs/net": {
-    "dateTime": 1629248810,
+    "dateTime": 1629157082,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "bc5279c31514c1de0b03b6cd53007a7ac991b1cd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "64dca368b41bdfb60054732a790cdb37987fc0d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0raxv23lflhvcgnz1ci2w6fn6gv5kyb6zx5fmmv8s8bqsq3sbsgm",
-    "tree": "5658dc3bc144e48179a9b1b3ea6fe01579168d53",
     "url": "https://android.googlesource.com/platform/frameworks/libs/net"
   },
   "frameworks/libs/service_entitlement": {
-    "dateTime": 1627520849,
+    "dateTime": 1627490635,
     "groups": [
       "pdk"
     ],
-    "rev": "17d892e0e0c2d906eb8b1b16bf0d60d3c11eff60",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5b34ce57ef4d23e0ed37729a1869e5283c1f0082",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z9kin6rn0dh7h1av6larf9swnzcni5ckjc4v8pzyrdvff9qj3l3",
-    "tree": "52f4cc8588931e1590e9b60f2f04e30035b9db37",
     "url": "https://android.googlesource.com/platform/frameworks/libs/service_entitlement"
   },
   "frameworks/libs/systemui": {
-    "dateTime": 1629421596,
+    "dateTime": 1629364203,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "036d68b5747cd742aa20b3f319239d8c0774506f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "47668892332b0e655ba27b25528910198214c617",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g7k9xz6k4ylnjkwy686db9alxhk7rpny4kkcvffglcsssmwlhmp",
-    "tree": "5b4c37764e65ff784b2c0a7f4dbef3f46635eaef",
     "url": "https://android.googlesource.com/platform/frameworks/libs/systemui"
   },
   "frameworks/minikin": {
-    "dateTime": 1623805665,
+    "dateTime": 1623269926,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "5ece9d722fe3d7cc6b6ab4cc60155f6e4a5d5eb9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dfb7649f7e12d5b7f2ca3381732f0168202540a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gja9jpb28rzvjk25ii48vq8mzlnsrhv3ja9k9xmab0jhkpfam99",
-    "tree": "ec5bc1c91ca33edd214357b76698c03f0f128600",
     "url": "https://android.googlesource.com/platform/frameworks/minikin"
   },
   "frameworks/multidex": {
+    "dateTime": 1613504479,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "d07e4cc436408812f80f97e1e98c4ac1ce14839d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5ed98aade04197591e43dc74fce00611ccea7d8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xwqn0ik1in5rpwnr1xygbggjm8ysiknp2hvf2m24859zg90lng7",
-    "tree": "49cfc4d8344e7015c625f74f9cf31d83d6283bec",
     "url": "https://android.googlesource.com/platform/frameworks/multidex"
   },
   "frameworks/native": {
@@ -7059,43 +6801,40 @@
     "groups": [
       "pdk"
     ],
-    "rev": "2d0065de1c00eac67d3c73fab767b32b976f913f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1f41a0ff9c05b40f5fb06db6187cf9513b63d179",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "036za5mxw82d9qavp2l1axmv9wn1kaq0dmapikzlryrv4dk9390h",
-    "tree": "540976f1371721dd573c8f67c52b0b6a6537ca15",
     "url": "https://android.googlesource.com/platform/frameworks/native"
   },
   "frameworks/opt/bitmap": {
+    "dateTime": 1613504478,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "e4655cf85a47f982f228e19fb42dfaf58f1c919a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "70898990912403141be52dabe383999aafec34b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ipvhhkj8d1fpixx5s51133k87riqdczaarw9lnr65anx4s781sb",
-    "tree": "bc524e8095bede9b190b597926f2a04209e871f7",
     "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
   },
   "frameworks/opt/calendar": {
-    "dateTime": 1613531886,
+    "dateTime": 1613504472,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "45d8e4439bc57cb5d1c2e54b4893c55f1cae6746",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b4de6cc21542999d8340810fda4b4305791cf0ca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jjj2y6qsj5q20fj4rr1kbx7cn233myv6yk5l2j23x41nryandd2",
-    "tree": "c9dc8dfb27aeebd6daf5c8c04627e9bd0d18b961",
     "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
   },
   "frameworks/opt/car/services": {
-    "dateTime": 1625188164,
+    "dateTime": 1625021065,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "a926fc9acd5682e8d7c827d69878e8873ce43b51",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8a27e52439083986e0eb5f899e4f35f250559046",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "199qvczry0qcqzbdhfbjmfx2waz22g0hxm5kb8m11av418r0f9nm",
-    "tree": "25b75eb6f8866a57e23f4b4eadc8121e71e9fd60",
     "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
   },
   "frameworks/opt/car/setupwizard": {
@@ -7103,111 +6842,104 @@
     "groups": [
       "pdk"
     ],
-    "rev": "e883676bab8ccacd5d0d5bb77e0caa4614e0aa6b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d0981ceb4022dded36271669da0e1f22f7acf010",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0s08gq92ab0s70nzcayccmx9mm4p6ymbnwfp92hs6h7raf48r2dq",
-    "tree": "355afd928b080792a15d2d6e39495a68b083bcc0",
     "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
   },
   "frameworks/opt/chips": {
-    "dateTime": 1630796768,
+    "dateTime": 1630732465,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "b427f9526dfd07ef4b567c4b0107e052b9820ea2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e2903008d74be46bbc4709c9a4d2e17de47a038e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0scl3zcp7w2lvcn2dhl25zz3xnv6x74pdd332rhnccylvd4f58m0",
-    "tree": "3bc7adbd8a6af3d62bfadaa60a672bb42ed3824d",
     "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
   },
   "frameworks/opt/colorpicker": {
+    "dateTime": 1619137318,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "abf88b3228c4f7cde57ddc3468068580d59202ca",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0d137f37131b36c9ba8f9c57fa4d55e3d9270479",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vvn2sc29sc2yhvk5lz0gcdfb12321w4bcy24xkqvsnfsyddc877",
-    "tree": "125c8f04e2b129881d3ef4712bddbbd3e80aeb02",
     "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
   },
   "frameworks/opt/localepicker": {
+    "dateTime": 1619234741,
     "groups": [],
-    "rev": "0609da18a9ddba56d84cdef22f29184a01a14528",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "50a6bf8c43d229908dd45a45c5f884608e20ba44",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r125r6xswixm6b6d68bzc489h6xhb7s0bjgs8fnay4vbsq4419s",
-    "tree": "fc9623505ca8e477585b6e349c3e30f71a266470",
     "url": "https://android.googlesource.com/platform/frameworks/opt/localepicker"
   },
   "frameworks/opt/net/ethernet": {
-    "dateTime": 1624410460,
+    "dateTime": 1624272956,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "416c388b4cbb52094676c44ee6209b92df34f2b5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "952c4f0affa9492441d2cbd61a1d42c979e844b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1w5v0hr8a7qwrnf8f63fb6lnw19hggzjp7a1wrpfg1l539jaxv8k",
-    "tree": "778d8c8da2ebf2701bc020d2963b35b4934b8159",
     "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
   },
   "frameworks/opt/net/ims": {
-    "dateTime": 1630724789,
+    "dateTime": 1630632189,
     "groups": [
       "frameworks_ims",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "6c032ce72d08502f00fe5b1e7db7d0017d43cfa3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1403bd1c6e4cb4ebdb33e11c19e58a6af82bde8f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03k1yfcjhlssb9gv288ss8dzxsk9v02gz75isnjqp44l40336g1d",
-    "tree": "30c7355f5dbce2a6de38658b9b28232eadcfbc2d",
     "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
   },
   "frameworks/opt/net/voip": {
-    "dateTime": 1622682494,
+    "dateTime": 1622590811,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "c5a6224c066a776165edb6850a885739d191670b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b084cdfba7e191cf11001ecd1f0e5ead0ea38350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y3mffpp81hgzkp9qlwl49s82b5zlb2vbznxc3x5hp5kv2p6i7bi",
-    "tree": "c9a45b33b3c2d00e39bc4be8877abfcd86fa1e41",
     "url": "https://android.googlesource.com/platform/frameworks/opt/net/voip"
   },
   "frameworks/opt/net/wifi": {
-    "dateTime": 1632539203,
+    "dateTime": 1632514989,
     "groups": [
       "pdk"
     ],
-    "rev": "28830d87536ce4f882336308dd0ba02052861b38",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "380d244292d5605826b6979a0b325dac0b23a0f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1a9f0psy6la09q1r5c499zc6gzsvqc913a43sg4xv1gy7x4axzh5",
-    "tree": "30ab859ec5483b2d52141915829bd670525e273f",
     "url": "https://android.googlesource.com/platform/frameworks/opt/net/wifi"
   },
   "frameworks/opt/photoviewer": {
-    "dateTime": 1629421605,
+    "dateTime": 1629402972,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "8e7ffb518ef119337b47512c59143ddd8ea62753",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b4d84f2e2619ac06a1525b05542c926b73ecdf7c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09k0svr6wgxs9dras8ycz4lb1mf94l5q60cark0akggjsm6q0a9x",
-    "tree": "17d70a1e7589cc5783f0827bed991e526323cea4",
     "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
   },
   "frameworks/opt/setupwizard": {
+    "dateTime": 1618492520,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "ebe93fe3e36f2b04d456a778f7f0fb2da4d76a55",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9fe5969610a92d096d9811cb0fdc58390cced940",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sdvs3n3nxd0dflqyjqqhf0g1drznwqrkbd4qv5za5n0g9dqg5x1",
-    "tree": "ea6bee30e256542ad06c28324a3263ea1f7f39e7",
     "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
   },
   "frameworks/opt/telephony": {
@@ -7215,45 +6947,42 @@
     "groups": [
       "pdk"
     ],
-    "rev": "f80ee1541e2b23935c9afbe5b1f344f6d79f396c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cf0c5520d671a41f5c025238bf25ff4fd55f37ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rg3z0hkirzgfdp5nrbih7j2nddljmphy11w219w1csw5vg0zj0k",
-    "tree": "3d00b72b8267a60213cc158959312a9c3acc32d3",
     "url": "https://android.googlesource.com/platform/frameworks/opt/telephony"
   },
   "frameworks/opt/timezonepicker": {
-    "dateTime": 1633216014,
+    "dateTime": 1633216021,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "02e6b53e112eb7767cd798bdab4c9234b91ae318",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e2d2f768550d8725452055a078c746b672b27c74",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yz5byfqgkra3qim8gnrafna4cdxss3cfl6gflkggw768viabbgz",
-    "tree": "1664b2924e4da9b8c639ec84eab20bc68569e38e",
     "url": "https://android.googlesource.com/platform/frameworks/opt/timezonepicker"
   },
   "frameworks/opt/tv/tvsystem": {
-    "dateTime": 1620263665,
+    "dateTime": 1620203497,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "8bb2ad3cbb406b7419f5e78e8e72ed9554fb3ed6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "89809de45766b13655f6ef3469782315cbd66b5e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1008lz757hs6yjl71xcblv8lny21xlkvsh70sbqnv7akbn4pk3m0",
-    "tree": "8dc469e64364fb85fbfbfebe72e96676963beb43",
     "url": "https://android.googlesource.com/platform/frameworks/opt/tv/tvsystem"
   },
   "frameworks/opt/vcard": {
+    "dateTime": 1613504479,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f3e79bfb9ea6d5be27ad1765115a6637347242b7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b17ab1c8e7fedada640bd3cd3a8f1c7a5770382f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ahqdbqw285rpk7cnsjq0fzb60jmpf5a5z32vz52apxlg68k5l1g",
-    "tree": "9e2219da322329cd682cbe07d4bd892dc6eb4b0f",
     "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
   },
   "frameworks/proto_logging": {
@@ -7262,98 +6991,92 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7c7433a9911eb4fd512f3caf6a86ca3a8760aec0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3f55c7fb09c8ec89d3d00d4e44f8295b94d57a2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11rg4ghhhgk1msblksvzq4vkqm9bmzm05649bviv3xrvxwglgpxw",
-    "tree": "c830dbeec5c38a3873f4222a2f84fb0dfd13f631",
     "url": "https://android.googlesource.com/platform/frameworks/proto_logging"
   },
   "frameworks/rs": {
-    "dateTime": 1620263666,
+    "dateTime": 1620177923,
     "groups": [
       "pdk"
     ],
-    "rev": "1c8c6f14cce6b514ac3f8d1ed089c3c91246b3c5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "056bd5fa7bcfd1157d0391642a97854e755af7d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gybw0hsp2p5mm7g2v737kg0ca5nys2f0333p9ma19sz5dyww3ma",
-    "tree": "c0726a51cec8ede53aa7796a05d2b75480ce0cd0",
     "url": "https://android.googlesource.com/platform/frameworks/rs"
   },
   "frameworks/wilhelm": {
-    "dateTime": 1623114497,
+    "dateTime": 1623085907,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "43adaa76d80a61d789da3b36d9a6cccb1dcc13cd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "598fe03926acfdd7180ee7a7293aca7c0287fc8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nf5sx9zjs2ybcp4fqwzphgan379l83fml58dhs5x4f24rj80bxz",
-    "tree": "46a6d340c53d08a5ce6a98e852357936044ea561",
     "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
   },
   "hardware/broadcom/libbt": {
+    "dateTime": 1615848245,
     "groups": [
       "pdk"
     ],
-    "rev": "55e96cdb6920d471695f24944ad6cdd005b215d9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dd95c255ffa9baf735d4a11875597826ee41d6e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12945i09sz39ygg91szzabmw7kmhasn9b18sb2v8fkxxzqcy7nih",
-    "tree": "b249c61abd349f7a66e30e998a5940470e22e6ed",
     "url": "https://android.googlesource.com/platform/hardware/broadcom/libbt"
   },
   "hardware/broadcom/wlan": {
-    "dateTime": 1631149620,
+    "dateTime": 1631059361,
     "groups": [
       "broadcom_wlan",
       "pdk"
     ],
-    "rev": "d2179d89ca854def3f3a5a930c85fe0065b7b1a6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f6cdcab21874c47df8c7776987c272fa853ecaf3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rmam26zvsz5k8bxqrqhjmy5fs0zq1ffwzqjmyas2y1pm7badchj",
-    "tree": "126b09a93cf6a0d13c7faefcd77792d46a65ec89",
     "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
   },
   "hardware/google/apf": {
+    "dateTime": 1613842238,
     "groups": [
       "pdk"
     ],
-    "rev": "78ffdda5c26f74b02dfa9d7b4d3d964f08522552",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "411c1485206d66866726e647fbb0ba1e6825c581",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "144hxkgnbh4jvm5a830mjwsj5zcp4z0g61731r9vj9kx8kaxqxrr",
-    "tree": "d4497b0d7a28a9ed7bf990a7669e8260e272a2db",
     "url": "https://android.googlesource.com/platform/hardware/google/apf"
   },
   "hardware/google/av": {
-    "dateTime": 1624583330,
+    "dateTime": 1633482419,
     "groups": [
       "pdk"
     ],
-    "rev": "69cbfa1497993c7fbcaa365392b50e797041d65f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "36005e9f6c2981b0c68f2dcbcd61792c6069cc57",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d3h8g5fbvqyxj8v7q1b2y049gi17wq8dd32yv2671f5rv5a668j",
-    "tree": "e99b1603dfe3fe7cf16d5b2e415cde77979fbbdc",
     "url": "https://android.googlesource.com/platform/hardware/google/av"
   },
   "hardware/google/camera": {
-    "dateTime": 1632539210,
+    "dateTime": 1632527949,
     "groups": [
       "pdk"
     ],
-    "rev": "d0a125ca816284423422e1b694310df3f29025d1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "722c3ed425888370bedce3b5f484de11c3ab4626",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sh2sn1gc0mhpdrzkb0c4aa7cykaixc17mzyxf3x3bsszmhz4lra",
-    "tree": "6f4254c5aeef219c2e42e470374629b51dfcbbc3",
     "url": "https://android.googlesource.com/platform/hardware/google/camera"
   },
   "hardware/google/easel": {
+    "dateTime": 1612566403,
     "groups": [
       "easel",
       "pdk"
     ],
-    "rev": "74d119decd42e821d3dfabbfffc604cd48793423",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "38ea87e272bb0f380ca9463b789dee7279991196",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0a8hgw2y5z36vqn9ifwsci7bn6qznz1kjzvswhzif2cag7249nvh",
-    "tree": "9df88c82f3605fdcacc6fc47b566743dd10dac74",
     "url": "https://android.googlesource.com/platform/hardware/google/easel"
   },
   "hardware/google/gchips": {
@@ -7361,21 +7084,19 @@
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "2d7669201f55ccbf1b9b0e3700bf039f9dc2f7c3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6b84f7ef573d6c38dcb6db13e035949aee3ba4a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0li7pzbp3la3r2084gf0y0skpls96ldlbhmsq5sk5qfjy3l0z2w4",
-    "tree": "95580b01cd25e28d0aa64b4317dcbd2408a8f955",
     "url": "https://android.googlesource.com/platform/hardware/google/gchips"
   },
   "hardware/google/graphics/common": {
-    "dateTime": 1635134670,
+    "dateTime": 1640531101,
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "4f62e5ff214555fd26dd04ac777623276c59e565",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "0q0ncx3zjkh9xfy4w2hdw0gq143zdd00ijxrl335g0pp0dpr5wdl",
-    "tree": "29a7d2d7c1fa3ab90aba38c1172ee0d2cedf5feb",
+    "rev": "e6cd7d92d2dd925b8830d4c51e5d35b2d2a370cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r83sm85w4h9didfd300vszw3hrmdj1nnmd1ylpm8bgsqjk87v3a",
     "url": "https://android.googlesource.com/platform/hardware/google/graphics/common"
   },
   "hardware/google/graphics/gs101": {
@@ -7383,21 +7104,19 @@
     "groups": [
       "pdk-lassen"
     ],
-    "rev": "eb05221d9e966f476bf6f369b52fef4808989a8d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d4de1184a7a429bb50a834891f65d576753089b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pywy3cap4sj2wmlf0yicm9ag79rv5vksnhqd9y8265mwz1gkabx",
-    "tree": "c8f3576bedb431de57b88270d18903b9dcc4b9bf",
     "url": "https://android.googlesource.com/platform/hardware/google/graphics/gs101"
   },
   "hardware/google/interfaces": {
-    "dateTime": 1627096045,
+    "dateTime": 1626911509,
     "groups": [
       "pdk"
     ],
-    "rev": "02cc95b80c5401fda749b914f6dd9103d01e9054",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9e4e57ec99704e7a1f8dd7bc1a03c770e3e841c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0da22b907fa4qg6ldjyr24bj09ckaglg4pa2r9ycjc0frlnb6xwk",
-    "tree": "93b2109c23f09b8810653e89f975e8aa71c5f782",
     "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
   },
   "hardware/google/pixel": {
@@ -7406,22 +7125,20 @@
       "generic_fs",
       "pixel"
     ],
-    "rev": "1460dd3c698c5355b17e4ac8f477f4faee3c816d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "104312d682d5b841516006c238d9ae5034dc457c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06rdkjfjq8dc8c0d44png6f5rwkkxalby5mq0bjs2j4kdhhrnqr4",
-    "tree": "a4fcf47d2786881a1c59082f798046c637f9be00",
     "url": "https://android.googlesource.com/platform/hardware/google/pixel"
   },
   "hardware/google/pixel-sepolicy": {
-    "dateTime": 1629421616,
+    "dateTime": 1629406062,
     "groups": [
       "generic_fs",
       "pixel"
     ],
-    "rev": "368246e84abdab1c26d13325a3faa209a715a255",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0287947b7525075368afbd2e9e333df2b981f83b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0dnmq2hfngyjv80pnkyizfmh1fknpz6rik0p7rmxw05i0i040cwq",
-    "tree": "94440e982bda63f6c696f4d7fceaaa0f5a193683",
     "url": "https://android.googlesource.com/platform/hardware/google/pixel-sepolicy"
   },
   "hardware/interfaces": {
@@ -7429,280 +7146,275 @@
     "groups": [
       "pdk"
     ],
-    "rev": "5fcddfe441b5a0a53cd99d3b2a073a2856fb9c0b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e971f96ab5714ade65095a18057a49128acee43",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0nv4k0q8zmd2zq59rv464ycvpljy31nxvm2lhbq3r9yp8bb4zbsx",
-    "tree": "219f24f785ef2125378e6b8d0105c69439be5cd5",
     "url": "https://android.googlesource.com/platform/hardware/interfaces"
   },
   "hardware/invensense": {
+    "dateTime": 1613841778,
     "groups": [
       "invensense",
       "pdk"
     ],
-    "rev": "5ff4d3ada9e14838c04f6e99b8e3952be1bbb46f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8d5af232a81839f1f20e8ca053b2f4b7ae1d218f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12sqj3i0avyqpl6nqi8flaskfqlsfvvxzllskkfa67n9cknnv2p0",
-    "tree": "540e1200e06e3cd55b86295f51d4898e3992f0e5",
     "url": "https://android.googlesource.com/platform/hardware/invensense"
   },
   "hardware/knowles/athletico/sound_trigger_hal": {
-    "dateTime": 1614910008,
+    "dateTime": 1614816722,
     "groups": [
       "coral",
       "generic_fs"
     ],
-    "rev": "f077ae4d117995a646c72733ce77b96f4ca9befd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "09e144d36a932a96a00719672b00f445542a0a88",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zh4cb9rggg5in2ha4sil7qn28m97iwldwn7d07nz6xyqiwxd4i8",
-    "tree": "0ffef1012dfebf8af3acf0ad88dc9aadd8e5a3fe",
     "url": "https://android.googlesource.com/platform/hardware/knowles/athletico/sound_trigger_hal"
   },
   "hardware/libhardware": {
-    "dateTime": 1625533642,
+    "dateTime": 1625273836,
     "groups": [
       "pdk"
     ],
-    "rev": "fb7781b28ce799243a57e665a419e1818e31af77",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "42ad563b503562329198d2446b919f734714a1c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "14qdi7lc6a0327zw8fw81zdz33xk9j1pkqq6gkmpzh5wn3ngvwii",
-    "tree": "b69723eebf023f54d0e71be94f0d74a98cbcf77e",
     "url": "https://android.googlesource.com/platform/hardware/libhardware"
   },
   "hardware/libhardware_legacy": {
-    "dateTime": 1618628850,
+    "dateTime": 1617192955,
     "groups": [
       "pdk"
     ],
-    "rev": "9d2fd47d845b4d9969e617b16db057de2327d778",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9194f0742abcaf01b702d527d412a05b3a7702bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v6v220b8gmjz9qnpq83wjwd6jircnnlkr4grnj14d24bxy3b1ar",
-    "tree": "83c86860f4ba35032370bce3c9874ad024870bf9",
     "url": "https://android.googlesource.com/platform/hardware/libhardware_legacy"
   },
   "hardware/nxp/nfc": {
-    "dateTime": 1633655216,
+    "dateTime": 1633655228,
     "groups": [
       "pdk"
     ],
-    "rev": "ee545a344a66cc291f26e5836b0f233c0682380b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a7d72645dd3f832385d3a45d38fd5defd9d59f4b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y2l4gl8ls44zm4bc8myx1iaiyfcg0ihvzg4kpm4vrzd38wy0n2d",
-    "tree": "cc16f70b04b7b1fdc189108fe9dbb87f218e74fa",
     "url": "https://android.googlesource.com/platform/hardware/nxp/nfc"
   },
   "hardware/nxp/secure_element": {
+    "dateTime": 1621898269,
     "groups": [
       "pdk"
     ],
-    "rev": "d9653a943a406a58e2ddd86d6ec82726d0873954",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "87ca0480eb6fc726fab823da9455e6e21f152d4e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "063k3nh3vp9nffvq2gl3zirn2wx9hna8z67fkcdj30f9bm6vglcq",
-    "tree": "4d07e30c9b6b4b69a36edf8545427be08150760e",
     "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
   },
   "hardware/qcom/audio": {
-    "dateTime": 1619658492,
+    "dateTime": 1619598962,
     "groups": [
       "pdk-qcom",
       "qcom",
       "qcom_audio"
     ],
-    "rev": "21d0946df277574a2f817bf2c0b53f37692d3535",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "526071dc022aff0569c66e575ee1030929f5e353",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hikyx0hvmycblqpapviqbjkf890b6cn4yqpiyrs4w4isbf8w37j",
-    "tree": "7b2ec52c19e87bcf9eba5112413cb0a58f69e3be",
     "url": "https://android.googlesource.com/platform/hardware/qcom/audio"
   },
   "hardware/qcom/bootctrl": {
+    "dateTime": 1613842340,
     "groups": [
       "pdk-qcom"
     ],
-    "rev": "319c825c990a5b23dbb18149b30c1406cae8d91d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7fadaecbe0b4446ba1306ef47a24c607c81b88c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04dv3a0zj03af7g4c19kiif4v1gff0fby467kh3ji440y4z00r31",
-    "tree": "95f00332886fc754a822b3aff23259761aab7cc6",
     "url": "https://android.googlesource.com/platform/hardware/qcom/bootctrl"
   },
   "hardware/qcom/bt": {
+    "dateTime": 1612566560,
     "groups": [
       "pdk-qcom",
       "qcom"
     ],
-    "rev": "0766cbc80aafc8d5f4495b167540f624148a4633",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7147b0dd87f9e450caa3ff9b4df285b49b4c6ebe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0a6h3jcprciwxjq86nfiiij8f7475mah4qgxgsfdd2b54cy37jbc",
-    "tree": "5cf47fabffe9164d2ca3b48b5bf310bbec9e7632",
     "url": "https://android.googlesource.com/platform/hardware/qcom/bt"
   },
   "hardware/qcom/camera": {
+    "dateTime": 1613822746,
     "groups": [
       "pdk-qcom",
       "qcom_camera"
     ],
-    "rev": "2a81e88559395ca04e93510fca2152f688c864ea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6cb88d4e101901be10bb1f22af17e83ce126e841",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p2932v9hsmv6i729zvzq0fypxcdh7xdhfyiz57pspm3xpv7f9yk",
-    "tree": "1a7fa7a4d0b8401cb0234b6503cb710ac7073b1e",
     "url": "https://android.googlesource.com/platform/hardware/qcom/camera"
   },
   "hardware/qcom/data/ipacfg-mgr": {
+    "dateTime": 1613841788,
     "groups": [
       "pdk-qcom",
       "qcom"
     ],
-    "rev": "cdc6d31f1e5c436c4b439a35f325f9d6bb26eced",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d16172155f70e86e931bb8d64b666c2ede657a39",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11zhb0diqxlz9vsxzbvxn8pv6amxrclvqybnr5acbs8awlc6h6xg",
-    "tree": "5e8f352f9c765fc8a9270541283494b914e159e7",
     "url": "https://android.googlesource.com/platform/hardware/qcom/data/ipacfg-mgr"
   },
   "hardware/qcom/display": {
+    "dateTime": 1613842325,
     "groups": [
       "pdk-qcom",
       "qcom",
       "qcom_display"
     ],
-    "rev": "7fcbc3fcd24fb91fab3cb373f2f2b9cca9a47e04",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f01b4d21aa7f244f9b0c3b02cdb7df3dc0ba327e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1w8fr68drhj6wjqvla801wianxb71ybpxwfia4v7mjrf7krs09a2",
-    "tree": "5b570ab27f488281c3924adf7e0d019dcdc0234a",
     "url": "https://android.googlesource.com/platform/hardware/qcom/display"
   },
   "hardware/qcom/gps": {
+    "dateTime": 1613822793,
     "groups": [
       "pdk-qcom",
       "qcom",
       "qcom_gps"
     ],
-    "rev": "2b283e5238de695db89e310ec7194b690b955cbe",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d00bb6042e9c1642b1823d761e33d936098320bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r99iirahalmj8w9v93cqi9lhandavj88jqwlcgd01czlrynwm9x",
-    "tree": "f34414c7c6208bc8bd6324c1ef1d96203bbb025b",
     "url": "https://android.googlesource.com/platform/hardware/qcom/gps"
   },
   "hardware/qcom/keymaster": {
+    "dateTime": 1612567136,
     "groups": [
       "pdk-qcom",
       "qcom",
       "qcom_keymaster"
     ],
-    "rev": "eb3eca9ce1175f5b6a8e83d873c7fe90de26b0c1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "90daa64e30cce892b9ad47ee7f4dde5c54e85ce6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09882azkwai7h3xdr0krqv4d5k63qdyvpwzcw6d16wljbfkf525r",
-    "tree": "95adc25ab3574e2b4fb37d4554ae327015cecc5a",
     "url": "https://android.googlesource.com/platform/hardware/qcom/keymaster"
   },
   "hardware/qcom/media": {
+    "dateTime": 1613842296,
     "groups": [
       "pdk-qcom",
       "qcom"
     ],
-    "rev": "f8b502793178905071325272babfb18c913fccab",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "875de1a1a862ee5a3ac5242d0bbae8bf50c43c02",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1djq7k9gi7d359cdif0rysfprcfs16sjmfjqkj88a6px9sl0mdy8",
-    "tree": "249399f4876e5fbda70ea944112734859d4d0e8d",
     "url": "https://android.googlesource.com/platform/hardware/qcom/media"
   },
   "hardware/qcom/msm8960": {
+    "dateTime": 1592337238,
     "groups": [
       "pdk-qcom",
       "qcom_msm8960"
     ],
-    "rev": "6ad1bd8f8b3e8583ebbce422b5755355a8f9ce7d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cced5368eb61f31a39089a2e01f3ce203b2e8717",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13ss8wgnd4306024174vsfv6ka2sf45jzx7d4b8z5ywcpqiyczwm",
-    "tree": "6ff8fdea8a4f4de8bf5bad30a5689b1f1403a083",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8960"
   },
   "hardware/qcom/msm8994": {
+    "dateTime": 1592337170,
     "groups": [
       "pdk-qcom",
       "qcom_msm8994"
     ],
-    "rev": "b58d21e44b82a83be62b9f7f2ceabc2c42a2c823",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b518b6bcbd858cc9e6a885131a1befa4a91e34f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "15zxcb9dx1862fvasyn11iav765a3522my4mxby5iymjax8sir99",
-    "tree": "bd7ce56ab1126bd0374752531cc2923d6e2aaba0",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8994"
   },
   "hardware/qcom/msm8996": {
+    "dateTime": 1592337277,
     "groups": [
       "pdk-qcom",
       "qcom_msm8996"
     ],
-    "rev": "599352aa811689a1c25d0453d988b31bd7fcb4c2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "88dfb6c24a1173bcfa1859d59ebd566cf2f5b105",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g381r0mv2rv0yzq0qw2m65z6a6wx2wsc14xln7q9pphn7x7kfyl",
-    "tree": "eab6e2ec0efc501bdfafbd858176a8222503f7e0",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8996"
   },
   "hardware/qcom/msm8x09": {
+    "dateTime": 1588715629,
     "groups": [
       "qcom_msm8x09"
     ],
-    "rev": "d99e5ede68889857b5f3606b5d33206a2030d5f5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ea1cadfdb22cab6a448b1daf8b9c15cf5ffef00e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17hq55hsfyzknrjfmw877y5cnm4mgxi7bdj0fpb920gcn6klfdrs",
-    "tree": "a4675d7c2c1824d4007a5c229a3bdbf3d9b06027",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x09"
   },
   "hardware/qcom/msm8x26": {
+    "dateTime": 1592337224,
     "groups": [
       "pdk-qcom",
       "qcom_msm8x26"
     ],
-    "rev": "6f563984c9c47fd11c7ffce2744e0fb2344218ed",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff0d31f255bf9d628ee6830f1438855dab6cd058",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kxbm2sk5lxzydh2f8jv1z6j3qpjxrb2b2vr3q71mfwms76z7zlc",
-    "tree": "1eb80daa5206e83bf56d6c6e6fb1a53f9c4f5ef0",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x26"
   },
   "hardware/qcom/msm8x27": {
+    "dateTime": 1592337231,
     "groups": [
       "pdk-qcom",
       "qcom_msm8x27"
     ],
-    "rev": "0a3917ee703e0a0b4455d423a1d294e7d3b2e11d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c41dffbca5fd1d7909b6978935402f79c1133c5b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bly3vx1ykfm251fz9c86znqzy9f8rlmgijaczzz1hk78mrk5sy7",
-    "tree": "6b411438e41606382a5f4592b0a92c7e61a72dd1",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x27"
   },
   "hardware/qcom/msm8x84": {
+    "dateTime": 1592337218,
     "groups": [
       "pdk-qcom",
       "qcom_msm8x84"
     ],
-    "rev": "b2633d46b8fb2b767560390fd9710eabe585fd72",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fa62fe17dc751def2b3aa8d079d5bfced6be73ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ds8p9sr9r3m9lncav7kjzma9m1v6abapddjx6xjncn9ghv3ga08",
-    "tree": "85cf4c498dbaf35bfb6eb23a1f4079547ab20d1c",
     "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x84"
   },
   "hardware/qcom/power": {
+    "dateTime": 1613841775,
     "groups": [
       "pdk-qcom",
       "qcom"
     ],
-    "rev": "1edca31cb1956fed65a2927e8a53b1341cb6c136",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "68e949fdff8fc0b0514528be3771b4d3703219d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hgjhbm8bj66nm29xgmg9xb32y12kz4jn8bm4fpflxn1cz4gb38g",
-    "tree": "eddf67b4d77826c20ffe2c52918c5abb84725871",
     "url": "https://android.googlesource.com/platform/hardware/qcom/power"
   },
   "hardware/qcom/sdm845/bt": {
+    "dateTime": 1613841789,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "5b6341cc321776bd13492a13b109e4c796068837",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "23afc2a00f6c94f5197850a23c54120b390d8b5b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16wxyxlvywkqpvlxlch8czcdjchnqnza5z8qhb1qgwv0kylrh1pp",
-    "tree": "0a37fb1e4b3ff9c825d67aca0f59479e3bd8b537",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
   },
   "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "dateTime": 1615992147,
     "groups": [
       "generic_fs",
       "qcom_sdm845",
@@ -7718,71 +7430,68 @@
         "src": "os_pickup.bp"
       }
     ],
-    "rev": "709d6d4509354caa215f47d9b431f8515f5a7510",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5b0ebd5110d874b35ebdcfc0ebda8a740188e42c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ymwzhq5n5cawc6cwspz5xbdc1vzxnxrp7nslmf9kc7mvln56hr4",
-    "tree": "4426d70b9508ccb473cac47a0b8ef79489131aa9",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
   },
   "hardware/qcom/sdm845/display": {
-    "dateTime": 1621904911,
+    "dateTime": 1618390393,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "67a5dcc76a0373b53e7e437433b96576ffb8c0fa",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ac88e014355b4f02276dfe8e636700604dc1b8ad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hh37liap88gw5rl1yn15mpx3b96iw8qk7agsvrrxszyxvbksii9",
-    "tree": "b96ee8b826da69869e2aaf557f3fbb97f138b9b1",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/display"
   },
   "hardware/qcom/sdm845/gps": {
-    "dateTime": 1624496901,
+    "dateTime": 1622445624,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "679d8fcb762afbbb6ed199f241259e7d9b48a6c2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f63364101a27fa8a40839230fe2a27a1b03bf8ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "15ibil263invfsc8p2889lb92370zxi27gkgx14b8y0jnpf4jx14",
-    "tree": "364320bfc1a467241adc6a19049e710e6a77bdab",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
   },
   "hardware/qcom/sdm845/media": {
+    "dateTime": 1613842174,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "9a5358f4636d2fc2f4bc1747fe340a48212887b3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dac029f7b2cc1dd2dc41073d9d7d3ea86854e745",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10csk645fbbkcszv3lb835h2v1il4x6dihadxg23g7y2cxfi6nvj",
-    "tree": "a2ba563355ad3182546a902988b459ba874f00dc",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/media"
   },
   "hardware/qcom/sdm845/thermal": {
+    "dateTime": 1613814737,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "af1ab8f2295acbb2a6601cc563081c95cb8a6f2e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "21ece187edef5b6a58e9e6558b9b69dbf160cfb3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08jfmac2ac6zgfxg8hgvxmv70xk5mlz15vqrxy5xcfsg2f4q1c8r",
-    "tree": "e1d5487e138c446de8a8c6c3f23c654ee315935b",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
   },
   "hardware/qcom/sdm845/vr": {
+    "dateTime": 1588703755,
     "groups": [
       "generic_fs",
       "qcom_sdm845"
     ],
-    "rev": "70b0ff01aa52a095bab6bcd5a8d1a78074377300",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e4acf780d357794a7aa84de483facb5587dee63",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06fbwha2qkigss5r7r5vmgnr3c64cxy3njdp2qlbsxgm0c07xy9q",
-    "tree": "8a89bf7312d03c03baab7335c255238f57347b33",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
   },
   "hardware/qcom/sm7150/gps": {
-    "dateTime": 1617152841,
+    "dateTime": 1617084077,
     "groups": [
       "qcom_sm7150"
     ],
@@ -7796,25 +7505,23 @@
         "src": "os_pickup.bp"
       }
     ],
-    "rev": "851bbb5ddfefdc10cfa51e6858b3901b34eb874b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "20315c7f7dc739045cfb3acbb84966d93c880c9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ilgf2rdxniq5b63an8asrbdir2f82yj05qcq8pg51gmkm2550nh",
-    "tree": "061cde30e7631cb42d269b27c22f52888f1f98cf",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm7150/gps"
   },
   "hardware/qcom/sm7250/display": {
-    "dateTime": 1624496902,
+    "dateTime": 1621842831,
     "groups": [
       "qcom_sm7250"
     ],
-    "rev": "1ddf263da8b7693b887509f552d9ec327ce2e2e4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bcaa76b47d753c82f16d1d918e59b8374c9865bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vha4cs3p8zy3b8m1di92wgypi8blsgl8a8aw997j9p4rg9pvm29",
-    "tree": "4995670f03ebbfcb5c66970390ca4e3de0f3b7a4",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/display"
   },
   "hardware/qcom/sm7250/gps": {
-    "dateTime": 1631329644,
+    "dateTime": 1630483928,
     "groups": [
       "qcom_sm7250"
     ],
@@ -7828,25 +7535,23 @@
         "src": "os_pickup.bp"
       }
     ],
-    "rev": "41a31bf7612b27c1a99fad1b84fa070f4c9be133",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "92190a33c08d8c77f8b2039e7e113757622e47a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0a4d7vqlj666q8sw6548fli1hcmviqaqv9xhay4a3l3g4ppgylxp",
-    "tree": "98c4ee325af7a8bcc7bd1fe08c804a47aaf298a5",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/gps"
   },
   "hardware/qcom/sm7250/media": {
-    "dateTime": 1624496903,
+    "dateTime": 1621509572,
     "groups": [
       "qcom_sm7250"
     ],
-    "rev": "b9827d85e12d786343f0bccf7fe2607466da0704",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e5605eafe7954f17482e303800d56fb1a82a8e1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mxv8v1fnxr4gmjc92l16zmzxbiyppppszmjyjc61rkj3z92vdk7",
-    "tree": "4e628b0f47dfed879f3358bceb70881bebba5a1b",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/media"
   },
   "hardware/qcom/sm8150/data/ipacfg-mgr": {
-    "dateTime": 1624583355,
+    "dateTime": 1621852175,
     "groups": [
       "qcom_sm8150"
     ],
@@ -7860,67 +7565,63 @@
         "src": "os_pickup.bp"
       }
     ],
-    "rev": "b230c4d1d82ad1f6aeec0c25b53b9c5420789766",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cc9d9549278fb64a44f77573596392d3df2471a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0nl5wgfh2fnwh6ypyb7c4fga6q434b1nzfl4ha9l0qm24b5zw6vz",
-    "tree": "7e1f9900341fe21990a095a8a64c5fa9d6b3dd41",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/data/ipacfg-mgr"
   },
   "hardware/qcom/sm8150/display": {
-    "dateTime": 1626138550,
+    "dateTime": 1626053565,
     "groups": [
       "qcom_sm8150"
     ],
-    "rev": "9573257401af5a286d4fd53416e60fcff58ba11d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9f08261195b17c0f11a1700f78244847897ea775",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11cf1n074nmgbl26w90h5g37yjivykmcn9likf9gy26qwg6ykwi1",
-    "tree": "0ef17a98444c2a9974e3c5eeeb9b31e51910041d",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/display"
   },
   "hardware/qcom/sm8150/gps": {
-    "dateTime": 1627700875,
+    "dateTime": 1627524317,
     "groups": [
       "qcom_sm8150"
     ],
-    "rev": "4cf7bfdc07d483c3e3963d92f73980eab7d231e3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "08927d5e251296e9f8f87152dac1bd25e4a97808",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0d1r0yfdlx6af5yv17n8550mk48xksgw60ifpx4j4wg4ns788ic3",
-    "tree": "d403f0541443e97e0ef7fd69f6f1ce2fe0db2f63",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
   },
   "hardware/qcom/sm8150/media": {
-    "dateTime": 1624676860,
+    "dateTime": 1621922907,
     "groups": [
       "qcom_sm8150"
     ],
-    "rev": "e5304299bf39b364c34f6dd2446b178e154166a6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "337d913ba2c30a533b6d7b670faf07b933f349eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07ghzjg7k8jydqg46w8s5w3ngjx0y533xyx8aigji399f1jdj9fd",
-    "tree": "7aa5196313b280a2787ad832462c59ec3ae216be",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/media"
   },
   "hardware/qcom/sm8150/thermal": {
+    "dateTime": 1613835352,
     "groups": [
       "qcom_sm8150"
     ],
-    "rev": "3cb50c51a191e9015da2a8d695041b5153beb559",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "65e83b2adb1386bec6fe4baf748ce05e985791fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "068aa9jpgn5b8gdy62jz74hhik1dh4yjgliaavfhvqmg1mbgn7d5",
-    "tree": "1f003b8ec0a8d68c0ce2710d25fc25016ed30818",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
   },
   "hardware/qcom/sm8150/vr": {
+    "dateTime": 1612566547,
     "groups": [
       "qcom_sm8150"
     ],
-    "rev": "4f807a282d33cabd87d6b15c7a03b23629b5fee1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "596a9169407dcc696edf0083a7664d19d8024050",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k4dfzb7l3pk0zdxzad6y20kckyac5dl5i26b6rg03ip940ij7dj",
-    "tree": "fbdcbf4a406c2545df3e2090af7dffac1d4dee2d",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
   },
   "hardware/qcom/sm8150p/gps": {
-    "dateTime": 1617152846,
+    "dateTime": 1617084053,
     "groups": [
       "qcom_sm8150p"
     ],
@@ -7934,292 +7635,273 @@
         "src": "os_pickup.bp"
       }
     ],
-    "rev": "8955b9cd6cdb179bde2278b93b2ff95ef02d9a9d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5023e65bfa093f4538bc283b0777b162778718f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m43j0m0cdjn7xn81n1a9h9v2b3846vixqffamajb8qrfp25yvzr",
-    "tree": "6bbb85006df6b5758c9a6d6777f198dfb1b358c0",
     "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150p/gps"
   },
   "hardware/qcom/wlan": {
-    "dateTime": 1628212080,
+    "dateTime": 1627458515,
     "groups": [
       "pdk-qcom",
       "qcom_wlan"
     ],
-    "rev": "c375e1404b7b736ade976a36afa1061941ed0ce4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "905dc54f50298a4b7b74ec0b2b7b6fc90234a2e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01kjgaf69v97ai2rcdaj6xz8gzc5b2nm4psxmsq282zhmaaasrhc",
-    "tree": "e63986e1731bcd7d309d964783171fbf6b0179ce",
     "url": "https://android.googlesource.com/platform/hardware/qcom/wlan"
   },
   "hardware/ril": {
-    "dateTime": 1622768893,
+    "dateTime": 1622642229,
     "groups": [
       "pdk"
     ],
-    "rev": "a55d79eabcbc47d8740940d5f1cde9e1d07ca0f4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7d32697e0ff9b161c0aba809849e39be798f7ba8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13r4911z64whzp7q6sm9153xqj9frzmyq95q6dgfx2z6826gxcxn",
-    "tree": "56d559459897140672b01ece5e2b2384267e9065",
     "url": "https://android.googlesource.com/platform/hardware/ril"
   },
   "hardware/samsung/nfc": {
+    "dateTime": 1619531128,
     "groups": [
       "pdk"
     ],
-    "rev": "104c067e815510ada77684d4a21dfbea8dd08199",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2a0363c5b49997628fb3e147c2be2f78d07852a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mcsnjjngc7v1rb0pdf9fkjz5ww7smpdyxvll32yayx27nfmnsdq",
-    "tree": "0531c42732bf7e25c620979c6932253994076c91",
     "url": "https://android.googlesource.com/platform/hardware/samsung/nfc"
   },
   "hardware/st/nfc": {
-    "dateTime": 1628212080,
+    "dateTime": 1628149063,
     "groups": [
       "pdk"
     ],
-    "rev": "e7a50a6ea9cb5ba3e914e960d66180706d4c9daa",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d77a2529f646ddf943dbb760714beb88553fa906",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1r021x5w208zl95ldgja0ziyjmf7yad6pp7yq3rz9nn1a0pi8phf",
-    "tree": "39e26acb372e65ef67687ff1668b0d6cc4dfc524",
     "url": "https://android.googlesource.com/platform/hardware/st/nfc"
   },
   "hardware/st/secure_element": {
+    "dateTime": 1619006432,
     "groups": [
       "pdk"
     ],
-    "rev": "c75eec44655090d14dba2498f90c0232a582104d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b979c55610c202ae34f87ff532b777b62abd4a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "043ca4c21n7jrrckdd2b6j9p1prg4y08k8giw7r90q8kk2bf4cwl",
-    "tree": "39f436c22989c75c9171f1a109d8bd4497e4d78a",
     "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
   },
   "hardware/st/secure_element2": {
+    "dateTime": 1619542024,
     "groups": [
       "pdk"
     ],
-    "rev": "655a81dc93bbc692d5117c0102eba28b956513ac",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c9d34df3c5b91a90c3497e1d01f40fa6da08993f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "183k0fmav5ndrkxkl7bnkm5mqyq0ddjjw6iilnl5y8122cg8phqn",
-    "tree": "82607633f39a2fa4bb06cbaa5ba3ff82b9015de3",
     "url": "https://android.googlesource.com/platform/hardware/st/secure_element2"
   },
   "hardware/ti/am57x": {
+    "dateTime": 1613841776,
     "groups": [
       "pdk"
     ],
-    "rev": "7f6134c392eac72c52673fa98abd2f71229cc9b8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "62d43157532dece513f74f821fc3d766963762fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gqn5lsyf7s420cdiga57w2c6g03zj048i5qq9r4904abcn9w1bm",
-    "tree": "f313e799c4e2737fe4c3f0e33bbeff02c2c9d508",
     "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
   },
   "kernel/configs": {
-    "dateTime": 1633144066,
+    "dateTime": 1633144053,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "078ad1ff569c0ac839f57423de68eb358a31a28c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8e9d68624740d4b84ab7fd8b4db332333d2dc15e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08w0m10d9ni4wazdr78gf1yzzihafqbzg4yxxjzpw1gwrv6qm402",
-    "tree": "89da8b16cd034da57775f3ef0e16224419f0a92a",
     "url": "https://android.googlesource.com/kernel/configs"
   },
   "kernel/prebuilts/4.19/arm64": {
-    "dateTime": 1633907258,
+    "dateTime": 1633907234,
     "groups": [
       "pdk"
     ],
-    "rev": "80673769b232a123181e5ad784184da05f81b27a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9ca774573c03e0223d70d4de3c3c06a741a1eae0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "00xf3wy11575mfa8bzkrx9lri4mj2dkq4gq1c2khmwzc7i1xprzz",
-    "tree": "9be27ea85cf888d615c3362e8e06eaf9f61abf0b",
     "url": "https://android.googlesource.com/kernel/prebuilts/4.19/arm64"
   },
   "kernel/prebuilts/5.10/arm64": {
-    "dateTime": 1633568901,
+    "dateTime": 1633568903,
     "groups": [
       "pdk"
     ],
-    "rev": "82f88bde23d92db9e1d07361f60630404d606931",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "829040e6bfc9f38b79f02a4464f206dfa550d194",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zy7dhy7wvv8igg6s0sxvxqfza8zjyqa8i71c10ycrckqvzhxm38",
-    "tree": "d66ef0401f56cc9ad06dcabf38a5315c39af5bfb",
     "url": "https://android.googlesource.com/kernel/prebuilts/5.10/arm64"
   },
   "kernel/prebuilts/5.10/x86_64": {
-    "dateTime": 1633568901,
+    "dateTime": 1633568904,
     "groups": [
       "pdk"
     ],
-    "rev": "3cc57c8063ce4afb06ec023e43e5d6ae4298a1e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fe2566a6606b84d5d3f4b85416ccb11ba219dde5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hwp77bndak86a5wxki0ss67x69b7b7rv0ajg7lc823v4zn15q4x",
-    "tree": "c8a913c124de9518195154ca966937c6c2d79a67",
     "url": "https://android.googlesource.com/kernel/prebuilts/5.10/x86-64"
   },
   "kernel/prebuilts/5.4/arm64": {
-    "dateTime": 1632445625,
+    "dateTime": 1632378761,
     "groups": [
       "pdk"
     ],
-    "rev": "c309c6a936ec62faa38b7efa13d9c7cc1c29d1e6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b490ad5d4a23a22096c92ec89617ef22d00df2ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "014kxvw0xzn7swf96wa2w2lgmkkmvyyh3rykv6ywwbivvxa9waf5",
-    "tree": "83b6a9faa8a165ca3cd79f7356d3fb9a340d9504",
     "url": "https://android.googlesource.com/kernel/prebuilts/5.4/arm64"
   },
   "kernel/prebuilts/5.4/x86_64": {
-    "dateTime": 1632445626,
+    "dateTime": 1632378761,
     "groups": [
       "pdk"
     ],
-    "rev": "d063ce3f98d62c07138883974eed8c07b908a971",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "17d7f1eb57085c1bf97ab684964b789593d430ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "167v0a8bb3k23d7lx7rgmwj67gdvm4aqp5s9lm41pvrf6ngpkxda",
-    "tree": "0f23ce5e0141fdff643a5810e441e8896b1cff2b",
     "url": "https://android.googlesource.com/kernel/prebuilts/5.4/x86-64"
   },
   "kernel/prebuilts/common-modules/virtual-device/4.19/arm64": {
+    "dateTime": 1612209682,
     "groups": [
       "pdk"
     ],
-    "rev": "3e335c027416a3201d1de18ac6fc5baa260b6b37",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b8b5f9fc5de3123efba066a32a065c90b2622f72",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/arm64"
   },
   "kernel/prebuilts/common-modules/virtual-device/4.19/x86-64": {
+    "dateTime": 1612209835,
     "groups": [
       "pdk"
     ],
-    "rev": "b5f1996d44885ac26fd63a03ffcd4aa236adda46",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a8bc9a8401214392d2a8e96805a3ba846a7b769d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/x86-64"
   },
   "kernel/prebuilts/common-modules/virtual-device/5.10/arm64": {
-    "dateTime": 1633568903,
+    "dateTime": 1633568906,
     "groups": [
       "pdk"
     ],
-    "rev": "b4d53d89bd9e0d85d1c6fb31d865cb25435dced3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "693c793bb71557e41ee2036d09a8fcbf3025a798",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0r5pwgvgdqcpxfx5mcicmpdljvnhs0wwsvvfsj0afmaph8gl7n2p",
-    "tree": "53a627cfd0e485e6077f31c182274cf113bb2c81",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/arm64"
   },
   "kernel/prebuilts/common-modules/virtual-device/5.10/x86-64": {
-    "dateTime": 1633568903,
+    "dateTime": 1633568906,
     "groups": [
       "pdk"
     ],
-    "rev": "7452e41ef0fcb76e5e2596305235ee7bab40044d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "759696ad20b4f84bc5bda21d0d0cfad3fdbeced8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0facy0r5bxbia8mg7v1s4x0in8z84w9h7rqijpgwkda6l2ach6d5",
-    "tree": "cb3fa4978bae62bc375492f356951fd242e10f74",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/x86-64"
   },
   "kernel/prebuilts/common-modules/virtual-device/5.4/arm64": {
-    "dateTime": 1632445629,
+    "dateTime": 1632378762,
     "groups": [
       "pdk"
     ],
-    "rev": "8a5c016363e458901be460c87dc7280e53da1ca6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e099b2c4281438ca627bdcffc78f6c301159de39",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0s4ih5lz2c44h96yy4nm203gqnqi3np9kjl32ymqmlmh5qizjgbl",
-    "tree": "2c724a88e9c0c231862b4b622f171edade4dc9ab",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/arm64"
   },
   "kernel/prebuilts/common-modules/virtual-device/5.4/x86-64": {
-    "dateTime": 1632445630,
+    "dateTime": 1632378761,
     "groups": [
       "pdk"
     ],
-    "rev": "c480b57d119adb7b378178cb82b1ab57a6e1a8c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8266a593748b3dd4c762c6c13bf85cbb1d82d107",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b8xl47wic0kbwk6fm5vli54khr9zwh8nxk0spay6h9vhcl32k25",
-    "tree": "26f6300eb303272c71323d18d655df32381f6298",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/x86-64"
   },
   "kernel/prebuilts/common-modules/virtual-device/mainline/arm64": {
+    "dateTime": 1612210495,
     "groups": [
       "pdk"
     ],
-    "rev": "d54d7148d63c47e8211701aae19b80a4fc21ab12",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5fffd58aefba2ab3a3598f3ffea9e8d73bd903f9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/arm64"
   },
   "kernel/prebuilts/common-modules/virtual-device/mainline/x86-64": {
+    "dateTime": 1612210658,
     "groups": [
       "pdk"
     ],
-    "rev": "d7aee9de08a917a12bf402150026302717a07677",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ec342d1c593dae585a06f7d5df815aaf72aaead9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/x86-64"
   },
   "kernel/prebuilts/mainline/arm64": {
-    "dateTime": 1623287354,
+    "dateTime": 1623221383,
     "groups": [
       "pdk"
     ],
-    "rev": "c66370d605227228b59b70f84cfcec0474463024",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3d200945220b09b626df433b9b66291e6825e4d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0pw66qkkcil7wmfamvikdjsdmsr4vysb4f0aby02ygix2kdwfx6p",
-    "tree": "9a64e4d88941a697a113e6cd8eb8b3bd60ceb259",
     "url": "https://android.googlesource.com/kernel/prebuilts/mainline/arm64"
   },
   "kernel/tests": {
-    "dateTime": 1624496919,
+    "dateTime": 1624417043,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "9962bf78c7142675694818a4a2c793393e95c40d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d85b2ea2b84e8d0bfb89730515b467dec7b17f8e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xibcqrq89p12cng3qsg5hcc7lf2mdz90g5cbipz7rxwqpid2qc8",
-    "tree": "aab8551ed6cf00ab715b49f4c5eff93f423cf5dd",
     "url": "https://android.googlesource.com/kernel/tests"
   },
   "libcore": {
-    "dateTime": 1630631245,
+    "dateTime": 1630595751,
     "groups": [
       "pdk"
     ],
-    "rev": "93b942f562449cc654e7ba02bf60bf72ba0e0d78",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bf7203d7a5eee0b7fbdb150b4cc72b71502b51a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1k7xbp5nkayyf3ksynanzh1hi8k3dbp339hkvpyy8x3fz7rd04f4",
-    "tree": "b97d703b79aa2d0d0e3edf85e0e0948fbe8578df",
     "url": "https://android.googlesource.com/platform/libcore"
   },
   "libnativehelper": {
-    "dateTime": 1625706864,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "8a549b67e951a27451d869fa9086b5f4321f8125",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "63facbd7dc049e14679b2a0079eab6da9386b1c1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1509vfazmfy60ny84mljzf1iw0m5hswg922z4wm8ac79gw5wsrf2",
-    "tree": "925ab5501040bb9ab74f586461aa7ddcdfc654eb",
     "url": "https://android.googlesource.com/platform/libnativehelper"
   },
   "packages/apps/BasicSmsReceiver": {
-    "dateTime": 1629421653,
+    "dateTime": 1629257446,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "165540d77ba81b7eb0b644e7ffc6a6bda078968a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1e98b9bfbdd8b83f562aee9f05b3aeb1431b9e1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13a8aj0lxiz3xw69iq5mf3kyc99v400x64gk9x2pgb6sqwdb8mn9",
-    "tree": "c19f124b9c9e98ff763a63907c93c43257bde066",
     "url": "https://android.googlesource.com/platform/packages/apps/BasicSmsReceiver"
   },
   "packages/apps/Bluetooth": {
@@ -8228,206 +7910,189 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "2f2435eaee8d949f06d6657e1eaae88795579fa9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2808176dfd969ed1b77e1041b72e120c3ad87470",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hbcrw62kha6s5548qg0zkayb9xa60cjmimkw7mhsnfvx54pvv7h",
-    "tree": "3f077b596266fe77e0377021f6a60cd65954df56",
     "url": "https://android.googlesource.com/platform/packages/apps/Bluetooth"
   },
   "packages/apps/Browser2": {
+    "dateTime": 1617050915,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "dc7901b7508b07d34da433ae664386f18939fb14",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e9e203e975033990e947d50c1f2ded2bde35e0ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1h9fvxivq1vg0mcwjvi4bzz37l8qimznybpljqin45smddavryd3",
-    "tree": "82ed31c417e668bb3f6a139ef7386c010a3238c5",
     "url": "https://android.googlesource.com/platform/packages/apps/Browser2"
   },
   "packages/apps/Calendar": {
-    "dateTime": 1633050435,
+    "dateTime": 1633072725,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "13b786c95f85973cf8f8079d39d2d8dc21ada75d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4308b4c8d62589d5d6226e8db1b9999f3a2dfe5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0kfvxpgm706p2yqm52m0c13zzsq7l93b318jinphqkc9pknb44az",
-    "tree": "b48d512d19f0a4ae8b6c36a1453e36f1cfc9cd07",
     "url": "https://android.googlesource.com/platform/packages/apps/Calendar"
   },
   "packages/apps/Camera2": {
-    "dateTime": 1619744939,
+    "dateTime": 1619720017,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6acd4d5dc667c70ac2d8aeb280226508417cfef7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b83603dae95f123114cba4e4ec23f28ae966c483",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vxvf0jx742y1ygdvlgxx9mzr7wnd5hk7n61vlni8qphnyjzgwqs",
-    "tree": "f7f45e1b6f0f715d2f4c5de4df26dde1869d39a6",
     "url": "https://android.googlesource.com/platform/packages/apps/Camera2"
   },
   "packages/apps/Car/Calendar": {
-    "dateTime": 1633907269,
+    "dateTime": 1633907245,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "b4e56e19ba71369e123cd5a5a70b0f8017d8055a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7a02fb122ddf482c8f23f5193a1a1f4faca8f2d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08phbcifdw93d6q91kry8rrqwsnasggga6n3yk3107vwiwphp22z",
-    "tree": "ee4686e89f4dc2afd0c92e24b85da9a1912c0ec2",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Calendar"
   },
   "packages/apps/Car/Cluster": {
-    "dateTime": 1624748930,
+    "dateTime": 1624667074,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "992ecc9d554aeb33e68aa8a54717878cab2353b2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ce858af6281f86d6864a8d510f54ed2abf799640",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jmpvmk09bca9x4kcnaxxbskqdphv8fxwf1cjhw19c8qda8dwmb8",
-    "tree": "2f687e8c9cd820db6d85aeab7abaa00758e22066",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
   },
   "packages/apps/Car/DebuggingRestrictionController": {
-    "dateTime": 1628039320,
+    "dateTime": 1628015930,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "70acb9155ca846241ea4f4741a9589d8018124c5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5e6ba46d0ca4b927b060834f8c3935980a114cdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hl1gyk1x3if9vbbd57qi69xrkzlbazfd71cvna9my33aazlz22n",
-    "tree": "f2f470f6f65f12d0af6841050b325a17370b4ecf",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/DebuggingRestrictionController"
   },
   "packages/apps/Car/Dialer": {
-    "dateTime": 1633907271,
+    "dateTime": 1633907247,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "295af03d23d70b9dd725f7a8a22ea2e14a0939d8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a58a296571f8ebb3cb5d5dade62f0708be077550",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j5akq6gscanvjfq9ajm81ayws4kpnfwxzaf73l446i0ynh9krvq",
-    "tree": "23d562f5e6c4f04ca59151661ede1379ec52dd88",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
   },
   "packages/apps/Car/Hvac": {
-    "dateTime": 1612577260,
+    "dateTime": 1612566565,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "08cc16a51aef755b48e41a8c4aa401a2b0466afb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "83b8bd294cf6acf05fd9fb6db45e97adeb48df7f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1d2hqs0qqjihdjsqcpa1sg1k54rzdnzgj1y045mmxjp3sywd4lny",
-    "tree": "2633e741f7980841567a7e05b925b70cb5bfa4c6",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
   },
   "packages/apps/Car/LatinIME": {
+    "dateTime": 1613841785,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "a72181a1222bd543f2679eba713a2c1791834c0e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "109b369f4aa6288fc31e2a2d36cbfccb63d3b821",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0386ikmn57maxfr4brily6klk0996d93yw6fahk0h1vlh1bhqgma",
-    "tree": "b73aa0fff4ae9691282dc86d1fd86e554d5ba82d",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
   },
   "packages/apps/Car/Launcher": {
-    "dateTime": 1630631252,
+    "dateTime": 1630449945,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "cff9cd84922776327047874a9ebd248c9d3b9a20",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "41d8f537afa92650a0541a2a3d1ade2e2e9a0e2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01xigbj12hwgx29rf1xcc9cj8bq2c19qrq8i4wq5hq9c7b9x68kk",
-    "tree": "916e37d53c684e171aad899595fe03d9ac443da5",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
   },
   "packages/apps/Car/LinkViewer": {
-    "dateTime": 1619140111,
+    "dateTime": 1619125457,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "96bd6e1cc9a46ee44b2d42f282bbacb9fbeaa51c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1853c8db652cddad119ed81cdfe05369e122db97",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z34jrm6jwb5wpvia998h5izbmx7s80k3vgk43kmizkpfkd99n9p",
-    "tree": "8d6544b8fab60721c8b4a6dba67def484d3bc297",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
   },
   "packages/apps/Car/LocalMediaPlayer": {
-    "dateTime": 1625015321,
+    "dateTime": 1624663495,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "8cc887185b6b01117a2638d89f265bdc17b5e4cd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f70786d5bd8ca16734df9a7d5dd3f08f762b8954",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1q5kbq8p08vscikaqjhkx2dq4cv7i7q3x4ga9fvjfgjnpvvwcgla",
-    "tree": "dc5267e3993f84a485a484a2f5f827fed2eff256",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
   },
   "packages/apps/Car/Media": {
-    "dateTime": 1633907273,
+    "dateTime": 1633907249,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "ee17784f794332d81d5f6698a8b61c709861eaea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ac24d54e7bff4e397f9bd7b56678161157daf7a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0cqpvv9wssnb08k7bys4nzpx5bk20b5v60ff0jkcfp8inijgig1y",
-    "tree": "cb270d6675c3923e8bd9e0b4148977091bae5e4c",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
   },
   "packages/apps/Car/Messenger": {
-    "dateTime": 1625353683,
+    "dateTime": 1625278625,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "1ac1ad58e089080fcd1d551a154476dd0bac9e38",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b99b08add99938e4495836ca46c872a86a62c50e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gfrnnp74byx7rcxx8sx383vbpngmd99bjswkdv6rf6v71pxghs5",
-    "tree": "abe9c36eb63a4fcc07540fa5fff0550437b3c0e6",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
   },
   "packages/apps/Car/Notification": {
-    "dateTime": 1633216070,
+    "dateTime": 1633216077,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "70a8415c88812092a2fdc1b55fc6098df7471bd0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7e0cfac164c39f63204ea0732aca8f68ddfe5d8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yvbxq5k6bhdjh32cxgdvw475j8lhzh0ss8dijflla8rczy2rx4w",
-    "tree": "357805b27eac3aa1f61e21161322eabf67a66986",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
   },
   "packages/apps/Car/Provision": {
-    "dateTime": 1614823676,
+    "dateTime": 1614663424,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "65a44fcf7bc2bee68c9a2984cf3f1edab690ca67",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c3f421608e687af926bb82cfafc61af58fa2058",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hfam8x8qx9ggli07kgwinf6l1lllb7cv0i8g1k7ff0fahm7frrk",
-    "tree": "c76a6ff9a0f310f1282cae38a0457f7ef1768f3f",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Provision"
   },
   "packages/apps/Car/Radio": {
-    "dateTime": 1619140114,
+    "dateTime": 1618537295,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "9d699c16243a0254b1810872fc88c0ce26c82e83",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "127eaab5aedfe62e939aa4c5c571fa314b072dc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1cnswjixyvfvv4hgsvdwb3hga5pzr2nljkx8rxqwjdpa0c8ny8dv",
-    "tree": "d0a393ae3b39216349894ef823a8080b1dbb0a8d",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
   },
   "packages/apps/Car/RotaryController": {
-    "dateTime": 1624496929,
+    "dateTime": 1624473444,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "b70b7ddcbf23d9633e275f354d3c499dc90439f2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5f61ec4a9272da19fd99cef631f37d75824947d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p4if21xgcj2if6ap4h67scxgy9rh42my4s1n82s9dqclyan7npb",
-    "tree": "272726afe08fb4e1d808aa690c7d6ce587d25dcf",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/RotaryController"
   },
   "packages/apps/Car/Settings": {
@@ -8435,220 +8100,203 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "0d06083d35f8f3c0df78427ccebbf25ccaf7e11f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "10419d6245bf8005a96813436158e3845fc52622",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "105swgz0fgh3j6krlzik84if823pk3rqc0rqy914n457yaymq9h0",
-    "tree": "094396efba0f975f6d35d744f27aebe40bb3ee78",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/Settings"
   },
   "packages/apps/Car/SettingsIntelligence": {
-    "dateTime": 1623978532,
+    "dateTime": 1623862905,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "78e2ca9620bed6a4b7060e2ce9a194156da72c39",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "feb0329906af211b18fbd32f77ce692dd20d8579",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12hhrinxbnllsqq8xm1c1glip9rccm28axw6h7pmqdr71z4nd7wr",
-    "tree": "5f14f85a8916a48e4377807a3ba7d450c922e533",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/SettingsIntelligence"
   },
   "packages/apps/Car/SystemUI": {
-    "dateTime": 1629853654,
+    "dateTime": 1629476788,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "c05a2b61ba265091de0d8aeff72b43a5ab1b7eb8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8e25de8087e6007cff8947e033321f4ac7d70fda",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xjgdsqbd0qbbyabk2l383wkf504apfbrxpz22gpc3jw2k9i3vfz",
-    "tree": "c694a8d1f002bfd66ab68a5fdbd671b5e817c980",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUI"
   },
   "packages/apps/Car/SystemUpdater": {
-    "dateTime": 1625015325,
+    "dateTime": 1624663223,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "bc56a2749ba96584d922acc378672a4a36ce60ba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5cbee695783178dae8a58c5973093f0ef7e86e7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0c5i2y5p3y5gmbdi4fl3k6nrifr9kp1g15115i92fg3vh78f4g0x",
-    "tree": "eb245a3f4bd1ee407d13573318e21184366c3f71",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
   },
   "packages/apps/Car/libs": {
-    "dateTime": 1633655262,
+    "dateTime": 1633655275,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "b80f6110c0481e30f23c3ed4b89453f895eae6b9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e181dac6d9b39dadf1818ddd7224b5cb36a6bb8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hs861hidar3a5ib6yrqfb92kz5nyxshpj8f9gl0kwi1cv57paz7",
-    "tree": "9c46cc49e06006705908ff02d60eeb09ec3b8c62",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
   },
   "packages/apps/Car/tests": {
-    "dateTime": 1625015326,
+    "dateTime": 1624659459,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "34388b0a1f7693ddef725907a9f3d434fe5cd06c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5909a7ddf81331c3d0a481b549202991e44a6b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03cwfjb13np93vfvpidvbwrx57d41hb673ddrwh9rnqk1h1sj0z5",
-    "tree": "ad8d4aa72f7f5c24180b32816d7e2e6239977dd3",
     "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
   },
   "packages/apps/CarrierConfig": {
-    "dateTime": 1635877150,
+    "dateTime": 1635860786,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7f0fed917fde91d81d4480d7e015fe67f3380b4e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8fc9861a66a3c281b864a6bb10e93b6f3028367e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1i6my1iy8k5xxswk16jvfg0cma4vsi43g8256gvx8y98ymcm6ih9",
-    "tree": "032d547ec6cf6e0b874fc7efbfa125f70fb1be2e",
     "url": "https://android.googlesource.com/platform/packages/apps/CarrierConfig"
   },
   "packages/apps/CellBroadcastReceiver": {
-    "dateTime": 1633216074,
+    "dateTime": 1633216082,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "af1ecd8bf1606077c9ba540b04bf529bbe4a4c27",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bdac19da393f2da01a4f72381f99f6f18e99ea42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kdwdiplag1zfnzfns7cvj3cm1ixq9q560ql328l787p4p2frl27",
-    "tree": "146eac5574db651531666fd2177cc2b03a717676",
     "url": "https://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver"
   },
   "packages/apps/CertInstaller": {
-    "dateTime": 1632539265,
+    "dateTime": 1632503464,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "62a5ee03413d479f218345177fe47a475f1f0218",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e9403a68710c8fb0b44b4b1972720598526cc2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1h6aiddwy7jpyk0rlwjj9590pqcwpshscr9i2ylhq44yfax9qb67",
-    "tree": "71e1e25bf4c3d08abc5d65e9bc050c9272ded122",
     "url": "https://android.googlesource.com/platform/packages/apps/CertInstaller"
   },
   "packages/apps/Contacts": {
-    "dateTime": 1633655265,
+    "dateTime": 1633655278,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "87820d71695ff848465bff71b4387cfc091dd0c2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3191a4068d44223112cee830a9856afd2ee610e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rr3yr5hnzany65gzwhibhglywa57kbkldh1g2276gmj98y3rhbf",
-    "tree": "fd3f6d22a3d887cb4594f2c3c70956f8d9f7f58a",
     "url": "https://android.googlesource.com/platform/packages/apps/Contacts"
   },
   "packages/apps/DeskClock": {
+    "dateTime": 1614925334,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6f776cb2698dfef7dbfa084f17db1cd55f12149c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b781a9271dfb1c16bd29e9fe20bb2e21801bac6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v7bkqlsi8q3djjbs6h449p3nw9mg0c120y6bj37nkmyci4lw9nm",
-    "tree": "a2ccccbd8fbbcf3c77e9c32fb32785ba6e6334ad",
     "url": "https://android.googlesource.com/platform/packages/apps/DeskClock"
   },
   "packages/apps/DevCamera": {
+    "dateTime": 1618492520,
     "groups": [
       "pdk"
     ],
-    "rev": "ec941ed8eb5ba0581f75d9697d97e84ac70f5b74",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f361dce59fca57e4cebf4d0999423028e0bce329",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10vv74hndkdq9281dxsv8jk8frfjjqkqw2h48wc63c762mvvfy5f",
-    "tree": "ccb336647a05be8420ae64ee6d356c6887e29078",
     "url": "https://android.googlesource.com/platform/packages/apps/DevCamera"
   },
   "packages/apps/Dialer": {
-    "dateTime": 1619305702,
+    "dateTime": 1619227585,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "5210bc6a30d312cf68788d3a0087a5f9d5317084",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c7edb562257a9de9377a450352420567cca54269",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jl84bzvf9s45m9api93byy7hl7n5hwv23xknqj4yv3hhz8xwqps",
-    "tree": "065173dc266b8642a8c3e100b2b01e12a0ab02cf",
     "url": "https://android.googlesource.com/platform/packages/apps/Dialer"
   },
   "packages/apps/DocumentsUI": {
-    "dateTime": 1632964137,
+    "dateTime": 1632935292,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "8dc22c703db487226ed675ff3d519c18097ac3c7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8a2529a00fb8a8418fd8e5bf3176d2274932e8ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0h4faxq62ml9g2dxa2brgq4w0n32xrfzi4zcajjvh9w8vxvh3in1",
-    "tree": "5eacc20af334d75598f284da617acee793cf24f5",
     "url": "https://android.googlesource.com/platform/packages/apps/DocumentsUI"
   },
   "packages/apps/EmergencyInfo": {
-    "dateTime": 1632186460,
+    "dateTime": 1632148195,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "76509f7cbb32a4b208710c302aef3be3ca974b00",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ebfa5587032448c18cbc9fc250cc06542622dc3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v7fcmd2qbb7p9j1zm45jrqwzxaapmap05pdf86nx2055yxz8r7a",
-    "tree": "fad6b2ef91cff06fc4f069b9aa71dbe964bcc92b",
     "url": "https://android.googlesource.com/platform/packages/apps/EmergencyInfo"
   },
   "packages/apps/Gallery": {
+    "dateTime": 1613842641,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "b296d8eaa28d2cfab32990bdd1ad7ca872458bfe",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8f9fa4af6acc3fe9382193af4f1abee874a088d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1jvm1nsp49a8bdzrykm2ywi5d8kp5s79ynxsaazr56xh88m63swx",
-    "tree": "6958bcc76b4425b782d9666f1979589e058108bd",
     "url": "https://android.googlesource.com/platform/packages/apps/Gallery"
   },
   "packages/apps/Gallery2": {
-    "dateTime": 1613866113,
+    "dateTime": 1613842710,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "dff9e21d31668f1e9a5a23f5d015d4c5733e5166",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0392cb2240a9dc07aec700994036fd10737744d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0867dc7j5diqyivnd9j6s8c4iwjgml5r47s364s8c8z7jz2haicf",
-    "tree": "c7c97e98a83129d90f5a5329b4e83ab9f9f41143",
     "url": "https://android.googlesource.com/platform/packages/apps/Gallery2"
   },
   "packages/apps/HTMLViewer": {
-    "dateTime": 1620263728,
+    "dateTime": 1620159861,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "1fb88b8715d447b56c0408e6b029fbd9bcaa7f3f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "93bc3980683853b36f919478acce8990e2e00055",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p8kx6jf10ga48l7sbbn731yp8rfy9z2l2n5kvxwwc7vflbybi90",
-    "tree": "a14c9134e4556b9ecc12559ea69aca438c032f45",
     "url": "https://android.googlesource.com/platform/packages/apps/HTMLViewer"
   },
   "packages/apps/ImsServiceEntitlement": {
-    "dateTime": 1632445651,
+    "dateTime": 1632355343,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "996becce95a4566450155c6a62d260277c5b4a4d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0a01690fb5e678490b5cc31a75d4b9ec2caac308",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10awzbjfzx3pvc879rrf28vrnhmj8iz830jxxah38l63sr1x4y1v",
-    "tree": "ffb7e6ae2e264091a81cb5307f958af41cbd3ec5",
     "url": "https://android.googlesource.com/platform/packages/apps/ImsServiceEntitlement"
   },
   "packages/apps/KeyChain": {
-    "dateTime": 1633568926,
+    "dateTime": 1633568929,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6e16909ab6768de7cc6a13f5f1073b165eed6fdf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "87f73c9b854c60d51ec7dadcae0f1c16205f0534",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lcdnsmyf9qqfbafbc68w6alyaxp2zxg3mb1cfdcplwx7bhng50i",
-    "tree": "acf68890c48ff285ec833abd6a2bc2670a216eb2",
     "url": "https://android.googlesource.com/platform/packages/apps/KeyChain"
   },
   "packages/apps/Launcher3": {
@@ -8656,194 +8304,182 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "c4686b752b0c1cec59afdb2d486212258d514aa3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a068987964ee467a57198e716dd065469406fd5e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1czm9w15jr0nvkwd6zbhzzwjdwshskbgzmiwqryjjczc9h2dlq1k",
-    "tree": "ac27ca25337a30d3ed5ad66c3733ef472add4d6f",
     "url": "https://android.googlesource.com/platform/packages/apps/Launcher3"
   },
   "packages/apps/LegacyCamera": {
+    "dateTime": 1613832689,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "3f76f3009f19fc37d16d28a9a823f18aebd32628",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6588dbe4a397c2922687c39e6d18f216e1e501a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xlgpy1lpcixp767g81kahhzid6g81qa4ghzk0q97jpqb9dp7fsy",
-    "tree": "d3ae8b5ad33fd16cb1adb7528909bd416dc093f6",
     "url": "https://android.googlesource.com/platform/packages/apps/LegacyCamera"
   },
   "packages/apps/ManagedProvisioning": {
-    "dateTime": 1632791241,
+    "dateTime": 1640531102,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "3102c6bf85e00fe96d40792a25b2ec4d66303579",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "1jb7xwf0awrpfzvp70sg3nn75ypnsz3bm8giqfs0v2x10fg7d10y",
-    "tree": "5364226203f8bfbadff912807c19e3327904b3d2",
+    "rev": "d867fc36176dd2c804bbcfbedd3dd0e69eb01433",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cd6qy9nnbvla5lf565cjb6scpbhpg8gn2csha6smbfaa5vnw6i4",
     "url": "https://android.googlesource.com/platform/packages/apps/ManagedProvisioning"
   },
   "packages/apps/Messaging": {
-    "dateTime": 1633655273,
+    "dateTime": 1633655284,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "8cb27c6c2c8c364379b427c53fdad4f1cffee95e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ba482d1c71a76d83eade7a701ec9b88f7f1ba07d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ykkj37jd9p4w0ds7v9wbhdx77zzkn2sglcnliyqv8dfr18aqrwl",
-    "tree": "62e1d55b901f76bcbace161144501cdbf6017d71",
     "url": "https://android.googlesource.com/platform/packages/apps/Messaging"
   },
   "packages/apps/Music": {
+    "dateTime": 1613842349,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "a221847612817c17463a7755aaa112ad5819336c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e1056a9d4d59922a3ef0c280bad8b5c920f376f5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0as5xx38vj9lhkqx0vwd76sdn53cd3f3p2igb48lbx31d037q4c3",
-    "tree": "8c5e6acc2fb2b1e33b38ecf45d8366a839e4cb23",
     "url": "https://android.googlesource.com/platform/packages/apps/Music"
   },
   "packages/apps/MusicFX": {
-    "dateTime": 1631401682,
+    "dateTime": 1631334490,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "623f1ce87cd7fb780ec342f268abbfbb4661405e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "67daaa1df051b5dd7e0ac3a1e04298a70c3e37a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "150w5ly9ngqmm2w6jsr43l1dl32id8lhyy42saci4hq4fndyrapm",
-    "tree": "a332892e193b0befb7f45a2e229539e2a219756d",
     "url": "https://android.googlesource.com/platform/packages/apps/MusicFX"
   },
   "packages/apps/Nfc": {
-    "dateTime": 1633568929,
+    "dateTime": 1633568932,
     "groups": [
       "apps_nfc",
       "pdk-fs"
     ],
-    "rev": "93f421642a3179b04643d5555937f06259e33230",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f2fe63716d5d285eb17aeeea277e8318fecec7ff",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j5snrhyd3apk5rpnyc8xzjwqznh79czh5hp6zh9a1vkfarxg4bl",
-    "tree": "2e7d9c59ad0637e9e245cc65bec2de6175a04ffd",
     "url": "https://android.googlesource.com/platform/packages/apps/Nfc"
   },
   "packages/apps/OnDeviceAppPrediction": {
+    "dateTime": 1613934452,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "3eeab9f3661715ba8e16aa62bc2d83f0ac3d565b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cb51631578c2fbd731f249ed7654c0a521e4704b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1fkf6vkd884q62xl21kayi6113ggay9yla8v89nq1dyp2k5w3dna",
-    "tree": "857c06d175eb126d3bf461cad47007d867281814",
     "url": "https://android.googlesource.com/platform/packages/apps/OnDeviceAppPrediction"
   },
   "packages/apps/OneTimeInitializer": {
+    "dateTime": 1612561058,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "885efe587fab50a9336be8a3871c2b00df487155",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f560d872c05e39b403ad9b990eadcdfd4f04001a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p5xhhljcd2bcpb57b22h65rgsv6k11l3xdi0bc4jaim9p12sikp",
-    "tree": "abad0f19e7bf6fb5486dbf2c0ef6d3fb1e9f9a59",
     "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
   },
   "packages/apps/PhoneCommon": {
-    "dateTime": 1630278479,
+    "dateTime": 1630268878,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "0dc99ea1a5cc181b8d39c965d90a444d1f5869aa",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c26921d9a36f5f7af6f43d58d6e3ccc8e21d5b13",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rkb6bjjvjivfi6inz82wlg0pcasywciw5szdxra95vgh1fxq3w9",
-    "tree": "5b697fd74d5b5716080d271edc42259555561a16",
     "url": "https://android.googlesource.com/platform/packages/apps/PhoneCommon"
   },
   "packages/apps/Protips": {
+    "dateTime": 1613934267,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "b362017fc0871b9c6bee8395c0b250603f359611",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cf8f65a13775b589fefb2f34aa3e45b4f142c5d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0krih7himlvr4i051i1ccrr46pvz34nl7zabxq37i5902fg7ifn6",
-    "tree": "de37dcef6ca4db1feaf28f2c84c34584ebc2265c",
     "url": "https://android.googlesource.com/platform/packages/apps/Protips"
   },
   "packages/apps/Provision": {
-    "dateTime": 1613866121,
+    "dateTime": 1613841788,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "79b82b57579dfdcf39356065d7e9109277077323",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "edfa0a39591e067643658431e1cf329f7755fac4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1b52p9b9i19cg8pip9ykfj5finlvxxv9ikwjfjpk022pzg0p0zz2",
-    "tree": "103d774520d2f59781636ae3a6e490b9727d8bd8",
     "url": "https://android.googlesource.com/platform/packages/apps/Provision"
   },
   "packages/apps/QuickAccessWallet": {
-    "dateTime": 1632539277,
+    "dateTime": 1632515932,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "4079acb8462e38b3174de30feddb2aba3d498d16",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "30e868c0caf969b0753674221c2ad7ce4d7f09b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z85rzf28s2f28jxpa89ja51yl8kf12z43a1k72lb7q7cgma6w9a",
-    "tree": "4b969ed90c5a09cc09f21d82424e939e61a8a36a",
     "url": "https://android.googlesource.com/platform/packages/apps/QuickAccessWallet"
   },
   "packages/apps/QuickSearchBox": {
-    "dateTime": 1633050460,
+    "dateTime": 1633072750,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "1331f081334fc7f76a04e4d9754ac672a8fc97ba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "43897b82e50238a46e82a2b70951ef46831fdebd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "144xmkff19450fqiihysyma0n40jzsqgkrwxdgjq2ja6ipdq4ccl",
-    "tree": "8d1244ec640e9d91e12befdb8e04ad0dc4186c06",
     "url": "https://android.googlesource.com/platform/packages/apps/QuickSearchBox"
   },
   "packages/apps/RemoteProvisioner": {
+    "dateTime": 1628476460,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "cbed0eb854a1c150edf297b2cf6b09b94ab61feb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ed833974e3b1fd8512da0b65749dfe14da959f2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1z5khrz27380n6rrjm290nj8cv36ngamj52zbzffy26xi7haxcwq",
-    "tree": "2b5fe390795a99edf02e2729c99bb42312ffc58d",
     "url": "https://android.googlesource.com/platform/packages/apps/RemoteProvisioner"
   },
   "packages/apps/SafetyRegulatoryInfo": {
-    "dateTime": 1629587275,
+    "dateTime": 1629521007,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "5e81f63f48ff4b46d20dec991b080ff073968006",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c617559b15691407f2635997cfd365e26adae573",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1r88hq0ak16arp7nkn6ihfkdly07ypl0l0f2mnxw9s2c1sj0j5rz",
-    "tree": "955a1a7a079aa3ac5f1ef5cb1cc2865515c2698c",
     "url": "https://android.googlesource.com/platform/packages/apps/SafetyRegulatoryInfo"
   },
   "packages/apps/SampleLocationAttribution": {
-    "dateTime": 1620176908,
+    "dateTime": 1620147500,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "7171a9c052e34905dadad998f7632949ecd64536",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b26337dd5235449474aea7884f6a584678d71f4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rl5fafh4w2ly59yby031ag1h5b1i7fp01i89qlsc85x5c4k3ash",
-    "tree": "5a5a7697a4be8151f68c69a7c4c4ebc5d91897ff",
     "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
   },
   "packages/apps/SecureElement": {
-    "dateTime": 1620176909,
+    "dateTime": 1620126396,
     "groups": [
       "apps_se",
       "pdk-fs"
     ],
-    "rev": "0f0397534a9c3ab80d357d978fd99df47170b70c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1a86d34812e9fb7599ad72b32d61184297e0690a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0csvapdfp737y40sywzxbk87bx20dn3j7ppalz6wigc25r2a5wz8",
-    "tree": "7a6ccf14e7ecc9cf63c6edeb638232bb09879ed5",
     "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
   },
   "packages/apps/Settings": {
@@ -8851,43 +8487,40 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "5891d4a6851c21a3e9c0e04324bcdae0023190a7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e5c9f7e2f920b55cbacfb7eb5e380738941acba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1g6srz7dikifzkhzvpnlz7zaq3cv1h249mg5xyj66scywgw1971g",
-    "tree": "9d630d003251f7b7459b06bf8209f417ccd254ec",
     "url": "https://android.googlesource.com/platform/packages/apps/Settings"
   },
   "packages/apps/SettingsIntelligence": {
-    "dateTime": 1614910074,
+    "dateTime": 1614816734,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "bd03cda7d8268beb65739a114bef1ce27483d402",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "40bd23c448fd3218a8ce689ac2fc7326ba6adb22",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0l0yv5d5azgp0iax13dbzqxfkbjgwf0yr0pmiamhi6fjyqbzmh0b",
-    "tree": "95cf443f54ffd146ee5821792c331662ff06c22c",
     "url": "https://android.googlesource.com/platform/packages/apps/SettingsIntelligence"
   },
   "packages/apps/SpareParts": {
+    "dateTime": 1612561067,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "a96caa82682f6a73892cd75fd080f6bef59b52df",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "229881e9e3396356f383d2faca0689cc97a2fb76",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1maawjwjr5mcyh62h02fv6g0jhchfw653y89mmjr1wc9xf13ywvn",
-    "tree": "6d6b6b945d0ea4976fbf05c818facd1806568ec2",
     "url": "https://android.googlesource.com/platform/packages/apps/SpareParts"
   },
   "packages/apps/Stk": {
-    "dateTime": 1631329691,
+    "dateTime": 1631237247,
     "groups": [
       "apps_stk",
       "pdk-fs"
     ],
-    "rev": "0e3222f6ed131c76be6e7c89364740e778a13b35",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7b5892072ac3de13961b807878fd89b92c51c211",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05fmh1jk7a0a36sfm0jkv4q1g5h1i02i01fmip2d3czq27xq3l6q",
-    "tree": "6648f5552a05a93554a6e770e968fdb9aa808c12",
     "url": "https://android.googlesource.com/platform/packages/apps/Stk"
   },
   "packages/apps/StorageManager": {
@@ -8895,75 +8528,69 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "a09a7fdeb4e68acf4e71883879be91b272f39219",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "197f711fb0f8377264504ed4f71d0e83a791d29f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pshqbc597ljw2m0c7113pb4dhxv3ikrkqy7p2l717sdib7jn4b5",
-    "tree": "3f202fc988fd085ef44b7029ec1d8e749acac3a1",
     "url": "https://android.googlesource.com/platform/packages/apps/StorageManager"
   },
   "packages/apps/TV": {
-    "dateTime": 1620695304,
+    "dateTime": 1620683181,
     "groups": [
       "pdk"
     ],
-    "rev": "d6041597b6ec7928380eca608bb8af1a8c4c7a48",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fe56d3cb87b779ed0d65bc27300e64e397a25ca4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qx3r6m8crigjdxyhxbbfvmrs6r9yjjsjkz5i6aclg2l02hmrqq8",
-    "tree": "0f7f1db0ccb17c9cae5cf514ee2c892d98980222",
     "url": "https://android.googlesource.com/platform/packages/apps/TV"
   },
   "packages/apps/Tag": {
-    "dateTime": 1632539282,
+    "dateTime": 1632504416,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "1b16a24fbce9e9a8dc7c13dae0dd2533ebc92b73",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2da6d18d655756947ef7a19b94887719f4ac302f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0f8rbw0h448islyq3p7hdl4r779lhl4b0lkh4yspmmsz3z2azqik",
-    "tree": "2391d343c55d376fc9fe8b3e6c2e1932d60e1103",
     "url": "https://android.googlesource.com/platform/packages/apps/Tag"
   },
   "packages/apps/Test/connectivity": {
+    "dateTime": 1613823670,
     "groups": [
       "pdk"
     ],
-    "rev": "bdbb6f3f6c73199cf54db695311d1fc8a952fccb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "65f770df0643a47741d7ac4a9600393070ffd57f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10mb5gqc3lyi02r4i68yqhqxiwik1xdi87ik9s6lr9b04clf1fax",
-    "tree": "05d5904f0008fbc74a4e5f753acb49b9a64e7b0f",
     "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
   },
   "packages/apps/ThemePicker": {
-    "dateTime": 1630278489,
+    "dateTime": 1630267894,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "5fc08f0304c630f9ce2ace0e810752c03ceae3e2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ffb560a12cbbe92cbcd5a5d369999380b6ae19d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16cnsp44f9k9b4i75z1754n0h63h70bh59hlcp0dgsb0bf7qnpjf",
-    "tree": "85db4c3284f5ff7f30b19db25ba638c9a9000a8f",
     "url": "https://android.googlesource.com/platform/packages/apps/ThemePicker"
   },
   "packages/apps/TimeZoneData": {
-    "dateTime": 1619053715,
+    "dateTime": 1619035266,
     "groups": [
       "pdk"
     ],
-    "rev": "afa83b3f2c17729e23735e57d4bbd0a7c82aaf7c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bcaffe59921770d4011f6a5fde0553440026f1a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07ap27ilgs63idvgw1lyzy64djz657ad4wz273y0pibgh3nm5fj9",
-    "tree": "fc1d9b27fc316702df1d047d29055251d7cea7b7",
     "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneData"
   },
   "packages/apps/TimeZoneUpdater": {
-    "dateTime": 1622768938,
+    "dateTime": 1622749914,
     "groups": [
       "pdk"
     ],
-    "rev": "8781dfada81380e41d49d44d6d84c4a4cc3c1a51",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "72a2c703559879af84c9e2584d6e1151264b4998",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12ir26ysn4n8q1mvyhxp0lmry7k51zam3n2pcdkg3v3g1s344g80",
-    "tree": "51503410d01f20f2790ac565bf8a590d9dc73da9",
     "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneUpdater"
   },
   "packages/apps/Traceur": {
@@ -8971,10 +8598,9 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "c788f746039e1a65ec56387124456f823e4544d1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4856f4b3411a455f10202fa3afa0c807a0608092",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zj5q2y6mkd6aklbbz0g9az871xisxxa85zb6id4l64pddv6p2yg",
-    "tree": "d1696d1bca017b902470f46fd19aa1879bf95e12",
     "url": "https://android.googlesource.com/platform/packages/apps/Traceur"
   },
   "packages/apps/TvSettings": {
@@ -8982,114 +8608,108 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "ae658f7e23f3873e32345bc23a6d5d04aede8e8f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "5608f203272e428d597db1d2ea8bcfaea9b3ca28",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ah6yd3wjxrdq3061jrpvg0ykl36xjzdvk0ksg4wdbi45a02qzd1",
-    "tree": "456dda17311a101990cdfd372217969af1a56e8b",
     "url": "https://android.googlesource.com/platform/packages/apps/TvSettings"
   },
   "packages/apps/UniversalMediaPlayer": {
+    "dateTime": 1613934678,
     "groups": [],
-    "rev": "faf26aa57e8ecb31a594a86ef23082cb7dbf3f66",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c2f78bd5aebd936cdb16611e187e38d239fda722",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bzyk8zck067snc55bknnd4rsmsqkx3y41yg5w9lm410a7vr7bgz",
-    "tree": "f638e6ad1eab9f5d2f5cc73d6cea3001d2a93d91",
     "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
   },
   "packages/apps/WallpaperPicker": {
+    "dateTime": 1612561039,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "ff8523d946a5c369914ad98f4bae37c6086b93c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "57c0ca9bebe18afc1d4790effe121b1fdffecc11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1amwx8m2ckvx5clggdsnwas0ix9qnam2z9sfdwy9wys6rb9mf2qp",
-    "tree": "69129ff2b784a648f9f2a046481d74030a9ad48c",
     "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker"
   },
   "packages/apps/WallpaperPicker2": {
-    "dateTime": 1632791256,
+    "dateTime": 1632753189,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "0500382be510bc29b4b00eeb9a8798219907aa69",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b039704911f4f3cd086aff55652bfdaa2b2efa9b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0z9n4vwca6qys8p45j2cplh75i4fc4brsbm0wnsvrs0awsff3hda",
-    "tree": "513a1fd0669eda417f8331613905d68a54f9650f",
     "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker2"
   },
   "packages/inputmethods/LatinIME": {
+    "dateTime": 1623982579,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "9bad73d618e758bca9d9f500b62e5b4824ca1f47",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bdc5cf567abacd3e91e0998ada341ed4abb9e3e7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06irq7fz55icip6g5km52ds3nc1az8vhg5ra32szsq5qxg788scl",
-    "tree": "e4444dfce56d9b592a8c7edf3c81a4220690e537",
     "url": "https://android.googlesource.com/platform/packages/inputmethods/LatinIME"
   },
   "packages/inputmethods/LeanbackIME": {
-    "dateTime": 1612577290,
+    "dateTime": 1612560903,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "8ecec4d348332ef7ce912cf129c6de1a2f24b0e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "26136094b101bf5ba61323e66dfb19e4a4345eb1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "19wfvg8izsyvb2fwy1gl21vfk7v9c1icbpw542pqcjdyc6dyb672",
-    "tree": "a419a03ee319d59b4a064250a7407dcc5a826928",
     "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
   },
   "packages/modules/ArtPrebuilt": {
-    "dateTime": 1625533733,
+    "dateTime": 1625256038,
     "groups": [
       "pdk"
     ],
-    "rev": "348c98a515e25e7589476d94c166745e78995743",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "89536bc5e60bb856be8983530453ace3b2098a15",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0i9lnw0byhqxwz242kbr5dhi8dg91grhkycp9jp5icdpza28l66b",
-    "tree": "59b6e5b89890f5dbfe1f6602b53e17ab3d642289",
     "url": "https://android.googlesource.com/platform/packages/modules/ArtPrebuilt"
   },
   "packages/modules/BootPrebuilt/5.10/arm64": {
+    "dateTime": 1610155294,
     "groups": [
       "pdk"
     ],
-    "rev": "3ab18c6109d9313320fea00244b1255bd9a78cf9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4897a6a51a9c9f8c2237ed9bc7820a096d74af66",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1n7apxd43m3i2sqgjcp80garn9zznfcsq67gnm0nywp0bbi7wd58",
-    "tree": "b295d4ff499093b36054a06f316ce2f001ebcbf4",
     "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.10/arm64"
   },
   "packages/modules/BootPrebuilt/5.4/arm64": {
+    "dateTime": 1613824002,
     "groups": [
       "pdk"
     ],
-    "rev": "4546e83926d6174c8126182c2994106249c92023",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "42b59fd038624ae55347c87f845ecc905ab7e07a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13gs7i4dcwmjwld93q0w47ar1gcah0kaqbkxacwlc404axfzqg72",
-    "tree": "7fc94d9f8246b59b1b40003c8e22a62793bc68dc",
     "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.4/arm64"
   },
   "packages/modules/CaptivePortalLogin": {
-    "dateTime": 1629587287,
+    "dateTime": 1629521001,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "dcbdef812af32afb2184ec525bb33409b1ab3c07",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d6a7c145b8b141398103ce0656ac3da007b264cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wrrk7lzh101lgavicb3ghnzvkgr6dd7irxf1ibhlrnkbkfg3q3l",
-    "tree": "5152b7a3af6d94e9d79e8599ec24b17a2c3bc9c0",
     "url": "https://android.googlesource.com/platform/packages/modules/CaptivePortalLogin"
   },
   "packages/modules/CellBroadcastService": {
-    "dateTime": 1631329701,
+    "dateTime": 1631221369,
     "groups": [
       "pdk"
     ],
-    "rev": "9cffcd31b544987b3c1392e48cc197250be80402",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9cb5a58f584f5199f226d62306eff2a0018ddc7a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0slndn640xczh9ry6lplyf9im6b26z9n6v4d367ihbv85kn3yhib",
-    "tree": "7a1e21e62799dba7d163edb83921809153e6f8cf",
     "url": "https://android.googlesource.com/platform/packages/modules/CellBroadcastService"
   },
   "packages/modules/Connectivity": {
@@ -9098,205 +8718,190 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "2d0c7df564c9c8521475b97828c94d5c1f6eec4c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f96c46754912c69041a3deab4206081bbcda21c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qxd4mwl9l1cz6b8sn2vla08nvhdssy64sf49ka6wlvy59cysria",
-    "tree": "be5f44bd022063bdf23c0149e772729395d4fcc7",
     "url": "https://android.googlesource.com/platform/packages/modules/Connectivity"
   },
   "packages/modules/Cronet": {
+    "dateTime": 1624437564,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "3a0008df838d0eb20f46357ecdea4baf8d464b8b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4af3e015d1c8f33ff31550ffc96d7d66ddf20f0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/platform/packages/modules/Cronet"
   },
   "packages/modules/DnsResolver": {
-    "dateTime": 1628305755,
+    "dateTime": 1628258794,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "1d5183eee562b78b75dc96717916a7f3b2d0ca6d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "84411433a5d58c041d1af2779345e5e302bcdbb1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ckllgahhki8dcx3md37x6jcyjm5maxmh98l43d107h14h1bva10",
-    "tree": "0150079259980dedfb3c75265c284082d7a19c2b",
     "url": "https://android.googlesource.com/platform/packages/modules/DnsResolver"
   },
   "packages/modules/ExtServices": {
-    "dateTime": 1628557742,
+    "dateTime": 1634000875,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "54d58e8a03c7ba419b2f4095dd4682c4a496a544",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7edc7b080443124236aa2c93feadab6c4653ceaf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "112sxv4lymh9sx4n1ai9hcxd56wpjc9fbll1ih6bvx2421y65ar6",
-    "tree": "ddb2eada4c721f48315a68a22fa82c171561e714",
     "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
   },
   "packages/modules/GeoTZ": {
-    "dateTime": 1624324183,
+    "dateTime": 1623872217,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "a6a683ac55af0f9c491a997248502a26a5e1fc3e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ff5b91bab9452895dc069e6fca8a902dbec93a3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1xw9s4x82r3aa98wcr5cbmclcw2cmmc22palh14ylsypcvpb4zip",
-    "tree": "f1ec5808d5f55046f3357bdad4fae5eb8a2d6365",
     "url": "https://android.googlesource.com/platform/packages/modules/GeoTZ"
   },
   "packages/modules/Gki": {
-    "dateTime": 1624324184,
+    "dateTime": 1622030690,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "750b3dd65ff1e407f2959ac0343d7d2949797656",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7aed682df9d52c7495f203f0b60e292d06539ae4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1snci4l616cvznfbgw3xvmkvsa3i95q1v3fp882327wmv65nrqww",
-    "tree": "c5bf5d001607873b3d716d6aba9bdc095af4ac64",
     "url": "https://android.googlesource.com/platform/packages/modules/Gki"
   },
   "packages/modules/IPsec": {
-    "dateTime": 1627607330,
+    "dateTime": 1628888010,
     "groups": [
       "pdk"
     ],
-    "rev": "9d10999df678b286a1029b2d5a3e6dd9616d743f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8dc668ff5a90331027820887bcf70e8ed31351a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v2qw6hjafasjn9vby9wac9kp204nfn0y3j0abhz2i591jnbzkdl",
-    "tree": "480b476cecc06322ed45723f7ba3db7c40123698",
     "url": "https://android.googlesource.com/platform/packages/modules/IPsec"
   },
   "packages/modules/ModuleMetadata": {
+    "dateTime": 1622030724,
     "groups": [
       "pdk"
     ],
-    "rev": "b213b3f7f1e47cb52c46115ee7f895f147ff89ef",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4f8143db8de7e668ea962c04a190f64fc3c6be9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wl1mb6fmnym4yyi1w4fc0zni7awb50mh9w91a6plp5j1rmy3x87",
-    "tree": "aca057c986eff64ba4d2a1a04130e3542d534c59",
     "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
   },
   "packages/modules/NetworkPermissionConfig": {
-    "dateTime": 1614132529,
+    "dateTime": 1614071034,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "3686099f86e423f1c70f1c4598cf10440d6860e4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "99104d9117e5f22912c2d7fb9567af2db2fee600",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nz2xs3rmpvbfwka7lxr87chqpchq57cc8r25qfgymbhnkkg61pl",
-    "tree": "0e3d372b36f4960d9a26fa32790ab9df8219f22e",
     "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
   },
   "packages/modules/NetworkStack": {
-    "dateTime": 1631488132,
+    "dateTime": 1631452622,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "994dca9aaf9428a7d397189f30f43ac6dcee0dc9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4812f11869e69277fc70c5c819fd553892206ff9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "139xx8p1kjg0p0l2zgpqxb7d6pprqzmsyb2jjmb4w2lzka5jm5w9",
-    "tree": "48a3cee0938cecf4f7382ef19e73f7a817610a55",
     "url": "https://android.googlesource.com/platform/packages/modules/NetworkStack"
   },
   "packages/modules/NeuralNetworks": {
-    "dateTime": 1632964166,
+    "dateTime": 1632862953,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "0e4ef807e6db004767587e142edc9cdcab72996f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6e15ee5c500f658ea0851c67deb6d4f73b310829",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1aamf7piyca89ri2xahgb2zbqdwx64qyslllnanpv6rq4zvf5pqm",
-    "tree": "ba53eac7fd1d0810b765df589b5b377ca0cb48c3",
     "url": "https://android.googlesource.com/platform/packages/modules/NeuralNetworks"
   },
   "packages/modules/Permission": {
-    "dateTime": 1633907313,
+    "dateTime": 1633907289,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "238b1b93b2b1712dd674550141eb6224a473cc30",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "88bb8f6a817f8f4c1df28c0b1097393904c5b1d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kg161m9cfhfz0y1iixrmyzgj5pa2wxw7r5gmvsvclznaffnnpzc",
-    "tree": "05f41af5f664c862d6c8e5ac80ce251ec1c53d93",
     "url": "https://android.googlesource.com/platform/packages/modules/Permission"
   },
   "packages/modules/RuntimeI18n": {
-    "dateTime": 1623892188,
+    "dateTime": 1623704087,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "ec12b8b8327c8ef157d7c93a8cd81e431db3d390",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2be2a40cb3fbdd2a88b9644bf549d5c1466df2e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "016clxna7xjxwy42chxfdcp48ny0j3g4nyxg57zvqglgrlx8cqp2",
-    "tree": "44050c600e4eac3d93bfef798b0c419c53b52c89",
     "url": "https://android.googlesource.com/platform/packages/modules/RuntimeI18n"
   },
   "packages/modules/Scheduling": {
-    "dateTime": 1627096130,
+    "dateTime": 1627009218,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "31e3bfe9d6b9a7b3855f74c649d28896d6a73cf1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "534595c58531bdcfe3e8fc60ba3d2180a69c768e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hl2d5b5nybidak1pwiw26sm08il2nb5jflj419f765p3g9r5byf",
-    "tree": "b868365729ade7f6a29feb437ff7e88f4c9d5860",
     "url": "https://android.googlesource.com/platform/packages/modules/Scheduling"
   },
   "packages/modules/SdkExtensions": {
-    "dateTime": 1628305759,
+    "dateTime": 1628268818,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "647ebc4b84bd82dd52fece05d27b5ba85a62e564",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "55df9556ac814c327aca3b99682680ecc95eab87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1m4pl0v7f56g74ym76qrq198g6pnd93w8zh05bynvyvarwbajphd",
-    "tree": "b9251322b945c26e995305c3dc0fda359587af85",
     "url": "https://android.googlesource.com/platform/packages/modules/SdkExtensions"
   },
   "packages/modules/StatsD": {
-    "dateTime": 1633482535,
+    "dateTime": 1633482510,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "e01a8e3668bf56da4d76d4297ae1a077b2537a4c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "58d133e7a2b2047098dbdea058217c8f628a6efb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g7y0v46pa2650m0rd9697gzp5zrlmlg70hhv0f2p3ap6q8y80gx",
-    "tree": "5c571d323dd22f809413bb1a0792c10d9185f787",
     "url": "https://android.googlesource.com/platform/packages/modules/StatsD"
   },
   "packages/modules/TestModule": {
+    "dateTime": 1539195664,
     "groups": [],
-    "rev": "dad5d47a7e5f7974a4f412744562c3c0d2142f32",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "41a212ed3a89f56fabea901bddb367c69f99af08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
   },
   "packages/modules/Virtualization": {
-    "dateTime": 1625706941,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "259364e192f410367a722904f8f25b9bfbc5fd5c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ba76ce28778c2e59fe9ff3ab15b1ede457c5ed11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1i7h4ppc6clrz7q992fmq7wsw7pznpai9kinwb2w87b0m3yzplk5",
-    "tree": "206b552dbb08747be7b3db10caaa037c675e6045",
     "url": "https://android.googlesource.com/platform/packages/modules/Virtualization"
   },
   "packages/modules/Wifi": {
@@ -9305,100 +8910,93 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "9d7c1fc10ef890774894491256b03c19791ee347",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7fcd1099ab2928c82c405f430944d05f38975098",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yx5yam0rqqx1mjj4jshdchy55i087n28mdyap2jb9nk0nbygi2v",
-    "tree": "ba876a0ed17c87e6f2a96e614a78ad4442466e55",
     "url": "https://android.googlesource.com/platform/packages/modules/Wifi"
   },
   "packages/modules/adb": {
-    "dateTime": 1628644158,
+    "dateTime": 1628615572,
     "groups": [
       "pdk"
     ],
-    "rev": "def60d99f8c4154afdb15c35476c0bfe2248d68c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "719a31ef284ab8b2b5f79dfdbbc31a22f4414820",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10819wff878fisyz5cjh305svrrfi3i896vhv2cx1y4w3cy7hrkj",
-    "tree": "8dc3f3ddbca05014de5c274e957184c7101cbc8d",
     "url": "https://android.googlesource.com/platform/packages/modules/adb"
   },
   "packages/modules/common": {
-    "dateTime": 1629421692,
+    "dateTime": 1629364203,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "6ff78b45a6ec366aa3e49ec29555cebfc6bbd338",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3452b821ba7cb635606770da8bc64eeb5270c6d4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qhh7wrhmxwdvpjg85j38xd44hq9dvwp8l6pk6qkgwrmb21gb0ri",
-    "tree": "4e9e3335f079610090fce9f2df4657ca6cb469f2",
     "url": "https://android.googlesource.com/platform/packages/modules/common"
   },
   "packages/modules/vndk": {
+    "dateTime": 1623704209,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "0bd18180c89be462e1dc4387cf9af9963a588f02",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b8bdf93c5328b64363bbc3db079fe798d77794b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01y5wlkqvj6qcplkjmwazmz8q964k9x32kx8v85kq7w5vgnlc33b",
-    "tree": "6032c5e1ad7dd0775ec4c87cfbbc83150edc90b2",
     "url": "https://android.googlesource.com/platform/packages/modules/vndk"
   },
   "packages/providers/BlockedNumberProvider": {
-    "dateTime": 1624496970,
+    "dateTime": 1624300738,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "c436f6522de7a0058eedca12e8cc64e9fe2bd85d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7a69ab7cbed4efaed65e4c2621ed7d03abc39b70",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xljiic1hbdkzcpzxmhi1s19h90fdb9yzx6yai6iqbws6zyi5wj8",
-    "tree": "f1978e24f683e733af9d745da54ccb25471f1853",
     "url": "https://android.googlesource.com/platform/packages/providers/BlockedNumberProvider"
   },
   "packages/providers/BookmarkProvider": {
+    "dateTime": 1613934275,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "ab4749bf815987401a4adee6626147749df3a394",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2e42998da60d84f0a9eec9dc79d5d1ea59719e68",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06p1pl2iq980hibsdal7jq7qnmvsr3w4zw88jvr53ifgjvaj7jyy",
-    "tree": "547dad8b6e8aabc6b73b01dc9098b6b5b90e5630",
     "url": "https://android.googlesource.com/platform/packages/providers/BookmarkProvider"
   },
   "packages/providers/CalendarProvider": {
-    "dateTime": 1627348164,
+    "dateTime": 1627081060,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "08d1259313e63802745d404e2332c256f41ba61a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "27606e23e6786f311b9db128eac04661ef3816e3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "10g01wxvmkylh7r7kjq2analk29zfs2xqaql75h0rw5bnvxkmfdc",
-    "tree": "b10ca6a2a49781012e5097ba8218dc8da64e7e4a",
     "url": "https://android.googlesource.com/platform/packages/providers/CalendarProvider"
   },
   "packages/providers/CallLogProvider": {
-    "dateTime": 1620695321,
+    "dateTime": 1620664186,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "bc34d108689af1fa3244cac7699bd725e7a078b8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "170a43ff130cbb65d0bd45390ebd2c2dd13d7d3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0qxaag2rzr45ixnnmzl88xhssvvlaz6mijizj75jkrdslj61q2ha",
-    "tree": "e9700fa34e5e575576b01f4753f83afe9bec1f24",
     "url": "https://android.googlesource.com/platform/packages/providers/CallLogProvider"
   },
   "packages/providers/ContactsProvider": {
-    "dateTime": 1633050487,
+    "dateTime": 1633072777,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "9c34c4089f63196e87dc554da2ead8395a9b6c96",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c349363a84f1f88504f80b2f6b8215d619071852",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mys19n8j884jp15d5f010gi8vjcb0mfa559bf3d5bl1czyhbhhl",
-    "tree": "efd0e7edd97a9f642767d7ca413921e62cb9f70b",
     "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
   },
   "packages/providers/DownloadProvider": {
@@ -9407,32 +9005,30 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "e7493acbaca76074ca923527ae0aa9c70c701295",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1b2c548b4b2e8c68a45e87a91a85421692093dfc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wk0c2nikn35rbmyc0aj1rhycg8w47w3zv76z73929lnmyl04n2p",
-    "tree": "94a88ff5ef204392e64417637ed14209c18d6941",
     "url": "https://android.googlesource.com/platform/packages/providers/DownloadProvider"
   },
   "packages/providers/MediaProvider": {
-    "dateTime": 1633482540,
+    "dateTime": 1633482520,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "ac18eb3a563c8752c7cbf1e3fc8d4e3b7e6bfe76",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "14e680ab97bcfa998f1b30c7874c08412a612672",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1czinab382mp2g1hqnnvf5mw0fad3lmlzs02m2ykayybargxmsnl",
-    "tree": "1ae4d341191aff5798f73cb73e76f23ceff2c7bb",
     "url": "https://android.googlesource.com/platform/packages/providers/MediaProvider"
   },
   "packages/providers/PartnerBookmarksProvider": {
+    "dateTime": 1613934274,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "079f8b3ef8fa749e026b8c29bc0ceacf04e76f47",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e247fcdd3bd157c0231affad76158bf09773a424",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12s14vcmpypbk2h116n3spvqg4akj6xizjrw7vilab7ln8wp89i5",
-    "tree": "9eed57a5bead6f8282b6aa5c19c892e3a184dbb9",
     "url": "https://android.googlesource.com/platform/packages/providers/PartnerBookmarksProvider"
   },
   "packages/providers/TelephonyProvider": {
@@ -9441,43 +9037,40 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "2a0497eee8685bb69d31b20317019b89b5f3f327",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "bd0bb421c9b492c9b30ecf3bb3fc6aee046965e3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qia5j6h4rxy84cbzm67xqjp3h57z0d53lgfgk8gd6gd9j74rcz1",
-    "tree": "03e59f42977136b68332ba3f7f4541c31b1ddc0d",
     "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider"
   },
   "packages/providers/TvProvider": {
-    "dateTime": 1629587303,
+    "dateTime": 1629521014,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6bc99f6095d36f4c879df859c19c92129f004ab3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dca8b5d2832e1eff82f6b370b1c2f459a3270288",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mkp75x3a22b4gyhw3j3lyc2xwd32xw6xhwkgi4iiql3kwqq8w7b",
-    "tree": "ce7afa915fe9b138657d6796d842bd8f1393ffde",
     "url": "https://android.googlesource.com/platform/packages/providers/TvProvider"
   },
   "packages/providers/UserDictionaryProvider": {
-    "dateTime": 1624496975,
+    "dateTime": 1624300796,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "25a148674b89686661376907ab693a914bb7ec97",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9c2e23634083ac8e2c4574d4ec3a740df0083b75",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0nkkxj3mm39lp6ga1icachqykkcarfslxi3jngxj8v1rriqa710w",
-    "tree": "2842b4df5a63d285f3a8a7121175800c1b8e5f5c",
     "url": "https://android.googlesource.com/platform/packages/providers/UserDictionaryProvider"
   },
   "packages/screensavers/Basic": {
+    "dateTime": 1622529042,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "d7caed49bf0b2fe4b4725f77c1b7aad968210544",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c0e1b53e325c672968dc633162b95fd38b32038c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03wkn8gl92cdcqkykb1m5kpmmzmc46hlinz4gyprpacn8wgr6zqx",
-    "tree": "8b4ffe89f15ce0bd0ee75fd2b4f9f4e69fa645f9",
     "url": "https://android.googlesource.com/platform/packages/screensavers/Basic"
   },
   "packages/screensavers/PhotoTable": {
@@ -9485,34 +9078,31 @@
     "groups": [
       "pdk-fs"
     ],
-    "rev": "5bac96b4bb22ed8cb1a850f609d4c77528cb0b32",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "37031d861f737f6114932a5fc432dc548534e442",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bp8pwc5sz6l9mlwwj24ngxkbcyds9gba9c2mpb7zsls46agqpna",
-    "tree": "065eb852d31ad7fe03d4ad08844254a41cc68d23",
     "url": "https://android.googlesource.com/platform/packages/screensavers/PhotoTable"
   },
   "packages/services/AlternativeNetworkAccess": {
-    "dateTime": 1630631305,
+    "dateTime": 1630520767,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "d44583c7e9bd3c07486ed9a9c9847ddbc5d6e022",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ec983a48b31b86ed2a6cde44ac81dfe07173772e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16b84vhvra87k6ricz42wi0i3byvb3bz9ivn464fc486j5vkgs49",
-    "tree": "e7aa59a21b28cb131bcca1498a66bdbf8027e22f",
     "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
   },
   "packages/services/BuiltInPrintService": {
-    "dateTime": 1631488144,
+    "dateTime": 1631453299,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "c0cccd1ca55ba9f299368c458778fbec6f2738e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "54ff1e4df5072ad564a50d8960176c17708c9ac9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04jkplcn8m16k0hcnzahpqga3dxxfmhqsrzac814kyihkxysk28z",
-    "tree": "b5e9dafd5bfb6fb3b1727036803ed101f2e8a59b",
     "url": "https://android.googlesource.com/platform/packages/services/BuiltInPrintService"
   },
   "packages/services/Car": {
@@ -9521,101 +9111,94 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f4e93f0096e457075d49a89a39e5011df8d57378",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7053f2287e3f04733087c539fe0f320ab03fd7b9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ls0b17nsj6na2yiqv53gzdaa491dqgd5flxgg5d7km28xkd85ik",
-    "tree": "7186c8c771175ef585aab446323957657b4dbed9",
     "url": "https://android.googlesource.com/platform/packages/services/Car"
   },
   "packages/services/Iwlan": {
-    "dateTime": 1628816922,
+    "dateTime": 1628733391,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "f76d5113cdafa8f194bb09fcbcd1b4d0030b9e30",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5e97db86d3ad51bd2d69d7644dfff7a56876883",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1l7f39npsjsy6rgaypz8c33y29y8b500m7ssrp1w0b3injj5ddy1",
-    "tree": "e483112ccd83f713aaa0b32542b8a0cdfc82e0b0",
     "url": "https://android.googlesource.com/platform/packages/services/Iwlan"
   },
   "packages/services/Mms": {
-    "dateTime": 1620176938,
+    "dateTime": 1620080669,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "9fe4eeb797d6b0e71eb65c78c109dbbf96292994",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b9f0b94a6f32e344fe289f658439cd579cd38fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "192dhws43zp66czpx42kciwggd1p21mp34if3hkkcv8gqb5vkxsg",
-    "tree": "1c9ef987f3cffdcef7f394efce1e173bd47fff72",
     "url": "https://android.googlesource.com/platform/packages/services/Mms"
   },
   "packages/services/Mtp": {
-    "dateTime": 1624496979,
+    "dateTime": 1624269588,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "04233cf58a8eed009e9ff9ebe1ab929bd529c97c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "071b381d0a99b0c0c03e1b8b2caf87d535db0874",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0581pybyfy4npszpycjkkphir38nvj6b16zfl4ciz8fxg6dcwgqz",
-    "tree": "c2f876e790df9f3bf1faa6a1355bd5a516649c11",
     "url": "https://android.googlesource.com/platform/packages/services/Mtp"
   },
   "packages/services/Telecomm": {
-    "dateTime": 1633748948,
+    "dateTime": 1640531103,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "08c9d3a0a860a598823201cbb838166046b0707e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "125wanj5vlb4d2zpc6ym3g871q2d3q66zcbpscqhv2vfgnf97nm7",
-    "tree": "3cbc5b46871d8ed121c6aaa583706bd0442e3127",
+    "rev": "56a27fe0c1e14003ec3bb3bd61669742e70dd007",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1api042x1w935r81r3c2fg0kh0a8f063bgy4qwbfd6aaw9ja343r",
     "url": "https://android.googlesource.com/platform/packages/services/Telecomm"
   },
   "packages/services/Telephony": {
-    "dateTime": 1635860790,
+    "dateTime": 1640531103,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "4d4624b62b1928b9c055e7e6498a6aaa415897de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "0y0rh86s1s4nbz363i9kwf0vq937cvsqayyf6h6l4i1vgsdphjln",
-    "tree": "21323ab30d8cef59f6b86dcb29b3a27718c2922f",
+    "rev": "d56e62fb5ab0b5d683f217ec18df4b176f8fbdbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19g4d59a1y49m8hgzfwh3j46rqccfwri0ym6sal50xaxxzxpk9mc",
     "url": "https://android.googlesource.com/platform/packages/services/Telephony"
   },
   "packages/wallpapers/ImageWallpaper": {
+    "dateTime": 1571790197,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "55648333dc914c30ec166afdf9b8f37bb3338866",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a8f56e359d00ce7cc32635afb7db62698a0a4846",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
-    "tree": "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
     "url": "https://android.googlesource.com/platform/packages/wallpapers/ImageWallpaper"
   },
   "packages/wallpapers/LivePicker": {
-    "dateTime": 1632186505,
+    "dateTime": 1632154235,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "c57db114fcfe4275dc08b1146469758682a78e3a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "162a69ed5b6953546809bdb2688297c2b0b39372",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "06sfrkl1rf81lk0imcblv1gm7yi018j3h56x8wsf4sfqjpv1pgzj",
-    "tree": "5a9519910f0b62b0749eb41b98af3066e68797f1",
     "url": "https://android.googlesource.com/platform/packages/wallpapers/LivePicker"
   },
   "pdk": {
+    "dateTime": 1619035269,
     "groups": [
       "pdk"
     ],
-    "rev": "0aec259c2dc36f044350cc03a0ef8a1ae715f927",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f31519014dbb9bdf58ad7d692426872155467a12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zxgc4qgxsz4vn8qyzmp8m4zqy98fcsgjsn6abhlagp3ihjh27hv",
-    "tree": "78656a13d6c2b9592df3dd4cc9ae2ccfcda4c6ea",
     "url": "https://android.googlesource.com/platform/pdk"
   },
   "platform_testing": {
@@ -9625,790 +9208,754 @@
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "50932ef0aea54388ce5dbb2b5a3c605c30a7c8cf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4348504da36bee7c3058e9a12874021056370a3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0dz7kxb15dgldyj8326n338qaahzsdy29gcxr9prssjcbarv5sbk",
-    "tree": "6f917d0b9f966aea2907b909533ac01a86f65b12",
     "url": "https://android.googlesource.com/platform/platform_testing"
   },
   "prebuilts/abi-dumps/ndk": {
-    "dateTime": 1623805783,
+    "dateTime": 1623682548,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "2169907fab1403b54b844c8c9d37ba3fd5852441",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ea7d8fc96958dd62b904eb3e08c334e24e007cbb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1422gwmj2f08z664xdzvjzi0q03v2irhxl7cl25yjxvr26gpgb7p",
-    "tree": "76d7ae6b484052faffa13fa6cdcabab00ce7a251",
     "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
   },
   "prebuilts/abi-dumps/platform": {
-    "dateTime": 1624929200,
+    "dateTime": 1624659733,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "eebd50106720e8f58ad1cbe5e11a910ba8b7d7f6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a27f69c91ad94bf9f5a72c8902d612e038c37fe3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0256schrmrnmjnip9r6na9hhci6cqydgy3syx3qafpg9mavzy5lz",
-    "tree": "f2977af0bdfde2cace26481decae3ba72746f077",
     "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/platform"
   },
   "prebuilts/abi-dumps/vndk": {
-    "dateTime": 1627002550,
+    "dateTime": 1626889471,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "1e70225fe5358b09c33f5f87b7f596163bce76e4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2dd88e51e7b5b35758c5fa83d0983cc760d79a3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1lss4fhd3g2323xl7v0jlfy69pg6x6fagpmvi0i06pjjgypq5nii",
-    "tree": "bd6e0e5d4e5e6f894c773b52a6cdf4fcd237ebc0",
     "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
   },
   "prebuilts/android-emulator": {
-    "dateTime": 1629421716,
+    "dateTime": 1629405212,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "fa2a6cb99ee322fecc62069ff0f4417b3eda9a77",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "122fc06513d35cc48fb32cc1f3914b932bca9380",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18s3ns14ar9zg89ydis0hyif9djjhngm29i4zxpac79b144iywj3",
-    "tree": "5a0f9ebea5487085dc5239b1bca0ccd89c7a4878",
     "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
   },
   "prebuilts/asuite": {
-    "dateTime": 1628125802,
+    "dateTime": 1628011448,
     "groups": [
       "pdk"
     ],
-    "rev": "d437300654d0fbedb6dbaf64168387048625939d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6fd8b18b154d2a95a233363b014f23ff594fc700",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "012s3a4fb2gsd7rwn8vzf3b7k38zk1kl6i80r2d4cys5a9vmadxy",
-    "tree": "a7254f8bb3f73033cde4ce17daacbc974bd948af",
     "url": "https://android.googlesource.com/platform/prebuilts/asuite"
   },
   "prebuilts/bazel/darwin-x86_64": {
+    "dateTime": 1615544621,
     "groups": [
       "darwin",
       "pdk"
     ],
-    "rev": "27869bb64c88623cd8970e0941e0a296a56d1c25",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ddfd8a933d3b157009233ad2074c2d2b01415634",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wcwyr0n9m0v9mfyjb8f3ljck0w3payq39iv33f2w7n0kihqalgk",
-    "tree": "2195ec5cb32d7f753206980a04668483be51a193",
     "url": "https://android.googlesource.com/platform/prebuilts/bazel/darwin-x86_64"
   },
   "prebuilts/bazel/linux-x86_64": {
+    "dateTime": 1615544621,
     "groups": [
       "linux",
       "pdk"
     ],
-    "rev": "d8a3509f5f73b9d660f71390b93f634195e85064",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fdb89fa5e9727b70fbeea876fecf097a9bc1e928",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mf45cyj47xqfpxp3cvdibwbxjswb2n10gpdydvyb5aynpwg492g",
-    "tree": "2dd17ba331ee8206edad3370bc7d6bc3c7c36e4e",
     "url": "https://android.googlesource.com/platform/prebuilts/bazel/linux-x86_64"
   },
   "prebuilts/build-tools": {
-    "dateTime": 1621386582,
+    "dateTime": 1621288019,
     "groups": [
       "pdk"
     ],
-    "rev": "d7eeadf9392238e0029406a31123e4f7ff68ec04",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "67be7b8b234ea95d6bc448b15fd39c7554e6caef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wph12829w8mj7ddrp9ml33igyg8qvw13hvjsv0jcl708pqnbnzf",
-    "tree": "8d996f123d292b388ba509ce224f8170de9be5b0",
     "url": "https://android.googlesource.com/platform/prebuilts/build-tools"
   },
   "prebuilts/bundletool": {
+    "dateTime": 1613815600,
     "groups": [
       "pdk"
     ],
-    "rev": "5683e14bde8cc0098850ba67a3d6cfd98e9298f2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "457356f1cbf57e03d507db9777fa40b0882964b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kg4bhhflbbzp2gkdf1q8yicsnfnm44z4yfh8y2wwzvlgxy87wmk",
-    "tree": "46486d665dd16510e4fff9b4c42b1713bdf9244a",
     "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
   },
   "prebuilts/checkcolor": {
+    "dateTime": 1586493700,
     "groups": [
       "pdk"
     ],
-    "rev": "63d8b14b9b0c4bec057aec6a517a908d1275d3c9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2213c3afbb7eed19bd88c5abfb33235dcb682cdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zaw6nl6k2l1d9g7rz45vybgi6yjmbxzfzz7kwrsgaymc27b060r",
-    "tree": "73274ed6d0aab4c9e945d9edb771bf98febbed26",
     "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
   },
   "prebuilts/checkstyle": {
+    "dateTime": 1619204254,
     "groups": [
       "pdk"
     ],
-    "rev": "3735f2e13e34e5d74b7cbd4c0bfc7eab74a426f6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "44042b40ba529801c88eabdb7702ae46618681ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j0apf2ddqkxi2v3qqsbjbk9w5b6i7frjfyashymzcwvaz474p50",
-    "tree": "36ad4012de2981dafd8fbf822f7cb716f3f4f09c",
     "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
   },
   "prebuilts/clang-tools": {
+    "dateTime": 1613834091,
     "groups": [
       "pdk"
     ],
-    "rev": "9d62167efae2f52beb72c0d59094b2a4af8a2981",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f90dfe70889a0d23e1f4231b5d3989c7c6f5b1ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18l1ppiv14asv6bv2ivshdwmcgx6r100jjyrxjzl5hpi8zwm6wlm",
-    "tree": "8ed9095f7e8268672f5709415125cacd7b018068",
     "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
   },
   "prebuilts/clang/host/darwin-x86": {
-    "dateTime": 1624676942,
+    "dateTime": 1624581601,
     "groups": [
       "darwin",
       "pdk"
     ],
-    "rev": "302fa2a56405df00f91c473933e01cad17805a94",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "320de8d454913c95c0f57eca37faa38bea1ea0b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ks4mbdskbwr2r8mxk3ymx68709ccm96j06hgq2wvmc4bb9ajyx0",
-    "tree": "db4453cf7bd7c6ff09ca17954a29c9fde31e1479",
     "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
   },
   "prebuilts/clang/host/linux-x86": {
-    "dateTime": 1632359333,
+    "dateTime": 1632330734,
     "groups": [
       "pdk"
     ],
-    "rev": "949656737ee0f472df0ccb6c9dd12c2837f6bbc1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "62efefb25356364413653c88c736102a2a2f8f4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rjlvygqj9hfkdbmwcwfwb8frq1q4kwg3gp4n16qzxh7cdfxi8xi",
-    "tree": "0e83c5e2fe2acf3cb42a543b9f4a960135c0ccc9",
     "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
   },
   "prebuilts/cmdline-tools": {
-    "dateTime": 1617930563,
+    "dateTime": 1617890084,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "d2874f02227c1d97a9a92232f01b8793ac527cce",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "14e9373fe7ed5c1c5e9192e57295751f00f14d13",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1h7r0mi51dgsgz61d3gmh0364zw8a3fgrg46fv26vwg2vj4dcp5q",
-    "tree": "d4c2c25d4f2eb95010d7e84a41b2128d9973c1c4",
     "url": "https://android.googlesource.com/platform/prebuilts/cmdline-tools"
   },
   "prebuilts/devtools": {
+    "dateTime": 1561663933,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6a890ab281f8a29bf4e0b3e7d4adbbefdce64ecd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "61f3dccac575257b2c86873c68085726cc38b530",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1yr6acnwdmwygnvd1kljs27pnhwywgm8gv7qp1m6ir23axwydx0s",
-    "tree": "55a19319df65b91d5d79c01ab6efb51ba7b01a8e",
     "url": "https://android.googlesource.com/platform/prebuilts/devtools"
   },
   "prebuilts/fuchsia_sdk": {
-    "dateTime": 1605060679,
+    "dateTime": 1604451501,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "3796d805ec82a479f61a99226970e7ba6088987c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3d324fb26f98bba1ed4e6836fbea2a0cb14ac5a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j1rnznlk5z0c985xb1fl8mxk52kwjl0c0vask9hka2bqwxcj7xw",
-    "tree": "24976feb7e1a0610689d5667ee0d1038c5554055",
     "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
   },
   "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493704,
     "groups": [
       "arm",
       "darwin",
       "pdk"
     ],
-    "rev": "04b27e91c9deee1e791913977d45cfdb52e2f1da",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "49f6096b7f00ed7a0bacc4d0bcd1d264926c094f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0svy6bm57kq0zkcmc1747x46b77jh4l0rbs8415ka50kvmhwph7s",
-    "tree": "5875bd1d6b09e18442cd0fa590a0d8fb4ee0a15e",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9"
   },
   "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586493701,
     "groups": [
       "arm",
       "darwin",
       "pdk"
     ],
-    "rev": "71332b90280c8d5256af6e1bee811ec072aead57",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "90f2ed301eb900d12d8d41bff03333d6c8f91611",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wv4rh1y00w0mjp535arw85psjfbzc3gplczzdhpanr1g4im5vlp",
-    "tree": "e69a0e7cce040143616fd3c303e79ffa3ae37cd6",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9"
   },
   "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "dateTime": 1578436765,
     "groups": [
       "darwin",
       "pdk"
     ],
-    "rev": "8299934c8b48a7b725a46b5c4702a25ff7eb96b6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a354a4c97c761ac85a97bcc6aa1365c00475ae19",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
-    "tree": "77441d174377cfb9d7ed360ff8677ee85a717c3a",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
   },
   "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586493704,
     "groups": [
       "darwin",
       "pdk",
       "x86"
     ],
-    "rev": "550eb767614b55aeba65834f3e30a9bc8841a546",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "db6815a533b2366ad079c1715807097e5a3b7c71",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1526g7ybbd0l31bvqdpbarscjsnp1rajfnb9bwyjy8wq1p4q1pcp",
-    "tree": "7d580e60281c9d472304fc597adb62cd306a5e2b",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9"
   },
   "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493705,
     "groups": [
       "arm",
       "linux",
       "pdk"
     ],
-    "rev": "447ea84869c3301f0349373ab796bd7a9da6f0b4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3e07eccae3bfab647f14716dfac5bf0c48f6f127",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0ag3hyvwi9sr0z95v09iwnx6n8wccxsga8z0gwgm286i0q5m4971",
-    "tree": "9959a53ab082bef137916638c48c9871c5d82cfd",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9"
   },
   "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586494587,
     "groups": [
       "arm",
       "linux",
       "pdk"
     ],
-    "rev": "f49cb84b9e26bd9b5a26f85992d895503d2bb369",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "094c5605329d86b143b799438e81203f8288c9d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1am7mjlf4vsybkzgvhhiak6j00awykncg0137wqagshyz5b0sp2h",
-    "tree": "91c70ff36200356813e0992c39b8b0d47d85aa0b",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9"
   },
   "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
-    "dateTime": 1618628955,
+    "dateTime": 1618517370,
     "groups": [
       "linux",
       "pdk"
     ],
-    "rev": "a9feb07b215598ce412fb7ac8cb614d177862fe6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4dd8082a5bad9bd52a8615ba2673c0cb101c8018",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bccbfl7imas5i47cnj5ms3lvsqkhp4nx37nbips3ia7d6fskjcs",
-    "tree": "72fab28769307d4c47d929b8b44554e817a14399",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
   },
   "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "dateTime": 1612560992,
     "groups": [
       "pdk-fs"
     ],
-    "rev": "6eebe3e643d899e0513a4a2e848a34dfa2759d13",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "45c2d2c74d21dc0746f6742abb3b22a070e3a063",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1a0ls85jsic0xiyifqaxsp15s046j3a28p8c5mih8ya0hbw80x7l",
-    "tree": "3edbb820ef657807d1ebdabdabd1f9017984632c",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
   },
   "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586494589,
     "groups": [
       "linux",
       "pdk",
       "x86"
     ],
-    "rev": "c0e01629ef893e0a7e03fcf9656162985b62de3a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b13fcbff4ae2c4f1b48d57d4c3958b3f0666f0a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0sbw4b8f21cmhxnx6ad5ia5jz1fhv7834m8xskaw4ik5dxrarm11",
-    "tree": "2b97eaece1d75e3722eb2b0f161d8defbd6c9aa3",
     "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9"
   },
   "prebuilts/gdb/darwin-x86": {
+    "dateTime": 1575581434,
     "groups": [
       "darwin",
       "pdk"
     ],
-    "rev": "cefd9181c12cdbb03c3b9bf99e85c9ccf4bb7bf6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b27d876221d012f1fe20590b7ea7eace5849dd3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gs89dnw1xkpb94lism8s8arhlkyq52h7w1v530a3zdj656h7xrv",
-    "tree": "b6c099af326581bc7d3297526b929a833744978e",
     "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
   },
   "prebuilts/gdb/linux-x86": {
+    "dateTime": 1575587382,
     "groups": [
       "linux",
       "pdk"
     ],
-    "rev": "af9552e51488502a77bae885d868198178b7c36b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3fde237888fbbd16431d288b891f40065eb710d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v8y9rdivi8ydrbcvxrkdlzc8snjpdjwgzra2s7qrjpd2qg4k4k2",
-    "tree": "139179852e0d524d29954c4d8ef02f5b52af88cf",
     "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
   },
   "prebuilts/go/darwin-x86": {
+    "dateTime": 1614014454,
     "groups": [
       "darwin",
       "pdk",
       "tradefed"
     ],
-    "rev": "99470157c5484c399efc8cde678024d54489a0a4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a92c322627f3339dcff095ea378358440f88f989",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16hxbnamn9cayw4fv940m22k6k3yz4m9nf3liy89z7bwl008s2yk",
-    "tree": "c077aa098d0282c797bbaa6f2f566c8dd6248c36",
     "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
   },
   "prebuilts/go/linux-x86": {
+    "dateTime": 1614014463,
     "groups": [
       "linux",
       "pdk",
       "tradefed"
     ],
-    "rev": "51778c4709054cf79cccd30b901dbe7d0f913342",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "da07b89b9e625ce67679b829b29966b2ea4f054d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07dv2mwbxazin9kf32fv6s30ac28q4khswfavql8d78zcmacgw03",
-    "tree": "a82013fa28ddc98b2d8b9471ad4e9d104d5e0cbd",
     "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
   },
   "prebuilts/gradle-plugin": {
-    "dateTime": 1618024149,
+    "dateTime": 1617920158,
     "groups": [
       "pdk",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "26d45cff5b022c500ea853661129e95f245eec82",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1c152ffc3a17b98d4d494cf329eef036dddcd84f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1sap095xg08fz10f6rxhnnd0c5d2xlld1zphp41hbdga5fhsn8gb",
-    "tree": "453be5b8e8d6183347c17de91bf277729136d44f",
     "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
   },
   "prebuilts/jdk/jdk11": {
+    "dateTime": 1615410185,
     "groups": [
       "pdk"
     ],
-    "rev": "c2ed46a23b127943f0b2ee59b28934f67fa65c8e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8cfff489f1170149365ec6f472733b840239d076",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03wsqba6nzghhrqsvsi33rfjh8hdzx98vjkx2as0l601l21cks8n",
-    "tree": "c9976c54131d897d9bbe1c78f537e2e625199e2b",
     "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk11"
   },
   "prebuilts/jdk/jdk8": {
+    "dateTime": 1551002778,
     "groups": [
       "pdk"
     ],
-    "rev": "c366547f4eeca115e6bb3f2bf15579e8839d76e1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "28d9bf8fd5eff0a09ef6851a29a2aa3040889679",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
-    "tree": "01bd432e31d7cf56674aa9b4f2b00ed315386305",
     "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
   },
   "prebuilts/jdk/jdk9": {
+    "dateTime": 1600160960,
     "groups": [
       "pdk"
     ],
-    "rev": "2f3fe1655247dd87e8629bd9576fca44319225f0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "da4547fea61530f79f639e16349e355bc7b26f91",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0f7b8cydz6j6pvgxln6g0dp62qz0g1768zszdiwswk8zcvzk80l0",
-    "tree": "d8c2bfea4bba77fa788977d9afd7bd61d9cd1a04",
     "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
   },
   "prebuilts/ktlint": {
+    "dateTime": 1586494587,
     "groups": [
       "pdk"
     ],
-    "rev": "1154cd9bf6b192a03bebba6002d381ec2d4585c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d368445cb3bfcd8d6943e4b5a40f76cf1ec1694e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11rsh1vvx4k2wyn6cmhq7s5inrg0nrvavvdcx3jpkrvdh3lr1laj",
-    "tree": "00750c90962b670ccafd883daf23c003f95f1850",
     "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
   },
   "prebuilts/manifest-merger": {
+    "dateTime": 1613841783,
     "groups": [
       "pdk"
     ],
-    "rev": "dbd288823eb96ed0620747b8f8b788862a307c19",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "20614295c47346340ad04c63318fdbbac70ea75a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0agc0j0mvr9fbi72x9dbf4dwsf9y8k4sniajzmdnkpyy5jlixd7d",
-    "tree": "9540763a308d33806006c230406ecf422f346b50",
     "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
   },
   "prebuilts/maven_repo/android": {
+    "dateTime": 1572476701,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "430c754259134b04a740bb9a316bcf016c3a2263",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b1ee646897c2d98222b3489e57ae8466780adf1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
-    "tree": "0832b1592aa8200e0d8b30639bfea5813030a20d",
     "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
   },
   "prebuilts/maven_repo/bumptech": {
+    "dateTime": 1613841787,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "cb9d528397068abce5e4a14be01ddc404cc8d5ce",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6323cfeec6d18990845b3fbd54273b13043373ed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03wzcxnixq9gfzciy09qjxw97d46zdhzihgx3g5lqv6403il1lf1",
-    "tree": "c0ad45b1cff11a10ebe49f329c81247b8d880514",
     "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
   },
   "prebuilts/misc": {
-    "dateTime": 1626311374,
+    "dateTime": 1628890118,
     "groups": [
       "pdk"
     ],
-    "rev": "715379a2624ebd15444855f77c251a6b937a3db4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3d4a4b90da0962e094ba9ce2beaef18afe39da87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1l0kg1lc81hfd890k5pba2ipbb1sjm1g62nrb1899xmd2zd6hl9z",
-    "tree": "4bf25fdca0b59d32f6ad186af971f0a0819b8fc0",
     "url": "https://android.googlesource.com/platform/prebuilts/misc"
   },
   "prebuilts/module_sdk/Connectivity": {
-    "dateTime": 1634163275,
+    "dateTime": 1634173787,
     "groups": [
       "pdk"
     ],
-    "rev": "7a57a7ffe545540355f8a2bb92afe02300889abb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "86f52fbc7f1f5e707f836601bb216fd0a66119d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wlblay3x1ichlbd3vd0vjfihvnkm7dfzhh8vih645f4837rpvmk",
-    "tree": "38e537b07b706a8c36d998cc480af6e5474ee898",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Connectivity"
   },
   "prebuilts/module_sdk/IPsec": {
-    "dateTime": 1634163268,
+    "dateTime": 1634173787,
     "groups": [
       "pdk"
     ],
-    "rev": "c9dd13598d1f7444aafdcf19b342269d01ff6099",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7b3a8e75e8657600aa46d9182ed15b50b6f526f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zkdxzm1m0c023hp95pzfzx5mdg6f05p09wivsi0c2x4z966gp1p",
-    "tree": "215d8450dc2a9636627818c93d7059cd92b53411",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/IPsec"
   },
   "prebuilts/module_sdk/Media": {
-    "dateTime": 1629162738,
+    "dateTime": 1629124011,
     "groups": [
       "pdk"
     ],
-    "rev": "c2f159c85bc8aa987e9cdba503e4a8fe62c9f99d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "105d58a2efeccbf8129fa8866dd426a408853a73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0fjxn8157kmafhizglaacknyi2ddalic2agi1plwmilm2s30p16x",
-    "tree": "d9e378701d361105db8793365e66d81470a72224",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Media"
   },
   "prebuilts/module_sdk/MediaProvider": {
-    "dateTime": 1634163274,
+    "dateTime": 1634173788,
     "groups": [
       "pdk"
     ],
-    "rev": "76ef0aa040c4ca9a0103245174f9fb42399911f2",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0b5c660225989f42f4031fd25d808229d78a5051",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1a919bdsm1vlb7imdsdbpzf2wxzk0xmfiqzvmcp4lr9g493ipq2f",
-    "tree": "5843d931395cf7a3a05359af7d16dc4d5264b51d",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/MediaProvider"
   },
   "prebuilts/module_sdk/Permission": {
-    "dateTime": 1634163266,
+    "dateTime": 1634173788,
     "groups": [
       "pdk"
     ],
-    "rev": "c9541f6068405bafa2b0f14d3bc02949e6e66966",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fbd096f34af36b1a9e7732c3f9a61b931874f0de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0g41b6w6mxvv34wcxycfmwpzrpqf2lxhhkkfipyjp1p1clbcm198",
-    "tree": "b86bf4c83f00eebffff882dcb6f3602ac89a3cb0",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Permission"
   },
   "prebuilts/module_sdk/Scheduling": {
-    "dateTime": 1634163264,
+    "dateTime": 1634173788,
     "groups": [
       "pdk"
     ],
-    "rev": "56bf9f1569012f543a2dc3a355c370ed15dda327",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "346bfee46208f1b520ce70aa3bd79a06c7a775c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "15m40phmcmybqnwvk12w3lvkd3ljlr5zbp3lqyjy8ssv5h7yr1fi",
-    "tree": "ecfe6e9c6aad2cb0baaf2461ece94566f7e0360a",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Scheduling"
   },
   "prebuilts/module_sdk/SdkExtensions": {
-    "dateTime": 1634163267,
+    "dateTime": 1634173788,
     "groups": [
       "pdk"
     ],
-    "rev": "4d1e3523f419be33fedc840e4d5aff9b3ed49e6e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c6a3dc344d17bc21dc3fc84f78cc849c2ca6dc56",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "193r60ly9ka9pgzy69zldx6ndjwh1fmcs6rsjgl3217hx5xw3r0r",
-    "tree": "6a0c3bbbceed175a98314e44c1b99e072a723608",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/SdkExtensions"
   },
   "prebuilts/module_sdk/StatsD": {
-    "dateTime": 1634163276,
+    "dateTime": 1634173788,
     "groups": [
       "pdk"
     ],
-    "rev": "bb753a4eb6836d132e72939bc5ca47c625a027cd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ac6a34ac5e654fd97fdf158416c6edf6f57d00ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11qf23h9125spm855byd6rlmik68x29w61hms9g8k4jln91r995f",
-    "tree": "35f15fbd948670c6f04a700a4edfb93a70840dd5",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/StatsD"
   },
   "prebuilts/module_sdk/Wifi": {
-    "dateTime": 1634163273,
+    "dateTime": 1634173789,
     "groups": [
       "pdk"
     ],
-    "rev": "3c0af209b253ae62e60545886f90182112b9f450",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "355f0b33b3759e45929ff49b17af6940fcd348f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1vs3ai0jkvv7nw1as6ywn12wip724zinrsa10hg6kfh5zirf8lwc",
-    "tree": "c8139a30daa82c6033f8da1216f12e6b0842ded3",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Wifi"
   },
   "prebuilts/module_sdk/art": {
-    "dateTime": 1634163258,
+    "dateTime": 1634173786,
     "groups": [
       "pdk"
     ],
-    "rev": "55ed0e4cd070fe81b21c9860ed593dcb4f54c0d8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a0a33c7d882136bdada08d98f901895a73e01571",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0iggz97jf5mawbx78lfyypzgbfm48a9jiblgybhkwp9fnqjamspj",
-    "tree": "460f52fc8c59d9317addb61a9f6174cc1a6c712c",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/art"
   },
   "prebuilts/module_sdk/conscrypt": {
-    "dateTime": 1634163269,
+    "dateTime": 1634173786,
     "groups": [
       "pdk"
     ],
-    "rev": "8bca1f8d0e0976d45ae205c825134d2a6f286916",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9081b1411993498aac11f78ac174c28f6abf5e42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mqhl63iv07dhla56w0i00qx86b01qyih84niiyipa8idm7z8khm",
-    "tree": "6bf189f86a0d56e7a9ac20ed7536cad740bd95fb",
     "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/conscrypt"
   },
   "prebuilts/ndk": {
-    "dateTime": 1617419317,
+    "dateTime": 1617325083,
     "groups": [
       "pdk"
     ],
-    "rev": "7d9f7d6fd4191808d0f05aa0a131cab3f711af1c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "87f284319f684d60541ab86ea9a75a1bc518725a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18g58y7abpi4kgc8zphv08yg89pcs6wazzm54v89lrbry6shhdp5",
-    "tree": "538f2862490075cda112e6e17786a116eed28768",
     "url": "https://android.googlesource.com/platform/prebuilts/ndk"
   },
   "prebuilts/python/darwin-x86/2.7.5": {
+    "dateTime": 1446753806,
     "groups": [
       "darwin",
       "pdk",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "4a5ea629546bba91748630de117b203b07f8b2de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "de0ef2c8dcb0389d80436a334bb1fcd0e24e0472",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
-    "tree": "c0ce8f39fe73178fd646b5c15f4f349f94ec7d96",
     "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
   },
   "prebuilts/python/linux-x86/2.7.5": {
+    "dateTime": 1551111763,
     "groups": [
       "linux",
       "pdk",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "d58e94926f58aa37c5eb92d3e247f69bb6884ab6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "67149b36e91b1e2b62797456fc640fc80feafc94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
-    "tree": "9fa1607f1d27e9cc931723d14fb9d7b29719e4d5",
     "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
   },
   "prebuilts/qemu-kernel": {
+    "dateTime": 1613842620,
     "groups": [
       "pdk"
     ],
-    "rev": "955da091660f8e05aaf9fd91001a6642b227ecac",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3433d798f907a2099da26c865cb32a5b60099c2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "174ffmr45kn5qkzbfc8a9irk8p2ksxzj5rylbbisswhlk7419rpq",
-    "tree": "e9b87b8ff69d452ce7a0979bfb45e96588cc3a49",
     "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
   },
   "prebuilts/r8": {
-    "dateTime": 1626138659,
+    "dateTime": 1625839157,
     "groups": [
       "pdk"
     ],
-    "rev": "21292f7810cfa1ec7b91fe74e1c9e5e305f92d0a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e77842f0b7a216ebeffbab78fcd3240f1d9a7ec8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "052xbmqp69pbl3p9q05jpnnzj7mws57rscgblmp2h55hnm6ay8fg",
-    "tree": "dafcda0444cbbfe9bfba06475c7631c3b2889fb1",
     "url": "https://android.googlesource.com/platform/prebuilts/r8"
   },
   "prebuilts/remoteexecution-client": {
-    "dateTime": 1633568997,
+    "dateTime": 1633569004,
     "groups": [
       "pdk"
     ],
-    "rev": "2508b5efd0f398d58660ce52aacae2f286b06f97",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7ccbad1aa8c87ba8b613f4e95ee33eb0ba691158",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0j1xhd15nx0bhrp03bd0sxlmqsi8dyv4scpdqqzql8c54m4av8yx",
-    "tree": "ec1612c659fe250c29c7ee0d31e1b2e6d1dd02c1",
     "url": "https://android.googlesource.com/platform/prebuilts/remoteexecution-client"
   },
   "prebuilts/runtime": {
-    "dateTime": 1624929241,
+    "dateTime": 1624546103,
     "groups": [
       "pdk"
     ],
-    "rev": "b73340534f4127397c63076160d65118862d525e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3d95e012199f2b722d45a83109bb2f0680a245a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0yyl276b039qmbz3b7mqnl4h3mqk5ggv0yq07k2hli9v09w55dha",
-    "tree": "c5b8582a633b4b0a9bfad6d1f1f7643e17a6b538",
     "url": "https://android.googlesource.com/platform/prebuilts/runtime"
   },
   "prebuilts/rust": {
-    "dateTime": 1619658639,
+    "dateTime": 1619640274,
     "groups": [
       "pdk"
     ],
-    "rev": "08d1946d0227392d943de2e9d1c6f738887ac22c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9c14f883d70057e0411393dc03aa3b10833aed9f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0k1vw6hallcd3fhl6scgq89qqpi198pxwd6vd4r1rlklpm4p2xyj",
-    "tree": "8a6abf62755a36c75c6131c7fdc4e7f5fb94e164",
     "url": "https://android.googlesource.com/platform/prebuilts/rust"
   },
   "prebuilts/sdk": {
-    "dateTime": 1628910569,
+    "dateTime": 1628868096,
     "groups": [
       "pdk"
     ],
-    "rev": "09b615ff424fbed5fc1b2cc6201e7f3935939be1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "275722017d043ffd4477a6c478a56260bb31132d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1139ri4kkbd9wnih9w78gswy5qavymwjr8ay04cj924axfs2z8s7",
-    "tree": "37e9e4466a25217afc1990b684e2832658d3a453",
     "url": "https://android.googlesource.com/platform/prebuilts/sdk"
   },
   "prebuilts/tools": {
+    "dateTime": 1626462024,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "20491ae7d6dd21c1bca8b0724b7d0f5bb0d2dc46",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0f8077c0a92b916846e3e16444b7b8625f3534c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0gqaix187cmkrnk0ydd2hz5mph334zi164jlikhn19bkgw8g75yl",
-    "tree": "9836f9237d776cd78f621963189a1f8efc0eade2",
     "url": "https://android.googlesource.com/platform/prebuilts/tools"
   },
   "prebuilts/vndk/v28": {
+    "dateTime": 1614588566,
     "groups": [
       "pdk"
     ],
-    "rev": "58b55fe1ca2784dd618556489dd07fc834a4cf37",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1ec5a6d097238b3cfcddd0431f49eab07a494535",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "18yxf5lk692292w99xijjyr545r928lyfxclkg1hpdvf5vk04a9g",
-    "tree": "c0115a8b4a21d204ab8de36b503435fe4307467c",
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
   },
   "prebuilts/vndk/v29": {
+    "dateTime": 1614588566,
     "groups": [
       "pdk"
     ],
-    "rev": "38480746f23d683dee10253128c4c8ffae35ec9f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0801f7c332aa60409cb66baca485f368fe9d035c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wl0lsbf5hr6kignm6fgb9mc0p7icyzz7yd8yl7h6ngqajdzh5lb",
-    "tree": "ed7fe7a575a4a60c9b31eedd3dbb9db6596d42e3",
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v29"
   },
   "prebuilts/vndk/v30": {
+    "dateTime": 1613992393,
     "groups": [
       "pdk"
     ],
-    "rev": "9ef6fa73d73468647974eecda40e3a9fd7f74713",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fa3b4b5ef72e407eebb7e97a173b115570c5858f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0c1ni4axai052b98pp6d6pyl0pshbz9sczcm6y0mlfhgvmlwk7wp",
-    "tree": "8d9573e4b9c0f52b2b7cfc5bb70d3a9508c683f7",
     "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
   },
   "sdk": {
+    "dateTime": 1613437328,
     "groups": [
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "7d13709c6eac1c6c1cbcce16bba1b12a9468efdf",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9f89c6e6af4785195f5ef701dd640afe0e574146",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1x4v7n0i9pcz91q5ii4lpwrmqr9v0hpwjv86mcqjzjw22rzi5rxa",
-    "tree": "9788658fa18e8e9e854407f7da7b1793ac9bb04e",
     "url": "https://android.googlesource.com/platform/sdk"
   },
   "system/apex": {
-    "dateTime": 1627607379,
+    "dateTime": 1627579554,
     "groups": [
       "pdk"
     ],
-    "rev": "33decfd4950d5203aa6c34789853d7c78b1f0909",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b169ab19adf118acb6594098288081ebb926ba5c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hilaxanwsiqaq95i7qsdrirx2nxlgpisxb8djfvf6vkc062n3yy",
-    "tree": "6a51d258229a5b7a74ad1d7026804d6eb6e486ae",
     "url": "https://android.googlesource.com/platform/system/apex"
   },
   "system/bpf": {
+    "dateTime": 1625568612,
     "groups": [
       "pdk"
     ],
-    "rev": "baabf97b53159adf71654aaa4d4e2e5852c97124",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e0162ba51ad3f611cde583e0d9d5820f69a551bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qp4zl4hzq1xdm7j6qd44bx2fb821j746vyxz9296zi6nwqaj0hf",
-    "tree": "b4608f90b54a697c11c980d1bc849e4e5e03e7f8",
     "url": "https://android.googlesource.com/platform/system/bpf"
   },
   "system/bpfprogs": {
+    "dateTime": 1613835230,
     "groups": [
       "pdk"
     ],
-    "rev": "b578c4143df6f056a7409ab8a70ceb9af6c49eb9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1ba8d8a39ddc308778bcb9809079616de65dfe29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "059l6k1y7jpjbkfamq83pjj8nzmghc5pqkz1p53pn556w1hr34jk",
-    "tree": "af8636160b4f77fd9bc488913a3ddcd9b891fc0b",
     "url": "https://android.googlesource.com/platform/system/bpfprogs"
   },
   "system/bt": {
-    "dateTime": 1636812491,
+    "dateTime": 1640531104,
     "groups": [
       "pdk"
     ],
-    "rev": "b1fdc247fe5e975bcade8eafe08f34c25591ea11",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
-    "sha256": "1784nbhk6chyyfykqwbnhhr6i9klxi8cxi3rqiqpfcpihryx8ghi",
-    "tree": "ced48a181be6bce8638be0b2948a472166a7ea0f",
+    "rev": "8d5bf6729984ca77b4fc72a60a558e9af51809e7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0h723is2hbrxpdsyi6hskwqrkrrz9z6f9vnxrqhp2gl9vs77hr5a",
     "url": "https://android.googlesource.com/platform/system/bt"
   },
   "system/ca-certificates": {
-    "dateTime": 1613866188,
+    "dateTime": 1613828482,
     "groups": [
       "pdk"
     ],
-    "rev": "c36c4eb50c4063a07208efc998c33d35bcabcda0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "544fecca995685415282f480ef86fb613803866f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1rz4x4mrsv112csx3bykgi78rrf1sc4g8p5yvma2yyrcn7j0vxq2",
-    "tree": "4cae0e9143eebac20950458b1d6b4446b454c4f6",
     "url": "https://android.googlesource.com/platform/system/ca-certificates"
   },
   "system/chre": {
-    "dateTime": 1630372155,
+    "dateTime": 1630355989,
     "groups": [
       "pdk"
     ],
-    "rev": "1bae13203d6424eba6bd0a8d98c4cddec7d3e66c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7fb5286e9da8f48002b0d401fce29c964ea93734",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07karyzhkmbfpwx3sf24wzq51c7v47ikq228f7fg9r8jdfgb9qy3",
-    "tree": "78156138e389fa417a6d5d763b6a52cecea48d1e",
     "url": "https://android.googlesource.com/platform/system/chre"
   },
   "system/connectivity/wificond": {
-    "dateTime": 1628910574,
+    "dateTime": 1628804096,
     "groups": [
       "pdk"
     ],
-    "rev": "5d3288393a015556261e68b4e0a7e68b2cbdf5c1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e02ac2f254cab370bfe2282cc2352cdacd9dcf76",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0lymnj2i95lcb3xmlawm1gpvrbr82y3kgggj1a71vcn4776bs7j3",
-    "tree": "db48a63437682dab654b0be0f3e13b73d9faf981",
     "url": "https://android.googlesource.com/platform/system/connectivity/wificond"
   },
   "system/core": {
@@ -10416,302 +9963,279 @@
     "groups": [
       "pdk"
     ],
-    "rev": "d152467c6ccc90016f9b9a16202ef9eb7ff22bc4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8e6c56e146dd67af66d2805e4c7b107d11e30261",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pvlwnw02yv01ag78y1jj57pj4dvkkc1gqp94h2bmldphpzlasg8",
-    "tree": "e2f4d4cf6b34304ceabee3fdc0d29190830c7c1e",
     "url": "https://android.googlesource.com/platform/system/core"
   },
   "system/extras": {
-    "dateTime": 1627772973,
+    "dateTime": 1628888012,
     "groups": [
       "pdk"
     ],
-    "rev": "11323cff6f12270a43bc51bfda0e81abd1fca8c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "1768bd3228c8c9980c76a6a697e86decbb69a457",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1nbb1gpdxpm2dhf52p59f284ss9b9vcb1qpax14p4s89s7cr1had",
-    "tree": "dd72a84514306c5cc0c9025a1fb9e9e3976ced32",
     "url": "https://android.googlesource.com/platform/system/extras"
   },
   "system/gatekeeper": {
+    "dateTime": 1613504471,
     "groups": [
       "pdk"
     ],
-    "rev": "7afbae127ece6fbd285e235e2eeef5033ef1758a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b8569c546ffa872bdba69bcfc49011c6ee70233a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wxbr2nrgv2w9zwy8vf7pi4vnjcs6jrhg7p0psp36iqqpj46ncpc",
-    "tree": "f09f14760e7ccfc14047d326269ebafcfcfd5498",
     "url": "https://android.googlesource.com/platform/system/gatekeeper"
   },
   "system/gsid": {
-    "dateTime": 1625707030,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "e5a945f468ab73f2fc458470953cf3f2307a1912",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "09ecf955847fd6dff265121558eae3dc23785fbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13xicpg8wk1y021a3lxlq49vr51v2nicfwn3zavvz0xgs065ygzs",
-    "tree": "d57fde808eb29d5bc6d96fa2497d95e4257729ba",
     "url": "https://android.googlesource.com/platform/system/gsid"
   },
   "system/hardware/interfaces": {
-    "dateTime": 1629248968,
+    "dateTime": 1629224552,
     "groups": [
       "pdk"
     ],
-    "rev": "d1b996099ad9587ee292065b03319493edf6cb5f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b32719e7dc910e464b1e5e8b6180b07391d588e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1wazlzks5irs3lx3glj150xx284gm8611x58vn1hyv0qbp2hzj85",
-    "tree": "4ebda0556353a5f6e91bf11e3c1ad0a363cd4c19",
     "url": "https://android.googlesource.com/platform/system/hardware/interfaces"
   },
   "system/hwservicemanager": {
-    "dateTime": 1622862599,
+    "dateTime": 1622819569,
     "groups": [
       "pdk"
     ],
-    "rev": "d18fbbf1bf049d36ee8b9b1f034533d05a6113f7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b5a78106f7128d9a63dd6a75919db7e64ecaae09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03sg3s64q6iik4i0b8l57dz5m1xxk9dfyqirz72y61ycl4hnagmr",
-    "tree": "18ce4c5ddff1e76c4dbc8ac93c4560ed46f62f61",
     "url": "https://android.googlesource.com/platform/system/hwservicemanager"
   },
   "system/incremental_delivery": {
-    "dateTime": 1631664823,
+    "dateTime": 1631299265,
     "groups": [
       "pdk"
     ],
-    "rev": "e33d99e9610cf7c391980d2e3028413cc40c1982",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "924af62dc94b7c37bd653158b69ddc9f648beda7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qlkk5jyqyqs69h5pl0hi53qfh8f8z9f7vllrrd4vbckl1bp57gn",
-    "tree": "7664caf564aa324a52b94d5de25335f279188b1e",
     "url": "https://android.googlesource.com/platform/system/incremental_delivery"
   },
   "system/iorap": {
-    "dateTime": 1626225032,
+    "dateTime": 1626160706,
     "groups": [
       "pdk"
     ],
-    "rev": "7314db276fde9092905f9fe39d50bed34e022763",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7fd8ba7d56dc6a860a273c722750e97e5076c84c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0q3ip59rm8b3x3ralfn414bc0q51p42hxk2n2mr9pdd7d3vhmbpb",
-    "tree": "39e58cfcefd023cd928cb339131a7ad85211f976",
     "url": "https://android.googlesource.com/platform/system/iorap"
   },
   "system/keymaster": {
-    "dateTime": 1628730606,
+    "dateTime": 1628888009,
     "groups": [
       "pdk"
     ],
-    "rev": "8a034d3ae246054f89e94fb04cd172d682d2aa06",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6304ff244cfd309446ed4006ca9b58a553adcb87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xfnh774f4s4rkyhpjm2y9lrzha5rp4scbym25jqnlzxamzcnv8l",
-    "tree": "8536a59c8818cf5eb9ca12d5e56af3783f865469",
     "url": "https://android.googlesource.com/platform/system/keymaster"
   },
   "system/libartpalette": {
-    "dateTime": 1623287611,
+    "dateTime": 1623150906,
     "groups": [
       "pdk"
     ],
-    "rev": "b6a5f37c6da6a3e73e7dca1759f737a0f169416f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "25bbba2a96e48b74011446bea1be929048f3360f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05l8n7nm3xzcxf8fi5mzbq62hxkgi3wk2sppi416jyfbznvs3h8p",
-    "tree": "0702da7c7adec09bd779fd13ed6d23cf1e1d7dfd",
     "url": "https://android.googlesource.com/platform/system/libartpalette"
   },
   "system/libbase": {
-    "dateTime": 1619745037,
+    "dateTime": 1619677419,
     "groups": [
       "pdk"
     ],
-    "rev": "167c51e5789d4ec2c05db6937b92d127c4940185",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b82afe96f4e63bff98c9cfc4417b3996c1b23a51",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0h5aw1r81ikh1y5723m8nzdl3z6f3fq7krrzjfrv80x8zwvgyml2",
-    "tree": "29b348c25163f9cf2f8941f2351ac0e7e01b35a6",
     "url": "https://android.googlesource.com/platform/system/libbase"
   },
   "system/libfmq": {
-    "dateTime": 1622077835,
+    "dateTime": 1621568409,
     "groups": [
       "pdk"
     ],
-    "rev": "74d631643279fd8ef147cecb450ad09196e9c627",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8726cca04217318c9155ba528822af6e2ddd75de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gnrsz7k2ish726cdcysa2z0ai6npxnx9kpgpq65crakcnswkdgd",
-    "tree": "30ce55f1cf96001129b8c7b187d6beff23ffdc37",
     "url": "https://android.googlesource.com/platform/system/libfmq"
   },
   "system/libhidl": {
+    "dateTime": 1624929280,
     "groups": [
       "pdk"
     ],
-    "rev": "6aee0e6c0103f60cc634ff5a0245c45cd9a2bef9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d3e195932b70fb6a39118acd8d287f92535fdccd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1y1sw5p7dlal4b74r00jp6p0y5mjpablpli42cdcq5byhayz08r8",
-    "tree": "8a5d133f1c9c6dc833bfde097a8a033bc25835e0",
     "url": "https://android.googlesource.com/platform/system/libhidl"
   },
   "system/libhwbinder": {
-    "dateTime": 1622077835,
+    "dateTime": 1621981060,
     "groups": [
       "pdk"
     ],
-    "rev": "74b03b0f7dd73e723253e20eaee86194a0f7d79d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a20d59706f59855a05843793f5142763da6e2d1d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "09nwism5hs2514pqccyh5nk558z2qrvrh2fhmqmfv3pm9sdd6bwj",
-    "tree": "29dcb15301360eca07d95185d057e07c80b70a11",
     "url": "https://android.googlesource.com/platform/system/libhwbinder"
   },
   "system/libprocinfo": {
-    "dateTime": 1625707040,
+    "dateTime": 1625122240,
     "groups": [
       "pdk"
     ],
-    "rev": "7c92e5ff0ad110bcd3226212ff514e1939d6e202",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0f38fcb840d63565e765d09103fda7b34e2590fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "015y2lxpg1w3ijvlfridfwnbjvqd6gcsgya6fri8xn651m5bhdlz",
-    "tree": "6b2000fa0bafa5a0e27b839d62c2e29c63428375",
     "url": "https://android.googlesource.com/platform/system/libprocinfo"
   },
   "system/libsysprop": {
-    "dateTime": 1618880989,
+    "dateTime": 1618498073,
     "groups": [
       "pdk"
     ],
-    "rev": "5b1e840e9c5b4021b139dfb90b6951c6963eeecb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "26c042b8ef1888a0910a0c3709e69c490c9c9eab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0m6nk4r3rp267mlc7pi9cq19a2npb836cf5kv8k1xza1iqiaq0bj",
-    "tree": "455f8bca670e82be8b576f961d50856e1619c6bc",
     "url": "https://android.googlesource.com/platform/system/libsysprop"
   },
   "system/libufdt": {
-    "dateTime": 1620263814,
+    "dateTime": 1620239508,
     "groups": [
       "pdk"
     ],
-    "rev": "aa61c0b1c08aa439d28a27f67ee914895cad7fa1",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ca9b2960c365944ec6f6285800d3446ffee34d41",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0lx95r91jpfcqhp9d91yvn6z5rdym4s4z2l3v2sa84dqpb72frpp",
-    "tree": "9b5717374b72030f155715d382d9d792f3fea328",
     "url": "https://android.googlesource.com/platform/system/libufdt"
   },
   "system/libvintf": {
-    "dateTime": 1620868258,
+    "dateTime": 1620777951,
     "groups": [
       "pdk"
     ],
-    "rev": "000d2090ad3d3ab6298bf449a5b222f7f2f93475",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9411ec2286194c946c94512b3deb70799ddbe48a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11rp914fxzapbdksjn6clmj40n9gmybgdqnngcppyqk4gs97bwz3",
-    "tree": "2a8a4ca15d04c161cca1356757df22225524318b",
     "url": "https://android.googlesource.com/platform/system/libvintf"
   },
   "system/libziparchive": {
-    "dateTime": 1619140202,
+    "dateTime": 1619098926,
     "groups": [
       "pdk"
     ],
-    "rev": "2883963d175f6dcb3b8d1efcc67cfd968cf749c4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "763f2f13e6e5778c08e91489be287a50c5ed5131",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0xhrhxj1f2cbknk5dgld8v9rhrzk22p2q6dzdhnlvyqgqzyf4rg0",
-    "tree": "3d64675ee697db52e2e95ccbfeab956f9ca43c88",
     "url": "https://android.googlesource.com/platform/system/libziparchive"
   },
   "system/linkerconfig": {
-    "dateTime": 1633050543,
+    "dateTime": 1633072833,
     "groups": [
       "pdk"
     ],
-    "rev": "8ef0e6ae31be0c45c750527d5da552ee0db82297",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "108dc596bf49188b7e61840a5fa243862de52b35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0vai4jakxwblgrh33siaz6zhf77mr2nwk4f880jk64fd5pw1rg13",
-    "tree": "c64597ef1468335b8f91e086878364f82e1a9df1",
     "url": "https://android.googlesource.com/platform/system/linkerconfig"
   },
   "system/logging": {
-    "dateTime": 1628730611,
+    "dateTime": 1628712187,
     "groups": [
       "pdk"
     ],
-    "rev": "27b124b6e05c9f23e12db21b04b82112589b6752",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dd74a68b5eda048b43c59a814fde1f8631c7c3db",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v7nk3yyllk4ah448kkjil1idv017h1zmi2qslp5zl19c9k1n495",
-    "tree": "c1afcf2b5a75b99df828428040d10ec12bbf8f52",
     "url": "https://android.googlesource.com/platform/system/logging"
   },
   "system/media": {
-    "dateTime": 1632539359,
+    "dateTime": 1632493700,
     "groups": [
       "pdk"
     ],
-    "rev": "73850ad13fe239fe1c523348f6b168052d4ffd8d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "37aac29475a6d489c38530bfb274f403c6c72ada",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0blpvzxdrcav3hrq5nb1yx3faj06f7byhjp6y0ipw2kabsbw361v",
-    "tree": "144f31bc07dbc2044155e8bd7e907173c6e49aec",
     "url": "https://android.googlesource.com/platform/system/media"
   },
   "system/memory/libdmabufheap": {
-    "dateTime": 1628910586,
+    "dateTime": 1628890468,
     "groups": [
       "pdk"
     ],
-    "rev": "5945a9952ca8f6dbfee8259476b4b1b7d22b5e4f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a47eaf25d3e94c4151bf02636a057b1643c51d2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "03l8sr6dmi8rnf9psclm0sg0pwqfnp7vknc6vydxgbz1gjxgdr34",
-    "tree": "f71e233c230fb661f6af0aa5c05e6760a7f243fb",
     "url": "https://android.googlesource.com/platform/system/memory/libdmabufheap"
   },
   "system/memory/libion": {
+    "dateTime": 1613829279,
     "groups": [
       "pdk"
     ],
-    "rev": "af4e3574ac539f5dc3271aca7b744312ee099386",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "c658a782051844a7743de960e0b6a2c7041c3631",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0jmb5lh6hgyzpsp711dd5igns56xls0crb2aqnzwqfyvn6dinbz3",
-    "tree": "09ec1548c76cf3ca467696310ac43e3930197ad7",
     "url": "https://android.googlesource.com/platform/system/memory/libion"
   },
   "system/memory/libmeminfo": {
-    "dateTime": 1626397805,
+    "dateTime": 1626297332,
     "groups": [
       "pdk"
     ],
-    "rev": "e3c93f660c5c8124865e87f433fe1fc9de93feb7",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "804ee893ce53ba15af995dea4a68b5a04ec36b15",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hxknnvj22ap00v3nsh6867vi1bcb6dpsm90n223c7z0247kb5az",
-    "tree": "79dbc9c04947170f5be6e88ff03d9f43119c884e",
     "url": "https://android.googlesource.com/platform/system/memory/libmeminfo"
   },
   "system/memory/libmemtrack": {
+    "dateTime": 1617815252,
     "groups": [
       "pdk"
     ],
-    "rev": "3ab5235ab45522684710c91721e964fb7fa612d8",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8e0f980e3dac5fcc5688b3f36eeb0607ef73cbd3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1v1zrkh94ynxgsi30s5i1ivahdabv10clysam1v1c762rczsgr8v",
-    "tree": "2812155ed23ea13706cac83e2f1290b75391bfc3",
     "url": "https://android.googlesource.com/platform/system/memory/libmemtrack"
   },
   "system/memory/libmemunreachable": {
+    "dateTime": 1623285996,
     "groups": [
       "pdk"
     ],
-    "rev": "a842e410f2e37d9d62b7825a3ae509edb9e2d027",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2b63b871b3059302e5a78766f58d1f4a5121c5a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1hg82k95l8ph8phl9n982yxy016z68m4hbwjj5sdsnmi217v2cpy",
-    "tree": "42846ff04bbdf2fd0a5b826be25d97e3c680d811",
     "url": "https://android.googlesource.com/platform/system/memory/libmemunreachable"
   },
   "system/memory/lmkd": {
-    "dateTime": 1633144188,
+    "dateTime": 1633144176,
     "groups": [
       "pdk"
     ],
-    "rev": "88886d027418f7c981d61bb7beab562fe6e45c3c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "03021f0e79176be311e64106eebf8c908343d1bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zs9110x7g59rjxrqjri4xm1s751p3yj0xq9dsbbhyg492l40wd9",
-    "tree": "62195f067757861b5be4b15d655724d26d42a5d6",
     "url": "https://android.googlesource.com/platform/system/memory/lmkd"
   },
   "system/netd": {
@@ -10719,428 +10243,404 @@
     "groups": [
       "pdk"
     ],
-    "rev": "90822ce5b11d2c16a0efca17a9ad736a66ed6f36",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b8ebcb1be89157ac56576e0369aea8dfa41c2cb2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "16ra9lzaac6rp1f2a57i6knjnrbhl226wjaf42bkdnw0zcj9gp64",
-    "tree": "7c671c07cab1211792eba3b292b33899fb1ab099",
     "url": "https://android.googlesource.com/platform/system/netd"
   },
   "system/nfc": {
-    "dateTime": 1631664754,
+    "dateTime": 1631046413,
     "groups": [
       "pdk"
     ],
-    "rev": "1021e7131b73d7a178c9fa7dacd6a9e544cd09cd",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "68de2b7edacc8bb81b8123f7be7caaae73d10f91",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0dyhv0n0a58y0mw1rxkr806dayvq444h2bm1mva79phzmb92mjsg",
-    "tree": "7c08ae8c02f7137c4af9232782614684e3609cfd",
     "url": "https://android.googlesource.com/platform/system/nfc"
   },
   "system/nvram": {
+    "dateTime": 1612561570,
     "groups": [
       "pdk"
     ],
-    "rev": "5f1822cfb9b208f2ea971a75b1b9624ccde5637b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d5cbfb622f4b2cb4e55a57e314f302862705bd09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "05xspxnd1366hmv4sjq2fmhbgjq4camppfnqpmakkydd4pw4qnn0",
-    "tree": "868282331ac5f78edf5f8e6621f41c5795b459e6",
     "url": "https://android.googlesource.com/platform/system/nvram"
   },
   "system/security": {
-    "dateTime": 1633569021,
+    "dateTime": 1633569031,
     "groups": [
       "pdk"
     ],
-    "rev": "20f2167f170bb7360d315c042e3f99296649682e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "21b26f2c4682b89c140c20c3d0670eeb45584c90",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mzimp7m7r2h5aa7dr90ba2lqg871cywqbwfx0z1ipam7pv7synq",
-    "tree": "a3cd6e40eeb957acd070251231ab07999f0f5897",
     "url": "https://android.googlesource.com/platform/system/security"
   },
   "system/sepolicy": {
-    "dateTime": 1633749002,
+    "dateTime": 1633749037,
     "groups": [
       "pdk"
     ],
-    "rev": "a1bad5f743a3989f2bad01ea00c85a8e5fd78a98",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e63819248660da224c0e643c67cda0767f5c66f5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pxxs8b4kpwl2jqr9xfpk97yx20j4slb8inw0crkjs9yvxd9a8a3",
-    "tree": "66b11822348bc99db7eae8b0c332ce77921d90b1",
     "url": "https://android.googlesource.com/platform/system/sepolicy"
   },
   "system/server_configurable_flags": {
+    "dateTime": 1613834532,
     "groups": [
       "pdk"
     ],
-    "rev": "6886d0316edb519affc45ebe7b570a6a6308e289",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cab156c6102680ff471817ff48fde13431e5d2b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1ih665qh777kw9vyz8sgsbk3nm2bnhklir7v4df25j8wdr8kw4hv",
-    "tree": "0d77aa0ab479220b8bf129f68a2cf2e8c9d9fd24",
     "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
   },
   "system/teeui": {
+    "dateTime": 1617044889,
     "groups": [
       "pdk"
     ],
-    "rev": "f24e294a23fb7a0b42a67be27940f9399216020e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "674fa5c63b51d6b5ed21f46f7159bb7657200dac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bicz4kmz79mifxfmzc2rzrgvp95zmcxm7giw8lqsigv32m55avl",
-    "tree": "2604035bdee8786a9c61f01e84a23f4614bdc0fb",
     "url": "https://android.googlesource.com/platform/system/teeui"
   },
   "system/testing/gtest_extras": {
+    "dateTime": 1613822497,
     "groups": [
       "pdk"
     ],
-    "rev": "d3b0072654227b095aa037b8346429eab0fffa3b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9758e62d2ac64617fbf4cd4fa42dc7e9a4d5adde",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v5ifyrq7wxsm0mh9843fidj4jmr2x10xqdvdwsshb1p17hxjyyp",
-    "tree": "5b82b63e08e6b34cb0895628cf81022e67a965f8",
     "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
   },
   "system/timezone": {
-    "dateTime": 1633569023,
+    "dateTime": 1633569033,
     "groups": [
       "pdk"
     ],
-    "rev": "6e4e173890ac79df33db4c3b16fc0052777b20df",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e01f7f455f680f0533f85f55806b781b73c5746b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08sn293cpbizif7ac3g77dj3dj8wpbcqxasca2xzhj0jxw3khd1c",
-    "tree": "23a77fc49f302055d819b9612450489034b05603",
     "url": "https://android.googlesource.com/platform/system/timezone"
   },
   "system/tools/aidl": {
-    "dateTime": 1633050551,
+    "dateTime": 1633072842,
     "groups": [
       "pdk"
     ],
-    "rev": "dde5212c2119718173fa4ac42f77032da94f8c96",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "89a5eb569ddc3aa755aee4d520f71b489f93dda4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13ybc6k6blaw6linb0iwfybv1np2k95l35s6hfmrlbppyhlkkrfc",
-    "tree": "9a501f24cc89133ea6082af6c53a9ebacaa2e1cb",
     "url": "https://android.googlesource.com/platform/system/tools/aidl"
   },
   "system/tools/hidl": {
-    "dateTime": 1627701006,
+    "dateTime": 1627587690,
     "groups": [
       "pdk"
     ],
-    "rev": "7be671623c5c5fa22e4fd650c0c95a5e54365bac",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "30fcc6376f5d5c4f638d211ed84bf4dbe69ad1c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "14klv5dx95fcihfck1r41bz9nxgcblf838sj62mad685pjmah7fb",
-    "tree": "665564272a2c03e0bdd2fc4732faa8f1e5864150",
     "url": "https://android.googlesource.com/platform/system/tools/hidl"
   },
   "system/tools/mkbootimg": {
-    "dateTime": 1620263825,
+    "dateTime": 1620207651,
     "groups": [
       "pdk"
     ],
-    "rev": "8d0189b20af2e9a6616f345ef0537f1cc1be7452",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "ec49060e9c4735d4793de59671be2342688186dc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1agwi6aripi1mwv9cx38q5944g7nw3kccfwa2y73n3v22vrnlw4r",
-    "tree": "dfa66c10c6783554a406c26697bed7b4c9926179",
     "url": "https://android.googlesource.com/platform/system/tools/mkbootimg"
   },
   "system/tools/sysprop": {
+    "dateTime": 1616580845,
     "groups": [
       "pdk"
     ],
-    "rev": "b9cce19118cb944e127343c1d30012295d9374ec",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2bec02c1451bd950525c520d468f11a6f6d5245c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0hvq6n3kj0lyyx782wwy32q1m24qclkmas5jdb2wy5hxcrsqvwds",
-    "tree": "1451b227eb7ae980d654e631e6fa0d63aa43df22",
     "url": "https://android.googlesource.com/platform/system/tools/sysprop"
   },
   "system/tools/xsdc": {
-    "dateTime": 1624410627,
+    "dateTime": 1623633975,
     "groups": [
       "pdk"
     ],
-    "rev": "6f5cb858098f68c8ade3ab27fad36b2633be5766",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "31b461e94d2339676173c6cebec9598079d8f992",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01kh80wg5r9b1csz23p7x0rqlpb26x5z4r4gi2y4ibisy5bva3w4",
-    "tree": "a2aff61a7fbe4235ef5c23d0465cd835e493139c",
     "url": "https://android.googlesource.com/platform/system/tools/xsdc"
   },
   "system/unwinding": {
-    "dateTime": 1633144196,
+    "dateTime": 1633144184,
     "groups": [
       "pdk"
     ],
-    "rev": "6ec2b562738b3fbd384377131284608f3284181c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "43b9ce9ca8f4a3f556efcb05405d43b9fab1c523",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0iw26p7rx6r9j11r0bvds8idpl7kw6gja4d81wyyfq2j8a2q74ys",
-    "tree": "48e0b2403de19a1475a492a80459cc9a7b14edf8",
     "url": "https://android.googlesource.com/platform/system/unwinding"
   },
   "system/update_engine": {
-    "dateTime": 1631668192,
+    "dateTime": 1631650748,
     "groups": [
       "pdk"
     ],
-    "rev": "cc5d1da10536426a79aa9de578825589b02fca04",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "dd505e4e2fc32e835746231b0b1c02729240505b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0rz4d5aqxhvcj0c748sz8dls6dicsvia6skqp4ynm523qhlhjdi6",
-    "tree": "b97130ec682e8fb5e12a4c4bffe79b72883d82ac",
     "url": "https://android.googlesource.com/platform/system/update_engine"
   },
   "system/vold": {
-    "dateTime": 1630545517,
+    "dateTime": 1630357499,
     "groups": [
       "pdk"
     ],
-    "rev": "3fc52bc25fa2b80dc763316e5e45babbcdfc2ffb",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8598a9dc13fa7ce2f1778092951172f8c8ebd987",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0p78mczcs4sdrknpckvway3jhmjmcbsls10km62ix6vjv50h7c8x",
-    "tree": "ab7ce0cea7df54eec1f789dae6c6d86fd2f57289",
     "url": "https://android.googlesource.com/platform/system/vold"
   },
   "test/app_compat/csuite": {
-    "dateTime": 1620349795,
+    "dateTime": 1620253428,
     "groups": [],
-    "rev": "e18e2f3e2d16c7c0f4a4503eb31462ba4fd82280",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "f71ad3e931337de7a7b3ed5332a45dbefdf74962",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "11h6hldlwrcfk314wn77a218384yh4kz4xz3nzvy3yqm99ywhz8n",
-    "tree": "13ff98e650cd3c8e0fdee0e6d88b15ef88300fe2",
     "url": "https://android.googlesource.com/platform/test/app_compat/csuite"
   },
   "test/catbox": {
-    "dateTime": 1628982588,
+    "dateTime": 1628926016,
     "groups": [],
-    "rev": "b92bc39b74d063784e542677b80787c89c91b6de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e8d3429999d36fe080b5b105f7a59cbe92a8b37b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02lahsm3xbcr6rgjkwknwwi6sm5w79h0wpg4mm89y6vh2yrf60b6",
-    "tree": "7bf38a7018719fd4abfd082e1a493a1cbf9c5cf3",
     "url": "https://android.googlesource.com/platform/test/catbox"
   },
   "test/cts-root": {
-    "dateTime": 1624676994,
+    "dateTime": 1624625659,
     "groups": [],
-    "rev": "b9791d6c54e738a808980cfaec5c35e56233eb7e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9c80ba0d0256b36c6a0b9d6ac3d91a9e358e68ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1garbzndz4qsxmv6cys2zf3gwlsay5yw5svfbz770hhim4i037b6",
-    "tree": "4d5e2e2eaefd2079769f31f00d42a747f77276c4",
     "url": "https://android.googlesource.com/platform/test/cts-root"
   },
   "test/framework": {
+    "dateTime": 1613828438,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "4c6405def6684ec54644d9fcfc7ca0a6e152959a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3166ba1d3ce8b5c2bce35fcb98cdc3f4e52b4f7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1p4gak809gfak9r64pzrq708p53i7y7045x10q7ji16jycw123lv",
-    "tree": "44844efda6427314e40c57463b95f55c6c7f22c2",
     "url": "https://android.googlesource.com/platform/test/framework"
   },
   "test/mlts/benchmark": {
-    "dateTime": 1619485812,
+    "dateTime": 1619453154,
     "groups": [
       "pdk"
     ],
-    "rev": "2d121329360b527fe54e2ba53014df7e74648db3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "71313d62e0549c03545186dcb70f097753e8b896",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0n5yjswf4lnshqg8y0lb2wi65gqqqa0xjfgffkif6m8ma6642mh5",
-    "tree": "f68d540710bea585d62d5be9acd02965f0830e7f",
     "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
   },
   "test/mlts/models": {
+    "dateTime": 1594388199,
     "groups": [
       "pdk"
     ],
-    "rev": "4e56557edff1978290f722456b147778b1ecfcba",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "6f7e2a0398d0214d4c0ac91a8ef60ede44799627",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "136fcq4lmc69yp1gzlynvrv7126z91aw2l1y1gns0d69xk9hfbjf",
-    "tree": "1b323d017c4a26d05cf18e9a008f95a9d38466b3",
     "url": "https://android.googlesource.com/platform/test/mlts/models"
   },
   "test/mts": {
-    "dateTime": 1629853776,
+    "dateTime": 1629762372,
     "groups": [],
-    "rev": "a9bf9f31ba6dc8f2bef821840d6b8cfd91bdf5e9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b61182250b9e5b58121de6df31781a61ef78f2f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1kl9kzfd319cyxj83qqgcdjvdh3fp7j5nmvnmv06zrw9krhdm5gg",
-    "tree": "ef3ca69d561b941ca1e2a34187e8880bf1a40648",
     "url": "https://android.googlesource.com/platform/test/mts"
   },
   "test/vti/dashboard": {
+    "dateTime": 1551088143,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "801e5e13f655b1633e840b8686cdd4e51e1f8c8b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "55e96b37e798a8a3a26ee207a065706464201c2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
-    "tree": "9a6aa23933457f0347256478c4c7f87c8436b866",
     "url": "https://android.googlesource.com/platform/test/vti/dashboard"
   },
   "test/vti/fuzz_test_serving": {
+    "dateTime": 1551002920,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "40cc6c5b930ae7850d7c7acce9786c607792cb2a",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2de1bf485e3cbb298ad3d9828257dd77a73b4633",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
-    "tree": "3bab6d094c78d500d34682e7f4e8aae8ca125301",
     "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
   },
   "test/vti/test_serving": {
+    "dateTime": 1588777700,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "0691eadbc66e58351db024a8b1ef692235880bd4",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "b5a35ff86a8956e60c39fb198f3d71ab42bc0dd9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12y5bwvhbj1yscbi87irp0xgwmb018fck905zf678aii8qckhp9l",
-    "tree": "7d35eda923c28249d3bae3eb19f6bba487662cd5",
     "url": "https://android.googlesource.com/platform/test/vti/test_serving"
   },
   "test/vts": {
-    "dateTime": 1633655377,
+    "dateTime": 1633655390,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "1a5fd026bf41470d4054d84d2d70ef9275b7f5de",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e58e5c30e8acc951b58f009ba76039accb689fb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12lf6wx0r5q57jhkgsb34854h74dggls5jyb48wk2s4glbf5y9i8",
-    "tree": "cf97cbbca48921ec108bd9d06cd741cc3a986298",
     "url": "https://android.googlesource.com/platform/test/vts"
   },
   "test/vts-testcase/fuzz": {
+    "dateTime": 1613835246,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "9ca2b6ad48a62e7fafe591f9e123a6be63e21530",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "3a4927081d472acb2b696b96eba0c4a9f9ff2322",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "106hmz81aaqpy3gq6apgz4a1j6nmvhzp8rbzpldqcl7ymn552h76",
-    "tree": "3b3c783e47ed4754d1b76652dfd2e4c92387f4e7",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
   },
   "test/vts-testcase/hal": {
-    "dateTime": 1631841223,
+    "dateTime": 1631750128,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "3b1b791815d01e83a1dc0ea758305b63ce65dd13",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "2da137e7c80b15df7fe2c5c64daf43d4cbd53880",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "008b7xd5xpkqzzlk5rrpd3mx9vss363dzmmrmk3n5ra51vr8r7jl",
-    "tree": "0ee2181ea515965cece784ede0bef67898f5e7a5",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
   },
   "test/vts-testcase/hal-trace": {
+    "dateTime": 1551088166,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "51664b665957f4c46c3e9e37cf8a63c2fac36265",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "334e9eb97ee6b15f6b2a49639c5525ac44c2122b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
-    "tree": "09ab51841180faca371e6527dc7cefaad5748992",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
   },
   "test/vts-testcase/kernel": {
-    "dateTime": 1633144204,
+    "dateTime": 1633144192,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "c67ce1ec71514867b9ec79ceb0b27c18066562e0",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "fd0a1dad7f4518469c155cf9cfe5c4191e5e9a35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "12m7drfr2z4rhamp1283rk96k9gskf9gqdhgbkyrnd6d3jasiqky",
-    "tree": "d88dccae9b35ea60c393a518e952f305f4c7d8ff",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
   },
   "test/vts-testcase/nbu": {
+    "dateTime": 1613834209,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "5a9f10aaa26c0e90467d0fdd43b79d3e4f0ab8f5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "a1fd4c707d1eff6ef9c4f680f20ab2e6ad5013b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1h3vd99wax8n5ygs6cg15f0p8kj07kas75n72j7b20n4qdy2bflz",
-    "tree": "d8db904ff542f4d6771c6b4f2098afc5338c8a28",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
   },
   "test/vts-testcase/performance": {
+    "dateTime": 1613828086,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "251699dceb256e83c4830be42cf1447c8ddbdb23",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0e1c597e4393809fbac50c80f662a8aeac18503d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dh5n3pprrdb607f3jriz2madgq3ri8fv4c4mcmqld5fbc56w05b",
-    "tree": "cb606caa8a0fd8f3e599a7b9300f6a9ece9d2b7b",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
   },
   "test/vts-testcase/security": {
-    "dateTime": 1629515375,
+    "dateTime": 1629477858,
     "groups": [
       "pdk",
       "projectarch",
       "vts"
     ],
-    "rev": "1007e0658f5c271c0cc1e4adb7e62b4570812d1d",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4d32e98674612bdb92942a6f222db0619f6ac1c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "08rnpidhp5h8yljvv6syb8sykqwqyyk996gc4sgml1kbx4h393q3",
-    "tree": "33cc60fa1b982ff0d2dc015f06cb6a2cbf55b640",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
   },
   "test/vts-testcase/vndk": {
-    "dateTime": 1629767402,
+    "dateTime": 1629748861,
     "groups": [
       "pdk",
       "vts"
     ],
-    "rev": "c17221d97420a3070d86de8be1a4e776c8989891",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d13b18af129aa01cb96bdb58ea545adeedc9e308",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1l8r1qczbzaqvlq8cd4x1wvi2y2lh14m4fqcqypxlmvi3nl62pqx",
-    "tree": "a98368bac0655b84f58ff0cab287d7aa89189741",
     "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
   },
   "toolchain/benchmark": {
+    "dateTime": 1613828208,
     "groups": [],
-    "rev": "4c4dce91bd295b8ef810359a0283457782366117",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "70c3a71142ecb106733cf791b1d3eb912156fa7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "04c2hzbgqxcim23z4brvq0px4cifmz52434lxacq741kqy8a3yn8",
-    "tree": "e15da5bed6d027a44541f47c3853c1853cd46506",
     "url": "https://android.googlesource.com/toolchain/benchmark"
   },
   "toolchain/pgo-profiles": {
-    "dateTime": 1626491416,
+    "dateTime": 1626386921,
     "groups": [
       "pdk"
     ],
-    "rev": "7d82650854937e9580e94db4aef49c47d27646c9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "623c608840f9ad092bf9c0fe490fd59413acd58e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "023wq00bzc3lafcy4l4dwyhx0dxlpxikqr7wixj8jvz39n0hlq9g",
-    "tree": "cee801eb9fad02be4a91188e528686ca6f3c1fe3",
     "url": "https://android.googlesource.com/toolchain/pgo-profiles"
   },
   "tools/aadevtools": {
-    "dateTime": 1619997064,
+    "dateTime": 1619980430,
     "groups": [
       "pdk"
     ],
-    "rev": "3bec120f924d0f8506b671eafad5c1ba2e990dd5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "0bcd62e44d72c66c381923162a8e454302d1337a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1zb9yfwjj9f0hk75vi7qg9j3fllpk3n5mfhgky8z385bh2jmzk5v",
-    "tree": "6955678b931165865359e22fabefa6924f7a7879",
     "url": "https://android.googlesource.com/platform/tools/aadevtools"
   },
   "tools/acloud": {
-    "dateTime": 1620954607,
+    "dateTime": 1620888217,
     "groups": [
       "pdk",
       "projectarch",
@@ -11148,158 +10648,151 @@
       "tradefed",
       "vts"
     ],
-    "rev": "d9144f49a6487271c6fb9c81b63e5a983660e925",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7efb620418c61c78eb4c49cd0fd65b9dec4bc733",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "02svjyi2vj85r6yi6k5i0xffkxkkxh6iyf7bpf99aiwq80aw3hfq",
-    "tree": "b7c942738553e015169331b4f4af09e2bc720d58",
     "url": "https://android.googlesource.com/platform/tools/acloud"
   },
   "tools/apifinder": {
+    "dateTime": 1623117550,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "980f564b336c4b0e21c413e7a79e880dc600ddab",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "61a25ab6da46b348f520ac35de3b5263a3079996",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0bfac5abla83d56kz7hvwdb12h60h90lj9ahy7cgg75qfgjnj9ic",
-    "tree": "e0df5e8ec0c4c9394b6399a8608535eaa55819f6",
     "url": "https://android.googlesource.com/platform/tools/apifinder"
   },
   "tools/apksig": {
-    "dateTime": 1622257799,
+    "dateTime": 1621911219,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "2b027a443d474e81515d970327a91e43a3c16bea",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "64ac786e76e582c47951569030429d3c64e29c70",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1dl6k7qnk9kl26sdr3a6hy2mg9939a20bk7qp11jb3c5vnmarcsy",
-    "tree": "9377b651b9a765ffbc05ec4a394972c54446e1fa",
     "url": "https://android.googlesource.com/platform/tools/apksig"
   },
   "tools/apkzlib": {
+    "dateTime": 1619441314,
     "groups": [
       "pdk",
       "tradefed"
     ],
-    "rev": "1c037361f05dc663326c38ee3071f5e3a320e565",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9115ad3611f5d841c807176c8cce3264bae2c99b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qbj6g2jivxjlxgm1z27anqgb0hh50fm3mqfpb4bd55mqn73csi8",
-    "tree": "029b26e05f844057c9c25576d2a98072bb5b851a",
     "url": "https://android.googlesource.com/platform/tools/apkzlib"
   },
   "tools/asuite": {
-    "dateTime": 1628039454,
+    "dateTime": 1627991749,
     "groups": [
       "pdk"
     ],
-    "rev": "4c785df00b4a98f3fe23cbf4ad0f31799595b7d3",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8f0bf810da42361f63bdfc99cd8ed337cbf6c1df",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0lhpqxdbakqawxvkm8ad53m11yvcha5s75jzcqyni806wcspnc2w",
-    "tree": "a4d09d5a645110499b27fe29d727fe1f47fac2e5",
     "url": "https://android.googlesource.com/platform/tools/asuite"
   },
   "tools/carrier_settings": {
+    "dateTime": 1619816368,
     "groups": [
       "tools"
     ],
-    "rev": "526e958b3a6cc1c8b4ba52cf86b248e2d8fe2cd5",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "faef458f6b7e434ea520bb7da3bf4607104253f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1gcpddy94nmhqbmpr3y1s6b29w6zx3r5ixn53hd0s4y0rfw9ahj6",
-    "tree": "3e2138982cecd7057a274f1b6ddaee6622ed7681",
     "url": "https://android.googlesource.com/platform/tools/carrier_settings"
   },
   "tools/currysrc": {
+    "dateTime": 1611318709,
     "groups": [
       "pdk"
     ],
-    "rev": "51a3781e821dea99c199d345caf2547a1de30904",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "88456cb9f75e1e49a5d0d19c0a463bd3f4f3214d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0h3smd8j3lrd8lnmzcpirn70k9q8l645sbgzfw6cxdrzbi7p2d1a",
-    "tree": "580c2914b0561c1b2c40eb0c2f29163e9bd7bbb1",
     "url": "https://android.googlesource.com/platform/tools/currysrc"
   },
   "tools/dexter": {
+    "dateTime": 1614949728,
     "groups": [
       "pdk-fs",
       "tools"
     ],
-    "rev": "8d247ad5f7ca3f6de640a72139266419faf5feb6",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "e06b2804ae9db940ffe6577213e11eca764b89c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1mmldb1h69bcxil78y708hfzr1v5s7y547j0v9cb2vgg48m109dg",
-    "tree": "a75b5e69beba5a07d2f5f1ffc59a1a7d0e534237",
     "url": "https://android.googlesource.com/platform/tools/dexter"
   },
   "tools/doc_generation": {
-    "dateTime": 1631754624,
+    "dateTime": 1631737440,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "594ef0d914c8ce703c264c95bbfe98e8f1232f5e",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "9c2e194c56864bd1970a9085718e320205528119",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0wrhriszbxc58k6sqmv1lsipac7bi67q15yjg2clb6k5irp8rzkh",
-    "tree": "b01c04b523e6a36bd765224d36e3d11e646229fa",
     "url": "https://android.googlesource.com/platform/tools/doc_generation"
   },
   "tools/external/fat32lib": {
+    "dateTime": 1613437327,
     "groups": [
       "tools"
     ],
-    "rev": "7e6d0dabdbeebe851ccd5ba85c82b2e04a1d22ec",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "029944db36db3b1788a66c7cb6ccf19a13084db7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0zx9wqm0l5w1ghcyj49bsfm39y8b97bckfmy9l5r62f6yx4hcgsh",
-    "tree": "4eb0655273eaa2e6a26d41de780d966c5123c9b5",
     "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
   },
   "tools/external_updater": {
-    "dateTime": 1620954614,
+    "dateTime": 1620858061,
     "groups": [
       "tools"
     ],
-    "rev": "9c724e6ac0393a8b6b6ea63a7f3e2d8aa716b79c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "cb60767c57d26046d84c3ff0b6ff19e6dd6e658e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0aa7dhk94wdc6qa45q2bhc8qc17x7f4n53gn8bqb06pdvwdiilmz",
-    "tree": "3ed4360a9de7ca76e250c53a99864e859d2a2cf1",
     "url": "https://android.googlesource.com/platform/tools/external_updater"
   },
   "tools/metalava": {
-    "dateTime": 1623373842,
+    "dateTime": 1623243260,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "5abd200389cfc33f9e4b33e0a26b0a50a8fe848c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8be9b7926aaf036d2b1227e1f3573b2c6c275a43",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "01clliylngzky0lljv77vw9bf52ca4jqv8g62867wcw46vh7n5lj",
-    "tree": "4957bd0ce1d763cb52fd552809fa9ae143990bc4",
     "url": "https://android.googlesource.com/platform/tools/metalava"
   },
   "tools/ndkports": {
+    "dateTime": 1599773449,
     "groups": [
       "pdk"
     ],
-    "rev": "a878bd984fdac43d4d89fe29b07fe66876d52c5f",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4b58b2e1514f2fcb3655d16c99648f5e50d572ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "13f0scvw1gkwjx24l6hqgk9v7q919zilas7v0b6h8pg2akiyd45h",
-    "tree": "96d3320fa24a1aa2160e56ef7d8157d653cc0f9b",
     "url": "https://android.googlesource.com/platform/tools/ndkports"
   },
   "tools/platform-compat": {
-    "dateTime": 1633396187,
+    "dateTime": 1633396175,
     "groups": [
       "pdk",
       "pdk-cw-fs",
       "pdk-fs"
     ],
-    "rev": "02c32640a0c26d62337c3dc5834c316b55158228",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "4c4deac4067e71b554fde3a78a42d965cc812ce3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "193lr1nxwghrz0ch9a2r744w108npnvr7rpzziy1h3wxgg8474qk",
-    "tree": "3501ee7196591d863fffbe49c8c8be567c1cdb1e",
     "url": "https://android.googlesource.com/tools/platform-compat"
   },
   "tools/repohooks": {
-    "dateTime": 1611281242,
+    "dateTime": 1611207032,
     "groups": [
       "adt-infra",
       "cts",
@@ -11309,54 +10802,50 @@
       "tools",
       "tradefed"
     ],
-    "rev": "c72d389002d3eb22f797d19df922210696e2d07c",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "8718ad886510b6ba060eec17d229220b27fcda89",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0c525jc6ysp6iqzjdqhmp47mb5cn2wx6aay8cknmjq9wnl9yjbld",
-    "tree": "70bb2d604d556baff0aaa19fb234feef5625efcc",
     "url": "https://android.googlesource.com/platform/tools/repohooks"
   },
   "tools/security": {
-    "dateTime": 1620090624,
+    "dateTime": 1620063693,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "e5c49f6835be49e62ae055b96ae2f07720b37dda",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "02eea8c0f4724a1b315ffc6b0785340ce0d343a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1pd6isfz0nab12mqmczmyvvp1dhsz1q18m7wzbh0mz3s4584dip4",
-    "tree": "9fa66ee643a4a9fe3883a4a5691a0303d9713622",
     "url": "https://android.googlesource.com/platform/tools/security"
   },
   "tools/test/connectivity": {
-    "dateTime": 1633655396,
+    "dateTime": 1633655409,
     "groups": [
       "pdk"
     ],
-    "rev": "7b88f54ce05be7965443e07aff40991d96a2cfc9",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "7bab7bc56b84f589d621b9f992362ee3424a028d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "17bdqp7l3h60c8kh3r78m6g0p6la1zqsjq7fzwn7jxhl06sryzkf",
-    "tree": "65dda65c28ba7fb717de9b35927df06aaddf0b78",
     "url": "https://android.googlesource.com/platform/tools/test/connectivity"
   },
   "tools/test/graphicsbenchmark": {
-    "dateTime": 1619053817,
+    "dateTime": 1619035270,
     "groups": [
       "pdk"
     ],
-    "rev": "d2a6cec69160da690727814868d3106b36447356",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "faabdd57fc66b6920b581a90678bc1d4d5bca4a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "0v5b8p7lwcwrmd1sxc6axf7qkdqyq9p5dqcyazngr0amhdf2xg0j",
-    "tree": "d058665435e5c2bccf79ca0c7c9ee9c7165d0799",
     "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
   },
   "tools/test/openhst": {
+    "dateTime": 1613834515,
     "groups": [
       "tools"
     ],
-    "rev": "6e7d3040ef3e580bdd93deb43f36276b121e5d26",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "14c955abfde3ce4110da3cb9856f21d8785dc622",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1qlnvcpsy11nd9cjjh6yy1bhcsikx3xg5rzkqbfhli0q0a5jwrpp",
-    "tree": "fe60ed2f76b9fafd353203be1470ee1461931cb5",
     "url": "https://android.googlesource.com/platform/tools/test/openhst"
   },
   "tools/tradefederation/prebuilts": {
@@ -11365,26 +10854,24 @@
       "pdk",
       "tradefed"
     ],
-    "rev": "1f881ca21971e33def2f07fc9ff73109e6206d81",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "91d3ac2869c3f12c070569111733718937af4c71",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1bcwf7sblx43fl2pxijr66f7h2y5mly5hvrvkd94zxa2svn694i2",
-    "tree": "57c8deed1e399676a9710bb6efad360328a655cf",
     "url": "https://android.googlesource.com/platform/tools/tradefederation/prebuilts"
   },
   "tools/treble": {
-    "dateTime": 1619745082,
+    "dateTime": 1619655332,
     "groups": [
       "pdk",
       "tools"
     ],
-    "rev": "1267d3ff49ebd299b1a869e7546195583059a53b",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "d77bc2ad9eec7c8eae1f827ea5de4d7c1d7e410c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1cm4prh06srq421ibkac8s9kdjxvq6s0gy336sa92wc886hg8k2d",
-    "tree": "4d7852d76974dbe8f7708ba392bf7e328697caac",
     "url": "https://android.googlesource.com/platform/tools/treble"
   },
   "tools/trebuchet": {
-    "dateTime": 1620954624,
+    "dateTime": 1620860981,
     "groups": [
       "cts",
       "pdk",
@@ -11392,10 +10879,9 @@
       "pdk-fs",
       "tools"
     ],
-    "rev": "7181697d9c660cd8c5bc9e012539b3144ec31901",
-    "revisionExpr": "refs/tags/android-12.0.0_r19",
+    "rev": "91e9260be9641b0691feb763bca2294d543477ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
     "sha256": "1i3iz9fyd0jbvmjawxy3w0qvf6ycnv6jvmxk6c7xm272ad43gxag",
-    "tree": "c46c4554991f543a715def82541c27f3db50e393",
     "url": "https://android.googlesource.com/platform/tools/trebuchet"
   }
 }

--- a/modules/apv/latest-telephony-provider.json
+++ b/modules/apv/latest-telephony-provider.json
@@ -1,9 +1,9 @@
 {
   "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider",
-  "rev": "38c025097891fc14748193c665fee35eb90a9ef1",
-  "date": "2021-12-28T23:06:10+00:00",
-  "path": "/nix/store/as9ciqnkyxmdhs9vzyx41ix8wjli6751-TelephonyProvider",
-  "sha256": "0zrb44684x1wwy3ybqg18jjsrdl4hfp5gc70z78mca7x3ibb5jnj",
+  "rev": "69a564f5878c491c0be9765a32527e4f0bc18929",
+  "date": "2022-01-15T06:10:25+00:00",
+  "path": "/nix/store/jzzp1qzardga2cqd4x6gx51f9pn6c724-TelephonyProvider",
+  "sha256": "086h288cbgy6slr3jfmn3bqqr3pp04k4xwjzz1nb9afzp9ii41gy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/modules/pixel/pixel-beta-imgs.json
+++ b/modules/pixel/pixel-beta-imgs.json
@@ -1,34 +1,34 @@
 [
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/sargo-s2b1.211112.006-factory-5dfc760b.zip",
-    "sha256": "5dfc760bb7022316572bbebc36f2ec380b1e7a796f863b697ead8a5af8dc4e38"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/sargo-s2b2.211203.006-factory-88b5efd2.zip",
+    "sha256": "88b5efd2e1e89596bdb22f346afa3608af6424d85bdb19621ceb83fb861ea51a"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/bonito-s2b1.211112.006-factory-8cebac8c.zip",
-    "sha256": "8cebac8c73940a78bea8b501aca3b17a0dac9e09b2fa860ebcbaf1fdbdd75259"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/bonito-s2b2.211203.006-factory-4ff61590.zip",
+    "sha256": "4ff6159079719c2a369a2855656e044903da191f2315952a32fb2b195431ce3f"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/flame-s2b1.211112.006-factory-9113027e.zip",
-    "sha256": "9113027e1b6a45239fb3b978d19e65d365e5a728893f6076861f91ad7e48b2b4"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/flame-s2b2.211203.006-factory-339ba07c.zip",
+    "sha256": "339ba07c6cdcc0b743c59b39ebdc2e0f27a28211d445b518479cc1089cc6babd"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/coral-s2b1.211112.006-factory-73fb5f2d.zip",
-    "sha256": "73fb5f2d347316c3d0f13f842ad8328d33b198484afd064c84652b61659b7481"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/coral-s2b2.211203.006-factory-876bc6f5.zip",
+    "sha256": "876bc6f51e13868c6ade5f4831f466c4977f6d1f668883d8839488afe06c2286"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/sunfish-s2b1.211112.006-factory-c456e8fe.zip",
-    "sha256": "c456e8fe4d4734bd8be0fe18082256d49e65df618adc7aeab39fb374b5c80bbd"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/sunfish-s2b2.211203.006-factory-a006ffbc.zip",
+    "sha256": "a006ffbc77d80fb7f9180b3864cd013b04cc2f8217300cb91b044019d262bde1"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/bramble-s2b1.211112.006-factory-5128af91.zip",
-    "sha256": "5128af914e1d75ed4607012ccdc6eeffe042076590f8744da337ee1f07e41393"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/bramble-s2b2.211203.006-factory-36c209a8.zip",
+    "sha256": "36c209a8477ae7f4ab55f737c8df6795951e04c1cee2c05736e332852bb9dda0"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/redfin-s2b1.211112.006-factory-54144b89.zip",
-    "sha256": "54144b89e85bf6df211cb3dadd72ee3eb24365f0496dea893d38485372fdfbd5"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/redfin-s2b2.211203.006-factory-588d1292.zip",
+    "sha256": "588d12926b12d04bffa337702c6696311668a14d921361b8b270a31ba427ed05"
   },
   {
-    "url": "https://dl.google.com/developers/android/sc/images/factory/barbet-s2b1.211112.006-factory-2ec9307b.zip",
-    "sha256": "2ec9307b71df6b04b234636830b289fe36a52035ed4eaa457d95a64201ca162b"
+    "url": "https://dl.google.com/developers/android/sc/images/factory/barbet-s2b2.211203.006-factory-5e874682.zip",
+    "sha256": "5e874682c6d0a55c05bd0a0cea4d8552c4243ff28b38f6707c0eaeb9b9814e41"
   }
 ]

--- a/modules/pixel/pixel-drivers.json
+++ b/modules/pixel/pixel-drivers.json
@@ -48,6 +48,10 @@
     "sha256": "e9152757c0038bddf13216c7b35cac6845791ba932e69dba3f556c6dcecf62e3"
   },
   {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-oriole-sq1d.220105.007-37e46fa2.tgz",
+    "sha256": "c3912a5c7862245ecc28e2ef4f36f9b9d5ee668f2a6c03b5981ae74564fd932b"
+  },
+  {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.015.a4-31a5656a.tgz",
     "sha256": "4267914736943b542103ee037b872084fce71b06f90c3f638cd7aca7d009abb4"
   },
@@ -94,6 +98,10 @@
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sq1d.211205.016.a5-d9a231e4.tgz",
     "sha256": "988f37494526fbc5c31c12e0c5bb016ea28a40692048f6c2d1dc38b448485351"
+  },
+  {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sq1d.220105.007-449f56b4.tgz",
+    "sha256": "f8d34ce04f12610f58e43e827d390e04ea87e8a0138abc955ac3c72be7bd5d67"
   },
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-barbet-rd2a.210605.006-22c86344.tgz",

--- a/modules/pixel/pixel-imgs.json
+++ b/modules/pixel/pixel-imgs.json
@@ -49,21 +49,9 @@
   },
   {
     "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.016.A1, Dec 2021)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-sq1d.211205.016.a1-factory-f588dce8.zip",
-    "sha256": "f588dce824359427508a3459d7e4cc20bf21f7db368867dea74a9c04649220b9"
-  },
-  {
-    "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.016.A4, Dec 2021, EMEA carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-sq1d.211205.016.a4-factory-a01693e3.zip",
-    "sha256": "a01693e309fcee8d8002ae6ff1104008b8e7f30b2f8d38f7e0f48520e2317f4c"
-  },
-  {
-    "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.017, Dec 2021, US carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-sq1d.211205.017-factory-2d49905c.zip",
-    "sha256": "2d49905cce345776ce60371482f7266224a65c300a5b4697caa07d71be1093e4"
+    "version": "12.0.0 (SQ1D.220105.007, Jan 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-sq1d.220105.007-factory-eab95d36.zip",
+    "sha256": "eab95d3650d5c2edb8da889e3417c696f69f2f2ea4c271cd4ad111a976d08ea0"
   },
   {
     "device": "raven",
@@ -115,21 +103,9 @@
   },
   {
     "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.016.A1, Dec 2021)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-sq1d.211205.016.a1-factory-86d212b2.zip",
-    "sha256": "86d212b21f8f6a13dac286e3246b859801ec27923d3d9e4b20218a1722e3d243"
-  },
-  {
-    "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.016.A4, Dec 2021, EMEA carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-sq1d.211205.016.a4-factory-bbeea871.zip",
-    "sha256": "bbeea8715cce48642f4035fcd3456394154caca010205a0e303490eedb8064a8"
-  },
-  {
-    "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.017, Dec 2021, US carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-sq1d.211205.017-factory-bf3da4b2.zip",
-    "sha256": "bf3da4b26554d84f99eaad9837330c7d757f7d31442397ef89a98307d169d96a"
+    "version": "12.0.0 (SQ1D.220105.007, Jan 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-sq1d.220105.007-factory-d8f6b8a4.zip",
+    "sha256": "d8f6b8a4ff4865c9ebf08096a6263bfa4a3116e1fdd7f07770299055ec59fe26"
   },
   {
     "device": "barbet",

--- a/modules/pixel/pixel-otas.json
+++ b/modules/pixel/pixel-otas.json
@@ -49,21 +49,9 @@
   },
   {
     "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.016.A1, Dec 2021)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sq1d.211205.016.a1-4fa45f8d.zip",
-    "sha256": "4fa45f8d5e442b4632b74d8615ad2189af2276b9334f44e15cd1e216e301646f"
-  },
-  {
-    "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.016.A4, Dec 2021, EMEA carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sq1d.211205.016.a4-b5f56c9d.zip",
-    "sha256": "b5f56c9dbd76ae9be33bdf2fc536bde3494d9b51f5786f25d39faf809bdec9d4"
-  },
-  {
-    "device": "oriole",
-    "version": "12.0.0 (SQ1D.211205.017, Dec 2021, US carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sq1d.211205.017-ea5f4814.zip",
-    "sha256": "ea5f4814e3b9fa5c6fa226f0a246c6c1037e79c10df6a1d1dee8d78f611c92ff"
+    "version": "12.0.0 (SQ1D.220105.007, Jan 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sq1d.220105.007-0e8d793c.zip",
+    "sha256": "0e8d793cb52b350772c48db20705fead678cf1bc9af6ccb43f88860a440917e4"
   },
   {
     "device": "raven",
@@ -115,21 +103,9 @@
   },
   {
     "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.016.A1, Dec 2021)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sq1d.211205.016.a1-81234517.zip",
-    "sha256": "8123451727768bc1777e5bb56c333c2674ea1a688e174aef2fdee759e442c1ce"
-  },
-  {
-    "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.016.A4, Dec 2021, EMEA carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sq1d.211205.016.a4-58c4992d.zip",
-    "sha256": "58c4992db48439dd65a015b51497843afa2a5eabd9e7a78bd20e1133a7b14b63"
-  },
-  {
-    "device": "raven",
-    "version": "12.0.0 (SQ1D.211205.017, Dec 2021, US carriers)",
-    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sq1d.211205.017-5576891c.zip",
-    "sha256": "5576891cab747592480f59096b0c224c78844de387d3bc7bbdef18c9c4279189"
+    "version": "12.0.0 (SQ1D.220105.007, Jan 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sq1d.220105.007-3a7aafbf.zip",
+    "sha256": "3a7aafbfb10172692e34195b776139b7b96030753d6cb7a393b6e3a591cc3de2"
   },
   {
     "device": "barbet",


### PR DESCRIPTION
The January update for the Pixel 6 (Pro) is finally here. Tested to boot on my Pixel 6.

Following the disastrous December patch, we will have to see how Google will manage to mess it up again this time :stuck_out_tongue: