### PR TITLE
lineageos: 19.0 init

### DIFF
--- a/flavors/lineageos/default.nix
+++ b/flavors/lineageos/default.nix
@@ -13,6 +13,7 @@ let
   androidVersionToLineageBranch = {
     "10" = "lineage-17.1";
     "11" = "lineage-18.1";
+    "12" = "lineage-19.0";
   };
   lineageBranchToAndroidVersion = mapAttrs' (name: value: nameValuePair value name) androidVersionToLineageBranch;
 
@@ -152,7 +153,7 @@ in mkIf (config.flavor == "lineageos")
   pixel.activeEdge.includedInFlavor = mkDefault true;
 
   # Needed by included kernel build for some devices (pioneer at least)
-  envPackages = [ pkgs.openssl.dev ] ++ optionals (config.androidVersion == 11) [ pkgs.gcc.cc pkgs.glibc.dev ];
+  envPackages = [ pkgs.openssl.dev ] ++ optionals (config.androidVersion >= 11) [ pkgs.gcc.cc pkgs.glibc.dev ];
 
   envVars.RELEASE_TYPE = mkDefault "EXPERIMENTAL";  # Other options are RELEASE NIGHTLY SNAPSHOT EXPERIMENTAL
 

--- a/flavors/lineageos/lineage-19.0/device-dirs.json
+++ b/flavors/lineageos/lineage-19.0/device-dirs.json
@@ -1,0 +1,718 @@
+{
+  "device/asus/Z01R": {
+    "date": "2021-09-20T09:24:57-06:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/asus/sdm845"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/w4sj60pja6gp4w7qsx75a97chcdzcahg-android_device_asus_Z01R",
+    "rev": "e1c3b6b6a064e6f1549b599c72caf3851a6943ad",
+    "sha256": "1xryz7fwzdpxdwl666wjzvahskw072n07wmcin1xz2sag68cjmzl",
+    "url": "https://github.com/LineageOS/android_device_asus_Z01R"
+  },
+  "device/asus/sake": {
+    "date": "2021-12-07T10:54:41+01:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/asus/sm8350"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/iwskb6axbgfq76an62p558yl2n1y252p-android_device_asus_sake",
+    "rev": "91464503bafbddc80b8f47d627bbe41da62051c1",
+    "sha256": "1rj2g2rsmkfmc8wh17w0hwvbx9myih3b7xsam7dkp9iim6hijv7g",
+    "url": "https://github.com/LineageOS/android_device_asus_sake"
+  },
+  "device/google/barbet": {
+    "date": "2022-01-13T23:27:48+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/redbull"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/j3g79ff483k64ixrqp6z1bxqnk2x1r75-android_device_google_barbet",
+    "rev": "dc667577d716ac123b7cdb5111c5581e3e09c237",
+    "sha256": "1nlz0nakrwbiwikg46hajp3icnmbk0p15i0apapv367v1c6df43g",
+    "url": "https://github.com/LineageOS/android_device_google_barbet"
+  },
+  "device/google/blueline": {
+    "date": "2021-12-02T19:43:07+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/crosshatch"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/l94s8jvy196k1fwpnyg97mv3ncrl3shh-android_device_google_blueline",
+    "rev": "40bffd6293c1d33acf397fd338b7f04c4d13b156",
+    "sha256": "14f3g8l9bhsiv91svvqcd6y38l52d6p6pb55y79s3kn719pjmq99",
+    "url": "https://github.com/LineageOS/android_device_google_blueline"
+  },
+  "device/google/bonito": {
+    "date": "2022-01-13T23:35:16+02:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/msm-4.9",
+      "packages/apps/ElmyraService"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/7v0h6szd7aygfs93rwvifb4va921qlgy-android_device_google_bonito",
+    "rev": "26520e04d663d2af629dc53cc158b18d156c9130",
+    "sha256": "130nnr0hhwl8gk093pqh0v0wqd6vq4v7hw19yxgzrl2vlkmdi0yw",
+    "url": "https://github.com/LineageOS/android_device_google_bonito"
+  },
+  "device/google/bramble": {
+    "date": "2022-01-13T23:29:16+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/redbull"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/jwml3kmw5szrp7d36m02f2l05c1igxqg-android_device_google_bramble",
+    "rev": "12fe7eabb96e66bd5dcfdac62c89f43580727836",
+    "sha256": "1mkv91wjmgsfy0pp512sn69mxvlyjqww82phaj0r0ilajg9z8ksy",
+    "url": "https://github.com/LineageOS/android_device_google_bramble"
+  },
+  "device/google/coral": {
+    "date": "2022-01-17T00:06:46+01:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/msm-4.14",
+      "packages/apps/ElmyraService"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/0fdrkay3lsnx99d3hghfwa6z53ygwqhj-android_device_google_coral",
+    "rev": "efe993dc819f45747ecfc97cca9c04044e49c8ad",
+    "sha256": "1xzia3js70dm79992nyxbsjdx5jxn4zs2zzbmazb66zccbnyipw5",
+    "url": "https://github.com/LineageOS/android_device_google_coral"
+  },
+  "device/google/crosshatch": {
+    "date": "2022-01-13T23:36:27+02:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/msm-4.9",
+      "packages/apps/ElmyraService"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/nj7b8dq4n699mnmrj9qzcpx25gj4badc-android_device_google_crosshatch",
+    "rev": "cbb333fa8e7f8266fade9b02d60221dda7952c36",
+    "sha256": "0271bv2d0dgzhi895x0zs2ca8x38dwwixmlcam47r06lgd7i77ih",
+    "url": "https://github.com/LineageOS/android_device_google_crosshatch"
+  },
+  "device/google/flame": {
+    "date": "2021-11-28T23:01:02+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/coral"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/ig9l769llxzwa4p38bcaas62mz18p74p-android_device_google_flame",
+    "rev": "3f0cf2898324099794b7d316f02eda3883a409f3",
+    "sha256": "1qs604y18lk0ra4jj3rf3fwn1nxckazwviljsq6w4wiikibpfmir",
+    "url": "https://github.com/LineageOS/android_device_google_flame"
+  },
+  "device/google/redbull": {
+    "date": "2022-01-17T00:07:03+01:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/redbull"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/39rmbjs5k330fp7inxkchw047nr00xfg-android_device_google_redbull",
+    "rev": "f25651393b5271f2f9620e18c25c70d2bb9df217",
+    "sha256": "11fqvssil7bdk6pwqyck11ffc6wipcxj4crdgp57l4wzn2gvlqx0",
+    "url": "https://github.com/LineageOS/android_device_google_redbull"
+  },
+  "device/google/redfin": {
+    "date": "2022-01-13T23:29:53+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/redbull"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/62x3kig3m2dz0zkfw68xq88l9f8g6p5a-android_device_google_redfin",
+    "rev": "1b5844bd852bcbf10fc370d3d6d5994b3cb70dbc",
+    "sha256": "1qd697fnz5ghmablsdg28q73c8slhwhgl8vri7jsa662prbj9w28",
+    "url": "https://github.com/LineageOS/android_device_google_redfin"
+  },
+  "device/google/sargo": {
+    "date": "2021-11-28T23:02:21+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/google/bonito"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/rv71jq32gz966xlhcd3wld31jghbvfm2-android_device_google_sargo",
+    "rev": "778f11fc241e4f78c64b3a19e82f109a6d8528be",
+    "sha256": "0np37krrgwqdwajqxks0b11mqvpg8wyc7scm90wycas76ywb7nz3",
+    "url": "https://github.com/LineageOS/android_device_google_sargo"
+  },
+  "device/google/sunfish": {
+    "date": "2022-01-17T00:06:54+01:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/msm-4.14"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/a3c0cnisns2il9cndivjnp8aglwph3rf-android_device_google_sunfish",
+    "rev": "0badfe96c64330dd7b8460b73f48d3795f31405d",
+    "sha256": "0f0mzpr7q8f8m5gma840yk918karqhi7pnm22xi3b62asc7gl5yi",
+    "url": "https://github.com/LineageOS/android_device_google_sunfish"
+  },
+  "device/oneplus/lemonadep": {
+    "date": "2021-11-25T15:43:47+00:00",
+    "deepClone": false,
+    "deps": [
+      "device/oneplus/sm8350-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/vvkmcscqcff1riamdh30fqz325jxm3y1-android_device_oneplus_lemonadep",
+    "rev": "c43dd2db1e6851e57c239e2767cd27f80cb64165",
+    "sha256": "0zz4561qskaxxyqymswp2ninrbndkmpaysyls078z0q8bm8182an",
+    "url": "https://github.com/LineageOS/android_device_oneplus_lemonadep"
+  },
+  "device/oneplus/sm8350-common": {
+    "date": "2021-12-31T15:19:40+01:00",
+    "deepClone": false,
+    "deps": [
+      "hardware/oneplus",
+      "kernel/oneplus/sm8350"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/jk0dkhpbmfxlqa5ggv6czqikd6y42pad-android_device_oneplus_sm8350-common",
+    "rev": "dc568fa506a9aab7cfaff8b6afae6c2a4c8476f5",
+    "sha256": "0abagzd1h5lx2cg12d0jivppiid03qh1mcdgxqznyb5ms3dwi5h6",
+    "url": "https://github.com/LineageOS/android_device_oneplus_sm8350-common"
+  },
+  "device/samsung/beyond0lte": {
+    "date": "2021-10-19T10:11:51+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/6asqavlv1mfib3hc8ssvdly3qyj2zlwp-android_device_samsung_beyond0lte",
+    "rev": "f6945d5ca28dda9540361854c16bd99ffb8decd8",
+    "sha256": "0bcwds3zgwgzrfw35s2xx0sd0gaqrp1v2y63h4s42529hb1ca1rn",
+    "url": "https://github.com/LineageOS/android_device_samsung_beyond0lte"
+  },
+  "device/samsung/beyond1lte": {
+    "date": "2021-10-19T10:12:25+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/0cf28b2s1cw7x068y31jxpp27s36vg8m-android_device_samsung_beyond1lte",
+    "rev": "12d3a8f13d84c60271315fe71fe57b99fa40354b",
+    "sha256": "14ya48fd358g04cfqnarcn2drqc68ifcqywc7j12psfxvsqlh4dz",
+    "url": "https://github.com/LineageOS/android_device_samsung_beyond1lte"
+  },
+  "device/samsung/beyond2lte": {
+    "date": "2021-10-19T10:12:56+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/h635x6qjw16rdnkga10zigz5v41m1pxd-android_device_samsung_beyond2lte",
+    "rev": "723b0b1812fa3f5a2a9e1975c3a4243d76116e25",
+    "sha256": "1m2vglhw8alfhbxkvza9bx64yrpihg6n0syhb4h9p1wppnxg9g0z",
+    "url": "https://github.com/LineageOS/android_device_samsung_beyond2lte"
+  },
+  "device/samsung/beyondx": {
+    "date": "2021-10-19T10:14:50+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/ylhpl8m2jqczql2mnfa2amyfdy4n4a1c-android_device_samsung_beyondx",
+    "rev": "fd7100a31e9d7e3acc8e111ffc8de2aa18ddafee",
+    "sha256": "1r8fzp1gxixk6a94y3jka5lm42219lm6bq9sx3mkaalzfn7mph9q",
+    "url": "https://github.com/LineageOS/android_device_samsung_beyondx"
+  },
+  "device/samsung/d1": {
+    "date": "2021-10-19T10:15:40+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/ww6v4a2kmy53fmbzw6jzlpd78sr4p48k-android_device_samsung_d1",
+    "rev": "7a3f2e37eeb18a54c7bacd6a04398c3204d6eae7",
+    "sha256": "0lzl336ikbm8c8jkl8wr6al6s6x6h33hj2sy10qqxfab8qyglm6p",
+    "url": "https://github.com/LineageOS/android_device_samsung_d1"
+  },
+  "device/samsung/d2s": {
+    "date": "2021-10-19T10:16:58+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/j6k490m5377mihgva868x2rqacdy5xzf-android_device_samsung_d2s",
+    "rev": "1c0664483345532813cc428464c3045b59522c1c",
+    "sha256": "1j2q38k9i84fjz8rya3zrig1accbmzbqpz3l6vg3lj41ja20a5p2",
+    "url": "https://github.com/LineageOS/android_device_samsung_d2s"
+  },
+  "device/samsung/d2x": {
+    "date": "2021-10-19T10:18:04+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/exynos9820-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/d14xzyli89z22fp1v6ynha42m3bn2gkc-android_device_samsung_d2x",
+    "rev": "a1ee37c325a430b03f4e56bbfe01192712eee9b9",
+    "sha256": "0gznbz9ni8p8064453snx3q3bpkjgyafx1iknm9i9kh335skh18g",
+    "url": "https://github.com/LineageOS/android_device_samsung_d2x"
+  },
+  "device/samsung/exynos9820-common": {
+    "date": "2021-11-02T18:14:20+01:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung_slsi/sepolicy",
+      "hardware/samsung",
+      "hardware/samsung/nfc",
+      "kernel/samsung/exynos9820"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/qkbw3vf77m6vaj3wap177jz58wdhvykm-android_device_samsung_exynos9820-common",
+    "rev": "8fec7c38ed6927cfeaf548be0c45c30eeeea759c",
+    "sha256": "08rf0bv55k5zr60i2z40xyx17qpqxqkin928qpsycq7w7sj09s1v",
+    "url": "https://github.com/LineageOS/android_device_samsung_exynos9820-common"
+  },
+  "device/samsung/gta4xl-common": {
+    "date": "2021-11-10T17:57:42+01:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung_slsi/sepolicy",
+      "hardware/samsung",
+      "hardware/samsung_slsi/libbt",
+      "hardware/samsung_slsi/scsc_wifibt/wifi_hal",
+      "hardware/samsung_slsi/scsc_wifibt/wpa_supplicant_lib",
+      "kernel/samsung/gta4xl"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/fs4iilkgcj4xhl0ykrb8xkmgfcyailbh-android_device_samsung_gta4xl-common",
+    "rev": "4e70e35e15373185372b3c6c4661b65019c27cbf",
+    "sha256": "091zj83bixkqgzd9sx28h8yfr2r01gjr15dnggnralrnzi89j9pm",
+    "url": "https://github.com/LineageOS/android_device_samsung_gta4xl-common"
+  },
+  "device/samsung/gta4xlwifi": {
+    "date": "2021-10-09T15:38:28+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/gta4xl-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/9890487r7ilhdsxs8m9lw5sz6hc2z3fl-android_device_samsung_gta4xlwifi",
+    "rev": "25ad19394e105b63f19fa5ccf61f9736034c6b35",
+    "sha256": "1hxm3vhv3vn5xw0w2xmac8m503asr5wsdc23xx72a19qkp1f6l9d",
+    "url": "https://github.com/LineageOS/android_device_samsung_gta4xlwifi"
+  },
+  "device/samsung/gts4lv": {
+    "date": "2021-12-11T14:13:37+00:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/gts4lv-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/47kl99rk8hf9x80p6f04gmkwxacf0xbb-android_device_samsung_gts4lv",
+    "rev": "15af9e08a7f734b7709ea416e5d9d9b126e01415",
+    "sha256": "1186cd61m6ipj9rx6fhn58zaszc2a094dn6r4djg98aydmcvh4r6",
+    "url": "https://github.com/LineageOS/android_device_samsung_gts4lv"
+  },
+  "device/samsung/gts4lv-common": {
+    "date": "2022-01-13T22:43:14+00:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/qcom-common",
+      "kernel/samsung/sdm670"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/qxzhrp0i4d2ac4j18qd1lsb7v4r49wi7-android_device_samsung_gts4lv-common",
+    "rev": "4449e4ae1292efaeb4444dbefb59366e6a49174e",
+    "sha256": "1q50apwf1i890nilmxvasspy1rsvb9zny60n1f18ymj8px0q0iks",
+    "url": "https://github.com/LineageOS/android_device_samsung_gts4lv-common"
+  },
+  "device/samsung/gts4lvwifi": {
+    "date": "2021-09-22T14:17:40+01:00",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/gts4lv-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/j19kcxbk44jrda0ly96fsyijrv8llv49-android_device_samsung_gts4lvwifi",
+    "rev": "c352c4e643e7f82c29b0002f4de807bd9928fdcb",
+    "sha256": "18lpaisdsxmq3d2qcnk3zmf0jmhij780fa5imrsva9w3mlkz89wz",
+    "url": "https://github.com/LineageOS/android_device_samsung_gts4lvwifi"
+  },
+  "device/samsung/m20lte": {
+    "date": "2021-09-13T15:00:05+05:30",
+    "deepClone": false,
+    "deps": [
+      "device/samsung/universal7904-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/izz7v6rl7qw9fs09yiqc49v25g98sr7c-android_device_samsung_m20lte",
+    "rev": "e8003124d2a6337642d3a59827eebea7334096c6",
+    "sha256": "1611ny6fzp1dcz6ggifh1366g248fd8j2za7f00n36ljmbqgd6g0",
+    "url": "https://github.com/LineageOS/android_device_samsung_m20lte"
+  },
+  "device/samsung/qcom-common": {
+    "date": "2020-04-25T15:47:09-06:00",
+    "deepClone": false,
+    "deps": [
+      "hardware/samsung"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/ajzhf40n8bifyqx3qq4rdz5j1asyd37b-android_device_samsung_qcom-common",
+    "rev": "3f56559a5436fd7be36fc6b7010ed3506ebe6e08",
+    "sha256": "0s4i22s0iiwfmgfg7fv9q0arpkpdqn8vxr4xlcq46r9qhzvmjblx",
+    "url": "https://github.com/LineageOS/android_device_samsung_qcom-common"
+  },
+  "device/samsung/universal7904-common": {
+    "date": "2021-09-25T23:02:32+05:30",
+    "deepClone": false,
+    "deps": [
+      "device/samsung_slsi/sepolicy",
+      "hardware/samsung",
+      "hardware/samsung/nfc",
+      "hardware/samsung_slsi/libbt",
+      "hardware/samsung_slsi/scsc_wifibt/wifi_hal",
+      "hardware/samsung_slsi/scsc_wifibt/wpa_supplicant_lib",
+      "kernel/samsung/universal7904"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/yxgyx3nhlm1gcmcrha6vihhxq4cwnixi-android_device_samsung_universal7904-common",
+    "rev": "24c6842d087a0107235fd8b5ac9a875c57de525f",
+    "sha256": "0yp85gxjg399c1ijrid1xp4d5if1a0pcb2nz0mlzdjb31c327596",
+    "url": "https://github.com/LineageOS/android_device_samsung_universal7904-common"
+  },
+  "device/samsung_slsi/sepolicy": {
+    "date": "2022-01-08T09:55:58+05:30",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/f2179rxw24k1wjz3siwk3736j247vclm-android_device_samsung_slsi_sepolicy",
+    "rev": "15bb890c8de68959705314e15c7bb19ef6a93dd1",
+    "sha256": "0cilp9j3xcyxqnbcl4lbfqsr3m9wf6s5rmdb7pypkc08pl5gyak7",
+    "url": "https://github.com/LineageOS/android_device_samsung_slsi_sepolicy"
+  },
+  "device/shift/axolotl": {
+    "date": "2022-01-18T10:43:14+01:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/shift/sdm845"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/y0pz01xr0fldgyapwsh43s89k00bd2qr-android_device_shift_axolotl",
+    "rev": "c15b888d77c39c5b320832bbdd53a73716c9a1a3",
+    "sha256": "05ndc4xyc140in4i7lda5ac17lisxjh0svcz833jn8wrnc1iq7xp",
+    "url": "https://github.com/LineageOS/android_device_shift_axolotl"
+  },
+  "device/xiaomi/beryllium": {
+    "date": "2021-12-28T14:29:49+00:00",
+    "deepClone": false,
+    "deps": [
+      "device/xiaomi/sdm845-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/5y4s3hny94jjykjb16yz6zgl5gci0c4r-android_device_xiaomi_beryllium",
+    "rev": "f89ca4f84860fb89e280c001aabde40b3de9b9bd",
+    "sha256": "1hknw8gsq6awzx4ljr6k2lzgx58vhlc05iwsjc33y9xqpm2l4f90",
+    "url": "https://github.com/LineageOS/android_device_xiaomi_beryllium"
+  },
+  "device/xiaomi/dipper": {
+    "date": "2021-06-28T08:21:00+08:00",
+    "deepClone": false,
+    "deps": [
+      "device/xiaomi/sdm845-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/6nr8bpapa5h488lznlrgwpl1ppm1lbi0-android_device_xiaomi_dipper",
+    "rev": "9c657f076228744ad0339499aecd5cbf826db63d",
+    "sha256": "020avrlysjqyki1l62pw1mkz6adxgxhwba7l74i5vw7h08kv97pv",
+    "url": "https://github.com/LineageOS/android_device_xiaomi_dipper"
+  },
+  "device/xiaomi/polaris": {
+    "date": "2021-04-28T19:21:02+02:00",
+    "deepClone": false,
+    "deps": [
+      "device/xiaomi/sdm845-common"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/m9wwdfjjayfzxqgbgwg0zr2m1ca0yf1i-android_device_xiaomi_polaris",
+    "rev": "9e70b33f07477eb6ab236614272c0a8bc09acd06",
+    "sha256": "0lb833ngnnk4whkiln60a280xc0qy0hsdhlzqnsp1l33190m4qy0",
+    "url": "https://github.com/LineageOS/android_device_xiaomi_polaris"
+  },
+  "device/xiaomi/sdm845-common": {
+    "date": "2021-12-15T10:30:01+01:00",
+    "deepClone": false,
+    "deps": [
+      "hardware/xiaomi",
+      "kernel/xiaomi/sdm845"
+    ],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/4vdbps0093yg52vy58a5jv6gc49ya9x2-android_device_xiaomi_sdm845-common",
+    "rev": "f1d96e6ca8fc84692eb67a884ede145646829551",
+    "sha256": "0absj8wxaiiprwj61sll1r0xxbwvi9l8an62icskiz6zzm3809mq",
+    "url": "https://github.com/LineageOS/android_device_xiaomi_sdm845-common"
+  },
+  "hardware/oneplus": {
+    "date": "2021-11-09T08:01:23+01:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/hj1kncska6ifp36k8s2fxgs875zkv108-android_hardware_oneplus",
+    "rev": "fd9b216aacf384b5a005f2e14241dbea8bfcc80d",
+    "sha256": "0n4bsqibkxsb1nl49qvhp9b22iccayf3m7qycd5k0rz6px8slmap",
+    "url": "https://github.com/LineageOS/android_hardware_oneplus"
+  },
+  "hardware/samsung": {
+    "date": "2022-01-13T22:52:27+00:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/g1v69bppsqnf19hzkls5m4nd70pjmdk1-android_hardware_samsung",
+    "rev": "2ff0392c1dc8ba6a7089130dfc0894a558bfbdd1",
+    "sha256": "1ail3dav153pvm00i102v5lrkmnxircvljy0dhk6psic1ng29z62",
+    "url": "https://github.com/LineageOS/android_hardware_samsung"
+  },
+  "hardware/samsung_slsi/libbt": {
+    "date": "2020-09-08T22:18:42+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/q9r6l6i7v68lrx4b5h0nbvlyad1sz6wp-android_hardware_samsung_slsi_libbt",
+    "rev": "f63a27ddba458a81db739f2adbd42abf075b9c18",
+    "sha256": "01xh5jaapz5bmdbpbadhnd2np292893sdp34f0zr75v60vbdyf55",
+    "url": "https://github.com/LineageOS/android_hardware_samsung_slsi_libbt"
+  },
+  "hardware/samsung_slsi/scsc_wifibt/wifi_hal": {
+    "date": "2021-11-24T09:28:20+05:30",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/b0vdd7m19yn9r7nch1qxkbyiwbjh8v42-android_hardware_samsung_slsi_scsc_wifibt_wifi_hal",
+    "rev": "dec43d779a232ae246b90fac49ebed182ea97817",
+    "sha256": "1nx10l9g35l9kap2df8r9zh3qc0qbk5jbqsbnrp9zgnsd8nkr7jx",
+    "url": "https://github.com/LineageOS/android_hardware_samsung_slsi_scsc_wifibt_wifi_hal"
+  },
+  "hardware/samsung_slsi/scsc_wifibt/wpa_supplicant_lib": {
+    "date": "2021-07-23T01:37:05+09:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/sibi7k92dciw8f7ng8dbybhxdsw9arm8-android_hardware_samsung_slsi_scsc_wifibt_wpa_supplicant_lib",
+    "rev": "70f4bf60f26b49401439ca56ece4c984d8c6952b",
+    "sha256": "14pvd205l1p2cklla5nn8m2qyq9x133bii4skdd02kmrb2iy5r8a",
+    "url": "https://github.com/LineageOS/android_hardware_samsung_slsi_scsc_wifibt_wpa_supplicant_lib"
+  },
+  "hardware/xiaomi": {
+    "date": "2021-10-18T23:40:43+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/zb41jm32i6kbbh3zzb3430cx3827ddb2-android_hardware_xiaomi",
+    "rev": "8fb3a9d7221cee2586ac1d63c79133546dfe2368",
+    "sha256": "0x8kb84js83z4fv4pm43ia5bp6c3vgqyd1c3c5m02hpcp0bfn52a",
+    "url": "https://github.com/LineageOS/android_hardware_xiaomi"
+  },
+  "kernel/asus/sm8350": {
+    "date": "2021-11-26T16:03:12-07:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/licapz5i3jalj2y7jh938pz958lqxq39-android_kernel_asus_sm8350",
+    "rev": "5dd81f5a411ec0be98ab2b5a8a41e8a3251c31ae",
+    "sha256": "0h9a7g5jd73ffjdsiaw9ydqjw6lnsm9z57zh1y01whc7nhxv5lnl",
+    "url": "https://github.com/LineageOS/android_kernel_asus_sm8350"
+  },
+  "kernel/google/msm-4.14": {
+    "date": "2022-01-14T00:13:43+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/dzavgy2l74ia8rf4s52m9k5pr133wayl-android_kernel_google_msm-4.14",
+    "rev": "094de4ce3c83abdf1325a334527d138249c345c8",
+    "sha256": "1w4z04wwcji6a17g8hsrk8jp2qh867v2ldvrhw75cpmcq8hmrw11",
+    "url": "https://github.com/LineageOS/android_kernel_google_msm-4.14"
+  },
+  "kernel/google/msm-4.9": {
+    "date": "2022-01-13T23:57:39+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/hvaxivbb8jx6sn1lic6n1qrx6wnp1wyn-android_kernel_google_msm-4.9",
+    "rev": "582e69474aa6889cc86fe4df81d96e5271ef4901",
+    "sha256": "12l6shm38wfahpsl9z1816w564dhqwgcj6f1d7kzhnxxwj575cbr",
+    "url": "https://github.com/LineageOS/android_kernel_google_msm-4.9"
+  },
+  "kernel/google/redbull": {
+    "date": "2022-01-14T00:36:11+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/d61bw0q8sb5nlffjc66ap2xqbq4hsbvv-android_kernel_google_redbull",
+    "rev": "2e93211233a1651e2df49994ed2c2b93990ed8a1",
+    "sha256": "0xsqh9bhscz7phqmippx77macdapd8njni57n0fgmln2dqyxf5qn",
+    "url": "https://github.com/LineageOS/android_kernel_google_redbull"
+  },
+  "kernel/samsung/exynos9820": {
+    "date": "2021-11-01T15:30:53+01:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/yz2hn51hi0q0wzb3bgbpkw3807mhcj1n-android_kernel_samsung_exynos9820",
+    "rev": "58f9a93436d4785b5689bd9a330dda61c217dfe0",
+    "sha256": "160ja2zyblbwjfpv4cy1fxzrqqihv5mfny3s25f5zzdq7df037nz",
+    "url": "https://github.com/LineageOS/android_kernel_samsung_exynos9820"
+  },
+  "kernel/samsung/gta4xl": {
+    "date": "2021-11-26T07:41:58-07:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/bn53mj11s37v60jw0mp29wj6f67cjdaw-android_kernel_samsung_gta4xl",
+    "rev": "3407d28db5f12ef7a160e15a21c97ad254b0b942",
+    "sha256": "0p56f6x7d54djxkzg3wg0his2hw0y6myjfyqi1wsnwmqn97jlcsp",
+    "url": "https://github.com/LineageOS/android_kernel_samsung_gta4xl"
+  },
+  "kernel/shift/sdm845": {
+    "date": "2022-01-14T09:37:06+01:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/5gyqgznsyi60szciw1s1006x5a8mkgq9-android_kernel_shift_sdm845",
+    "rev": "e847b8e42a47349ee2453e5d65d44f77071bc888",
+    "sha256": "1cics6lzy7wwf7l11hj9yhai852midz4dnif6315a1a7aw99pspb",
+    "url": "https://github.com/LineageOS/android_kernel_shift_sdm845"
+  },
+  "kernel/xiaomi/sdm845": {
+    "date": "2022-01-11T23:43:37+00:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/y0kckakgswg46j0inx1xis10shlglawy-android_kernel_xiaomi_sdm845",
+    "rev": "f9e515877b784b81fe5439d2c922750f1d934cc8",
+    "sha256": "1vdq2w9q5qj6z6m1d0sc1ydkpmv4s9g8vbdhwijr2mk6zg57b7if",
+    "url": "https://github.com/LineageOS/android_kernel_xiaomi_sdm845"
+  },
+  "packages/apps/ElmyraService": {
+    "date": "2022-01-12T17:19:08+02:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/k8i214by1rsiklycw9bim4b48a83yf9n-android_packages_apps_ElmyraService",
+    "rev": "d9375cbe19b2054c2f476348eeac56aff5eba5cf",
+    "sha256": "1pr4d61b5pma2sb0di2v686816r71rz2x95czlnnax61adbl7rsj",
+    "url": "https://github.com/LineageOS/android_packages_apps_ElmyraService"
+  }
+}

--- a/flavors/lineageos/lineage-19.0/repo.json
+++ b/flavors/lineageos/lineage-19.0/repo.json
@@ -1,0 +1,10800 @@
+{
+  "android": {
+    "dateTime": 1642263042,
+    "groups": [],
+    "rev": "9dff3d1eabe896bf1e6f93396d5ebcd4fef7f47c",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1hx7w6ih0ls5y5mvp3824l5s1vw2fv5w67jdvgm5bsa1wm90p5la",
+    "url": "https://github.com/LineageOS/android"
+  },
+  "art": {
+    "dateTime": 1635476367,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "267bff0378b4b875641487dae257b7a2554a8852",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q5l3x7qdyz6a11pgqbfsjf7frfnhxrz5nms5rcijfg9swahrh2b",
+    "url": "https://android.googlesource.com/platform/art"
+  },
+  "bionic": {
+    "dateTime": 1641127395,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cff260ec89bfdcfe2944f7d93f31d2cf9095c801",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0q326j2gglmnwwhs01yzj6vskvshv5xpzk2zm7chj1n7bfrp1sip",
+    "url": "https://github.com/LineageOS/android_bionic"
+  },
+  "bootable/libbootloader": {
+    "dateTime": 1616521027,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d1b40207399b542e38ea1ecafb338a847dbca659",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1g10xsdj43z21cw7yl1mg70jdmgf27xqm713al4bvpqy7g3l177j",
+    "url": "https://android.googlesource.com/platform/bootable/libbootloader"
+  },
+  "bootable/recovery": {
+    "dateTime": 1639515118,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "82e3efd15e89dea7c708f2c8d9d0f1bb1955ca69",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0w74x7lnsxfvs5v6588003m2qyamm08rq32qamzfq11p56jnaga5",
+    "url": "https://github.com/LineageOS/android_bootable_recovery"
+  },
+  "build/bazel": {
+    "dateTime": 1620912184,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "WORKSPACE",
+        "src": "bazel.WORKSPACE"
+      },
+      {
+        "dest": "tools/bazel",
+        "src": "bazel.sh"
+      },
+      {
+        "dest": "BUILD",
+        "src": "bazel.BUILD"
+      }
+    ],
+    "rev": "66ac50d71063df9afa5fcd1d782e84391f86a628",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jsyl5fjbqna5vw2w3qqn6p9gr9rln6mkzisd0dqz1i8wh7nw1rf",
+    "url": "https://android.googlesource.com/platform/build/bazel"
+  },
+  "build/blueprint": {
+    "dateTime": 1621853205,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "28eb87a7495b99f6a8a2a980ad389270572d32af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yi42fwvv679pfpr4vxy7vfrqr4la043a7s57rpbw2k5v7h6vm2y",
+    "url": "https://android.googlesource.com/platform/build/blueprint"
+  },
+  "build/make": {
+    "copyfiles": [
+      {
+        "dest": "Makefile",
+        "src": "core/root.mk"
+      }
+    ],
+    "dateTime": 1642213934,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "build/CleanSpec.mk",
+        "src": "CleanSpec.mk"
+      },
+      {
+        "dest": "build/buildspec.mk.default",
+        "src": "buildspec.mk.default"
+      },
+      {
+        "dest": "build/core",
+        "src": "core"
+      },
+      {
+        "dest": "build/envsetup.sh",
+        "src": "envsetup.sh"
+      },
+      {
+        "dest": "build/target",
+        "src": "target"
+      },
+      {
+        "dest": "build/tools",
+        "src": "tools"
+      }
+    ],
+    "rev": "c7d03df1386253b6e4aa43c7fe48d6173b365c8a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1jn2pjy4i7zqsrwd5jymad52q78ig7svax3z593j852mbiprfp5m",
+    "url": "https://github.com/LineageOS/android_build"
+  },
+  "build/pesto": {
+    "dateTime": 1620840185,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eab614a30eedd5e183cb03bede8294004714861a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cgw3nmazi87f7qam00szqzy37laz7lv5w9l5zagniv5z0kjl10j",
+    "url": "https://android.googlesource.com/platform/build/pesto"
+  },
+  "build/soong": {
+    "dateTime": 1639590409,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "linkfiles": [
+      {
+        "dest": "Android.bp",
+        "src": "root.bp"
+      },
+      {
+        "dest": "bootstrap.bash",
+        "src": "bootstrap.bash"
+      }
+    ],
+    "rev": "b724febb956f8e209936ff5cc36d6c3d6f5370d4",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0jc3fi5k53lj8dh5fxdscqgahhgr83ywqz7dkmw95f3cc709jhm1",
+    "url": "https://github.com/LineageOS/android_build_soong"
+  },
+  "compatibility/cdd": {
+    "dateTime": 1618861524,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f81ac3b554a1d801c915ceedccb59dae9f4167df",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04l9jdf0i7pf4lq3dxrik4gg3k00v2r3dr9mp6bznf6mm37cvzh9",
+    "url": "https://android.googlesource.com/platform/compatibility/cdd"
+  },
+  "cts": {
+    "dateTime": 1640531095,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8cf9aa78bf1c02c464f6aef2e7c52b07e7997a11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jbffqg6g2y90mdrxvgm4yn8g20d9ihxqmq175n6y5m8sh1ic8ah",
+    "url": "https://android.googlesource.com/platform/cts"
+  },
+  "dalvik": {
+    "dateTime": 1617898924,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "75bc2c404a03b08dd29d4c07d0e947099b64c276",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18iw5p98mm7wnfjd0yhnb1fcrnjwrigp1apbz2lyizlm95hkgz2v",
+    "url": "https://android.googlesource.com/platform/dalvik"
+  },
+  "developers/build": {
+    "dateTime": 1613823750,
+    "groups": [
+      "developers",
+      "pdk"
+    ],
+    "rev": "49ba0b0d72e6a4dbc2bb4ba05f8237d1b80fc359",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0pvgglif7iy8n6sx8xkxw7xf6gcv60lgfh4kbd4k1ry75rb1hfy3",
+    "url": "https://android.googlesource.com/platform/developers/build"
+  },
+  "development": {
+    "dateTime": 1629870092,
+    "groups": [
+      "developers",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7707b5aff0056a1788fe5758d48ee12271ee49af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03cjbillfbqs8hpzfpvxbgb6vb0jyxnk6wrkcbxryxdn90jsn3c7",
+    "url": "https://android.googlesource.com/platform/development"
+  },
+  "device/common": {
+    "dateTime": 1630361020,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs"
+    ],
+    "rev": "3b037b3abe5a57849abf73de773a01fdecc65266",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l39hk80ai2nsxjcbqg9kgf4xyb5s05kjijvswg2w055j0cmxsi9",
+    "url": "https://android.googlesource.com/device/common"
+  },
+  "device/generic/arm64": {
+    "dateTime": 1588703768,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ae09aac298ec8df4a0c524896a5e990a6c7b8ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l66va61ybzf224l9q2gq60i132ikb75k58h1za1faq18m8hwvyx",
+    "url": "https://android.googlesource.com/device/generic/arm64"
+  },
+  "device/generic/armv7-a-neon": {
+    "dateTime": 1614993775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dfc68e43c5c25ebdd289f3a4da89adc5faabb687",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1986xyq0p2cqf4bgw3xf21qjszbidll8iwz2snzvffapybhr1213",
+    "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
+  },
+  "device/generic/art": {
+    "dateTime": 1613834499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "431da08d4fd02ca5d55a9cfd82af2d9bc7d56d34",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ijzwbsqb7xhzlj1bc84mp6hx782q30cvdsk4z6m36yibwlmkd97",
+    "url": "https://android.googlesource.com/device/generic/art"
+  },
+  "device/generic/car": {
+    "dateTime": 1628039971,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a90acc1a65c5fab882990c1df6bcc25351036e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rlgpfbiv77038zlys5rxwpb1hv99gfdw01vkqwpmd9fjdr1xvbv",
+    "url": "https://android.googlesource.com/device/generic/car"
+  },
+  "device/generic/common": {
+    "dateTime": 1621414074,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ea35cdf94bca987389101bb8afe1ec9fa0dbd0c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1fvph5bf626bja9c0fq8c849qc7vgj5nnwasyjs5gkbhgzx0s9hc",
+    "url": "https://android.googlesource.com/device/generic/common"
+  },
+  "device/generic/goldfish": {
+    "dateTime": 1634353249,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64bce5a1739ba687b4d7b9aa1023b8407bba6ba6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09b8naf7hb03wfb5qcr9k78w3vh3bs0dm5c4178g9g95ddl67iga",
+    "url": "https://android.googlesource.com/device/generic/goldfish"
+  },
+  "device/generic/goldfish-opengl": {
+    "dateTime": 1631311649,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d081c0579693e2247fcf153266bbeb54b457d4b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07lr2xssjibvn22gaca19z9lz99rf8p6qzgdp33zg65368dfkl3k",
+    "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
+  },
+  "device/generic/mini-emulator-arm64": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddbff8ff46cd0441b666985b96ab1d02d9fc700e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
+  },
+  "device/generic/mini-emulator-armv7-a-neon": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "661c2c995d203a69969986b3ccda59188da3af27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
+  },
+  "device/generic/mini-emulator-x86": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "66c28d5a6f73415636430cc0d7548bfbd7402c1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
+  },
+  "device/generic/mini-emulator-x86_64": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04b8a3b7f779c402b76b994eb8d55fbe8b314fca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
+  },
+  "device/generic/qemu": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d7dc0a7f56668fa1710f5000fb41ee15daf216d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/generic/qemu"
+  },
+  "device/generic/trusty": {
+    "dateTime": 1620754469,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bac7be1a2957771f48403b9df61b5348ae3885c4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hj6w5lsdahw94dh8zgj2a6zs1vidcxdyi0wsxm7zwsvl1pwmrmr",
+    "url": "https://android.googlesource.com/device/generic/trusty"
+  },
+  "device/generic/uml": {
+    "dateTime": 1613829303,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "d9b54b345d4f883fada7fde9eb973322b5b76014",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18ninwq7gwgxxkrf5pgqfd05n8wjfnl9wc2wmwrs9r4kzgawmhgs",
+    "url": "https://android.googlesource.com/device/generic/uml"
+  },
+  "device/generic/vulkan-cereal": {
+    "dateTime": 1621016465,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "56ba159617bed11e929864491794366394a0e709",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1702hi0dw0rsar4dh0acgy7na6qcw0gv6cryidx1kpql6g8i265k",
+    "url": "https://android.googlesource.com/device/generic/vulkan-cereal"
+  },
+  "device/generic/x86": {
+    "dateTime": 1588705083,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6bb44a5b167d789f92d2ba40c66e8e1358d650f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1msvricg8asj7vhkpfx4vd3jykdg3xqs0yhrvhj7m48lhsandfdz",
+    "url": "https://android.googlesource.com/device/generic/x86"
+  },
+  "device/generic/x86_64": {
+    "dateTime": 1588704382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2e5a769ef7503203049e651f432865a97d007aad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1w7b33sap7ym1y23435n3cjsbvl8ws49m46lk8h1kgy8apg08mkw",
+    "url": "https://android.googlesource.com/device/generic/x86_64"
+  },
+  "device/google/atv": {
+    "dateTime": 1638489333,
+    "groups": [
+      "broadcom_pdk",
+      "device",
+      "generic_fs",
+      "pdk"
+    ],
+    "rev": "ddf6a0439140c12f3d4ad55ec3a00fda25c8347b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0s7ys98slicnd3lgfb8ji95b0iqgqqz5di8y7ak1svhd7nbpdi9m",
+    "url": "https://github.com/LineageOS/android_device_google_atv"
+  },
+  "device/google/contexthub": {
+    "dateTime": 1620164601,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "a76f4276b5a9821764758ffb3f0f10feac8b8413",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vs3ya2smc8qdhwlwiy4ksy2qfkwd6limy58kvwy12gbgcyqx483",
+    "url": "https://android.googlesource.com/device/google/contexthub"
+  },
+  "device/google/cuttlefish": {
+    "dateTime": 1633395662,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "4b9c1af38a5f08e4e02a6674a88276d9b8ae1ae9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ma4m33y8w0sx0jrd43i25h4i98xh6y6g8pfhfzm02b03nvfvngk",
+    "url": "https://android.googlesource.com/device/google/cuttlefish"
+  },
+  "device/google/cuttlefish_prebuilts": {
+    "dateTime": 1633568493,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "bbea0d9ba8d038ac62d0648141c1317b7c21c0b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1scgp6scm0mzqqc0bv59fzm50gb53jij1nbrza5p9vxfdr6kl3kd",
+    "url": "https://android.googlesource.com/device/google/cuttlefish_prebuilts"
+  },
+  "device/google/vrservices": {
+    "dateTime": 1613821483,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6873ee29419d3c641b1bcab13856b922ea480ba9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bqfiyv18g1il413rkmyhz4prkmq85ww4sh2d5i0rzpddc9rldjy",
+    "url": "https://android.googlesource.com/device/google/vrservices"
+  },
+  "device/lineage/atv": {
+    "dateTime": 1641321847,
+    "groups": [],
+    "rev": "73ee1e093482b6107803bb7918f5ad9d45ed2daa",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0sfzf9x4kql1msa1adx9473p573z3yxxc5ls7jxz0mkpa05hd5gv",
+    "url": "https://github.com/LineageOS/android_device_lineage_atv"
+  },
+  "device/lineage/car": {
+    "dateTime": 1626332915,
+    "groups": [],
+    "rev": "ac49fa77109148dfe3d6e433e179b09d83aa1e69",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1svwcxymhg8jqxs3ax443rb1ry0vr6kb4p8vfqpyi47hl9in00rk",
+    "url": "https://github.com/LineageOS/android_device_lineage_car"
+  },
+  "device/lineage/sepolicy": {
+    "dateTime": 1641491159,
+    "groups": [],
+    "rev": "a681fbc9795557c50539370c22cfc128a5fe339b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0wrvyad9fbqijlilx92h9zkm8k0s8alyxjb3r462w2bcny9j24k2",
+    "url": "https://github.com/LineageOS/android_device_lineage_sepolicy"
+  },
+  "device/qcom/sepolicy-legacy-um": {
+    "dateTime": 1641619558,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "ccc04106487b5e8e47e29d2a2755ae072174e809",
+    "revisionExpr": "lineage-19.0-legacy-um",
+    "sha256": "11g2jiphqwyfs0fwzm35p2y2m8xgwiw98yq1jzzh6lj5dy8d1bzj",
+    "url": "https://github.com/LineageOS/android_device_qcom_sepolicy"
+  },
+  "device/sample": {
+    "dateTime": 1620388245,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a562f50ebf8202186478b1c137b285cfffcbf7e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "14iyki70hlnb95i416izsw29hiyfpj1dnfb2pxnrr82qy3xk6dr7",
+    "url": "https://android.googlesource.com/device/sample"
+  },
+  "external/ComputeLibrary": {
+    "dateTime": 1614666515,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "fcddded3b981f58de607b308f58b2e8a6374b5cf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k1ian6l5wkr2lgbn061rqggrv2k37z8x56jw2k005ga020qb71k",
+    "url": "https://android.googlesource.com/platform/external/ComputeLibrary"
+  },
+  "external/FP16": {
+    "dateTime": 1613692256,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "95098b8418f4ef7accf20e99baaccb689e3ba987",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13lwr9v1rhr35mlvhzvwhwx9zcsry9nmin57w8wy8f3jm3m65lsd",
+    "url": "https://android.googlesource.com/platform/external/FP16"
+  },
+  "external/FXdiv": {
+    "dateTime": 1613828351,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d39ec24ee981e81da5f2f47b5b9657be6ddbfa27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1804qzjg3vn7crqfzb8qv4f8sz5gl09b6h1lsgdr2plz2iga6b6m",
+    "url": "https://android.googlesource.com/platform/external/FXdiv"
+  },
+  "external/ImageMagick": {
+    "dateTime": 1619030979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39c9d2a31ed7ae09f47408392a2bb77142c483e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06ngnvlj2yd1n5r9d5jg914br23ynp0hjwqlvcp9kyb9wnz8n7ll",
+    "url": "https://android.googlesource.com/platform/external/ImageMagick"
+  },
+  "external/OpenCL-CTS": {
+    "dateTime": 1621445785,
+    "groups": [],
+    "rev": "dde1869eb746edd8e5d9d292141369d55808e4be",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vs5jdpd0mxglmpcs0yjf778ink7mhkliahd7py6smw8mlram7kx",
+    "url": "https://android.googlesource.com/platform/external/OpenCL-CTS"
+  },
+  "external/OpenCSD": {
+    "dateTime": 1613823814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93cfff8bb015396bea979db38e8ddaa9ab21f9ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b3sn1yxyjl7ghzvgq2fk50q1q52s5wbwg7lgdd37kn0dfj8f7pw",
+    "url": "https://android.googlesource.com/platform/external/OpenCSD"
+  },
+  "external/Reactive-Extensions/RxCpp": {
+    "dateTime": 1613582546,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e57817bfad4d163de712534ed69938b2756d3cc3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ydkh937q0vss0y5zid0zfrhlvk0rib57g2cnylzl2f667svabr0",
+    "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
+  },
+  "external/XNNPACK": {
+    "dateTime": 1616547430,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b53c1c799f2a5d3fe7a728990f07d6037aae0856",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ps0gzf10n84ppcv23m03knwbllqd6x1skvn69sn6ssfiw12slwh",
+    "url": "https://android.googlesource.com/platform/external/XNNPACK"
+  },
+  "external/aac": {
+    "dateTime": 1620503750,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "236499aad909221b26debfa8badc2c7eacdc3d50",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bg8wabf6snkr7fy3izis441jhqhag1gngi53dlzfk7g7ljiz3if",
+    "url": "https://android.googlesource.com/platform/external/aac"
+  },
+  "external/abseil-cpp": {
+    "dateTime": 1613516541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0fb733d08b18f82bde95cb422cb8bfd72c702546",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "090a9pkyc3pxqz1pa42kmgqzqn3cs80f4arabm9sffnkxgds1254",
+    "url": "https://android.googlesource.com/platform/external/abseil-cpp"
+  },
+  "external/adhd": {
+    "dateTime": 1618259723,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a39d6673b3cf1d2de5a1ae0ec99cb5dcf45169f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k726ay3gq777jc9g57aqcnfvafh9xxhkfahcgi4mjcys6x60rbd",
+    "url": "https://android.googlesource.com/platform/external/adhd"
+  },
+  "external/android-clat": {
+    "dateTime": 1622589567,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2643968020cba18b7594dc7e8426f7a005116a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08bddsbl7za78ac6drf63pmpimyqcjkqp3xkjacqqppa16gk15f0",
+    "url": "https://android.googlesource.com/platform/external/android-clat"
+  },
+  "external/android-nn-driver": {
+    "dateTime": 1641349414,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "3c716eaf79e6913db53984f4aef26132cb5e13b9",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "142g9fr2cgl4zav2h9w0pr7z20a89zxbsb7iw88w4130sc23is1w",
+    "url": "https://github.com/LineageOS/android_external_android-nn-driver"
+  },
+  "external/androidplot": {
+    "dateTime": 1619205494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cddadef64739fa387c738aafae5542cbf006fa39",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dxx539y2fbys0v3108mvk6ac875rjz6sw552xa2mhdhj5hywx32",
+    "url": "https://android.googlesource.com/platform/external/androidplot"
+  },
+  "external/angle": {
+    "dateTime": 1631650514,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0e2bd12b5ed3765e0cf3e63f5ff8a981537a081",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sgr6i1qw61gi1brgqpxrcnnlp8ibq9ar8lzm577xxrjrivp3j21",
+    "url": "https://android.googlesource.com/platform/external/angle"
+  },
+  "external/ant-glob": {
+    "dateTime": 1613582543,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c52eff266c361f867dddd5d9684b7f745d074c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kv13x3rrjv04fyipfjgdmvbj9c22wb4ws8xikp2byvqss5qfyfj",
+    "url": "https://android.googlesource.com/platform/external/ant-glob"
+  },
+  "external/ant-wireless/ant_client": {
+    "dateTime": 1631057764,
+    "groups": [],
+    "rev": "9598c3df9cd82abb1922d9fb35525d247bf78f14",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1nv7iyya9v29h7c7y3jj44yfm06327dxc3mryg617y58izbgd7xn",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_ant_client"
+  },
+  "external/ant-wireless/ant_native": {
+    "dateTime": 1579643644,
+    "groups": [],
+    "rev": "c674e613ac60fcd7583ca26bbb8878eec6aec851",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0ymmapg5vfa2mqz1f6d93l3w8amnwyv22h1jd123rambh40yjbag",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_ant_native"
+  },
+  "external/ant-wireless/ant_service": {
+    "dateTime": 1639435917,
+    "groups": [],
+    "rev": "ff44e6342b95bfc920b30d24102e536dec4c5416",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "04bkklb3bnpx12178047f19zi3ipifpajxfl0gpmcj7q1v00sp9q",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_ant_service"
+  },
+  "external/ant-wireless/hidl": {
+    "dateTime": 1633761922,
+    "groups": [],
+    "rev": "0ee5afff121f9a5172dc8188e49244a592b31fba",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "15bdg094893li9jy06sc51fp694sh8hzwwnndjkhb533x4q2w872",
+    "url": "https://github.com/LineageOS/android_external_ant-wireless_hidl"
+  },
+  "external/antlr": {
+    "dateTime": 1613516532,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1bcb750cfee3fe9dffcc174f1d0565dc8b3e040b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09m5na2mm1qbbffzvmyvkvvp48wcfyd2m90asg07adaf94pw7xkb",
+    "url": "https://android.googlesource.com/platform/external/antlr"
+  },
+  "external/apache-commons-bcel": {
+    "dateTime": 1613513322,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67bcd0956c87ba6f9162b5479390ec20b829aa08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wg1k32wz232b3d0iz8n0krpclz21l8jmmpd08ybgx410ga0nlwb",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
+  },
+  "external/apache-commons-compress": {
+    "dateTime": 1613516533,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "612c676ea534b558b430012cb092d4a905eff1b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mrr0ypp23pljll9i0xawar6h4snw52k10xnggmsrj638xi5bmms",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
+  },
+  "external/apache-commons-math": {
+    "dateTime": 1613516535,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "149420d9dbde87e71585e12baa55f683432a00eb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17f2wbjgrpyjbcxxmwyfyxfbr7ci4z14ry1vp7dac0hlzn57rpln",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-math"
+  },
+  "external/apache-harmony": {
+    "dateTime": 1621989520,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2f2fcb047055c4f32fbbeb33425f6f8cd32f0d14",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13j3zz0wjvyyy8i4n56039n96yrla6iqzng13fi02fia2wwv5vjb",
+    "url": "https://android.googlesource.com/platform/external/apache-harmony"
+  },
+  "external/apache-http": {
+    "dateTime": 1622823701,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5408d2abe6b2792600ecae57c30f91d8b5f8e585",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "180wkbj8pj021w6wizcjlnjl8giw3bs998jrxxpyrkpnjbf7nw2a",
+    "url": "https://android.googlesource.com/platform/external/apache-http"
+  },
+  "external/apache-xml": {
+    "dateTime": 1614863600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d0e3bf8cdb5e8b44edc02dc1593619692a14ad6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07p95202kf49p5wpg5fq9nc99hcjcphac903sbm8wlsvcvppw6hx",
+    "url": "https://android.googlesource.com/platform/external/apache-xml"
+  },
+  "external/arm-neon-tests": {
+    "dateTime": 1613504485,
+    "groups": [
+      "vendor"
+    ],
+    "rev": "77ae105cbd3df608ca435bc398be123098190186",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05q3rb390d3zdmva3br4r2njy8hwvnn3ny796dbbsy8fwyq6ijzg",
+    "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
+  },
+  "external/arm-optimized-routines": {
+    "dateTime": 1619680113,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c3f64a7dde7880b36a61a7b3a2a80809331790e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ag1zvd22685wxp2yk82vkwc246y2n1csqqjspx6zsbixgjrap5x",
+    "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
+  },
+  "external/arm-trusted-firmware": {
+    "dateTime": 1613512057,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7eb3bd4a5a03885d5af78733a8b139b0a104d7c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rdw9ffppv0lqb2gy6pljp9irrckg389afkb9m90nlx84cw4kg4j",
+    "url": "https://android.googlesource.com/platform/external/arm-trusted-firmware"
+  },
+  "external/armnn": {
+    "dateTime": 1641349263,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "ec5cd5612f08e1be360295a24e7539ca99392943",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1ql4pzi8v1niid01b835ss6swy7rhdaw92icqalv4jr8vnab99b3",
+    "url": "https://github.com/LineageOS/android_external_armnn"
+  },
+  "external/auto": {
+    "dateTime": 1613821355,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b88897f4035af37d4d192d8025046ebc12311f12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02zs1cf9553f3wamv53sfxpphh2ss7l6lvww39f970zdpkkr1k85",
+    "url": "https://android.googlesource.com/platform/external/auto"
+  },
+  "external/autotest": {
+    "dateTime": 1613832706,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e31cbc81773d3d7cc8d44e8bbe8f579bf3eae7d0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wnd234ci6hwfflsdf248jvmwp8dd08hcka8nll3gh0wqmy9bizf",
+    "url": "https://android.googlesource.com/platform/external/autotest"
+  },
+  "external/avb": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ac009735dd5a88b1677086a213606dd1f90036a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1s35d3zns4w00k7x2x2pvc4b2y4c8kd46rmi7x860kszkl02kvwx",
+    "url": "https://android.googlesource.com/platform/external/avb"
+  },
+  "external/bazelbuild-rules_android": {
+    "dateTime": 1616444141,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1eb2a132a25cf1dfc73ffdd80633e2d1fb45c99d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0mg4iyzaq22b9n07146vmq273vrk2f0hlyj7jm71s6vhmlqzvl3z",
+    "url": "https://android.googlesource.com/platform/external/bazelbuild-rules_android"
+  },
+  "external/bc": {
+    "dateTime": 1620322862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3de3a8b03134e422877ea0567e4764217d1bae00",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ijih5ka54195h55c019z9nq5hmb71f3smgkssnh0rmjry6h5dld",
+    "url": "https://android.googlesource.com/platform/external/bc"
+  },
+  "external/bcc": {
+    "dateTime": 1613814570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "091549abc50d64f8f6504f948f07ee3ee7ae337f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04kphwmxxnpv72ycsn8skhlc8hkmm01rb8w8x0jl0gcbcw28dbng",
+    "url": "https://android.googlesource.com/platform/external/bcc"
+  },
+  "external/blktrace": {
+    "dateTime": 1613934263,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d483b516c347bd13c53753b5a92a56d32ffc781",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v4znxs40lqzd9k5qw5my887x3ybybdfhhcf7qi3y4v9p8wqk9mw",
+    "url": "https://android.googlesource.com/platform/external/blktrace"
+  },
+  "external/boringssl": {
+    "dateTime": 1619371958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f6603aa3245aef2f4a257a7b1acb394e7e63c44",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zdzw01rab9qnsj9vn4ygk0x2i3bm2zjidl7fxwxf8z42h027bpx",
+    "url": "https://android.googlesource.com/platform/external/boringssl"
+  },
+  "external/bouncycastle": {
+    "dateTime": 1620907722,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "be907c90cdfcd2db987cf6329de706d6cc91514f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0x4sy9406gffkglnkyg1pwpi66p1mhkrhh0p1245f2mbap6zbhx4",
+    "url": "https://android.googlesource.com/platform/external/bouncycastle"
+  },
+  "external/brotli": {
+    "dateTime": 1613829216,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb6bf9f89f37ab8c10a954bdc74efb7a5beb1ed4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jjahi9515i5fchmym5rc9fk63hh8dmmbacpvf5q8bfb96vc52bg",
+    "url": "https://android.googlesource.com/platform/external/brotli"
+  },
+  "external/bsdiff": {
+    "dateTime": 1618891219,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c44647e287a465e23697dacd185568956d120e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bvvbndadhzqsl8avqwzxag02i90zmplbzw5xfiprdrbzr3l07im",
+    "url": "https://android.googlesource.com/platform/external/bsdiff"
+  },
+  "external/bzip2": {
+    "dateTime": 1613834102,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ce6db7bbcbd569600c4c38bef64c9afefbff4a73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vc2m1fz3dhypn771zbhfdf1my1lgm1naz08zyfcm62j6p0263sw",
+    "url": "https://android.googlesource.com/platform/external/bzip2"
+  },
+  "external/caliper": {
+    "dateTime": 1614282416,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "83159506859460313eb1904ed1c8360d3d7e20ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hg2c1b1vqrx3ky9s1s9bdalvpf47sgm2w2m3cwwc66p92x9sk8y",
+    "url": "https://android.googlesource.com/platform/external/caliper"
+  },
+  "external/capstone": {
+    "dateTime": 1613835333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c18d1d02b15d90cb50c86493881c2675d4a710a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "181svy2yh8400xdjbz09rfmkzbzic8i8zjpj3mmicpq3lrbp37lz",
+    "url": "https://android.googlesource.com/platform/external/capstone"
+  },
+  "external/catch2": {
+    "dateTime": 1613516546,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee8b2931cd6802aa0f99d960903357af0964da4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "121f7mvnhl9ss3ckwliiqfdkpi0c1siq7vy2ghd46lk17yc7lc7l",
+    "url": "https://android.googlesource.com/platform/external/catch2"
+  },
+  "external/cblas": {
+    "dateTime": 1613582538,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bfc32c0f8888d2131e2d228ee22ea4be1283396d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vs0bvv7jxg9v853ys0262523qw6f83vlyzkq8dfrsvnsycakzzf",
+    "url": "https://android.googlesource.com/platform/external/cblas"
+  },
+  "external/cbor-java": {
+    "dateTime": 1613516547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6e32b4081e81803462bd9f3f6f19bd4dce953c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18ycp109z76isyfi7pac2nd9idi23wpywkbndp9ki1h69mwr2zmm",
+    "url": "https://android.googlesource.com/platform/external/cbor-java"
+  },
+  "external/chromium-trace": {
+    "dateTime": 1619035266,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "748eeb0a79f235198b844f6e14360a6a7af5966c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0alb6ykda1vi6n2g1cw3b3p871c9bpz4xgi163p7kz39hpwv4h5p",
+    "url": "https://android.googlesource.com/platform/external/chromium-trace"
+  },
+  "external/chromium-webview": {
+    "dateTime": 1623977980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51e3b0e8c52d17a8c1e4f86cdc731c35b4d58cbb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p4kh9ph8ijnldlkv9yp61aabwba0q3qipq2i1my6073f9fi0r78",
+    "url": "https://android.googlesource.com/platform/external/chromium-webview"
+  },
+  "external/clang": {
+    "dateTime": 1613822470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df3f64e94d879d9f35211f3f407ab9014eaebce2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06jjzh7xg63a852m61x1dy5mk32g505srm9qax981y1fiqy4pr9b",
+    "url": "https://android.googlesource.com/platform/external/clang"
+  },
+  "external/cldr": {
+    "dateTime": 1619792850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f49d339e058c84929776caac3c961b52be262ce1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10956w4glpps3sfa2qf69jn75y64vkbxjc0ra11pfx3is0xvbxmc",
+    "url": "https://android.googlesource.com/platform/external/cldr"
+  },
+  "external/cn-cbor": {
+    "dateTime": 1613582536,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b99cf1b25c758cd5725ae847ac7482c8af3ae9f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gh910wa3zrdk8jaghbbrwhr5cwxj2jiji98b00i79vdndi9fkp4",
+    "url": "https://android.googlesource.com/platform/external/cn-cbor"
+  },
+  "external/compiler-rt": {
+    "dateTime": 1613821530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73b16b948fd50f2dcca9b01b41aa85fb13c8dde1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sxxwngwcb9z6x3f9i7fw8j08h27wvzhdnmwxbrx2kz2zphm4gwn",
+    "url": "https://android.googlesource.com/platform/external/compiler-rt"
+  },
+  "external/connectedappssdk": {
+    "dateTime": 1621418517,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8713a3a1a9f631b40a1520c045ae773602a4868f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vavn5xrv27dqs41ijz6h5sp54ysb0azwkn4vzpzwwvvbkdxgdfi",
+    "url": "https://android.googlesource.com/platform/external/connectedappssdk"
+  },
+  "external/conscrypt": {
+    "dateTime": 1628888011,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "500ccf997a3f146d07febad5f640483285f17482",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g9kibaj663hwkbsd31vkxhib941gi2vz9pb757wb0afaayrhdv3",
+    "url": "https://android.googlesource.com/platform/external/conscrypt"
+  },
+  "external/cpu_features": {
+    "dateTime": 1614926428,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f00473b8f267c63ad456843bbb9c4ee5a36bf50f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "078fa0lqhy0v8nhb81yr4r80lr6d24r0xayxwzvyz9f78phvypi5",
+    "url": "https://android.googlesource.com/platform/external/cpu_features"
+  },
+  "external/cpuinfo": {
+    "dateTime": 1613824033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e0453d374a2f950c37931e0d108ca94842edb9a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0y7api7gknnfphvwz8fc751yzwj5vzzgm7zqdbrcf0r3m09my4yg",
+    "url": "https://android.googlesource.com/platform/external/cpuinfo"
+  },
+  "external/crcalc": {
+    "dateTime": 1613516535,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3dcce050eb89954a5c3f611a6c93a718c093a234",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nldnvwr197rpzigkxrdb1342vcnwh1mdazr831ynscqga55f7sc",
+    "url": "https://android.googlesource.com/platform/external/crcalc"
+  },
+  "external/cros/system_api": {
+    "dateTime": 1588165008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ee9612b05bee74c462e3062c7f58e425f762355",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jr6jiz7qjgwfm8p15lq6qh18iy25qbyr1accj1mxy2xcp3lcvnl",
+    "url": "https://android.googlesource.com/platform/external/cros/system_api"
+  },
+  "external/crosvm": {
+    "dateTime": 1620281201,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09dc36d927a6286d25fbc720784bb653603549a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ly6s74ajgf936hz3wb81cqla6a46dmxn0jk9137nqkxqyvanrfx",
+    "url": "https://android.googlesource.com/platform/external/crosvm"
+  },
+  "external/curl": {
+    "dateTime": 1613834187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b300f0642db1089aec47f6c7f62d9e4c10fe97cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wfyfdkw212wlqdmxwwm985hdm6wwcgx3lagbl373h9f9d6j7y28",
+    "url": "https://android.googlesource.com/platform/external/curl"
+  },
+  "external/dagger2": {
+    "dateTime": 1620860986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d995fb74f41105e144912fa329425f534e7c45c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0aa3q04an07rmyf3fjjs797fpm49mq4fi1y0arqdk3jcn44ha8al",
+    "url": "https://android.googlesource.com/platform/external/dagger2"
+  },
+  "external/deqp": {
+    "dateTime": 1632823903,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ea9cfc63b8dde88e54d86c0ea218be3973b6bb11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rvdnrfngy0niji5p9lqsgsccxfapjzp5fbvrf47k3z02i6ad07x",
+    "url": "https://android.googlesource.com/platform/external/deqp"
+  },
+  "external/deqp-deps/SPIRV-Headers": {
+    "dateTime": 1632823903,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b3e1648c7bfa4434969b166ee7544acaf1e9a98b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "197mx23883n4i2grsaaf7d09cbp70yajzd4ylwr186lg1q94j649",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
+  },
+  "external/deqp-deps/SPIRV-Tools": {
+    "dateTime": 1632823904,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bbac3629c886321be6ace9c237d31e8efacb5fd7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n9i57smxsy1hrqa7i0as6ky0ggcyp3y104hgmxmgzmxsch6a4n4",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
+  },
+  "external/deqp-deps/amber": {
+    "dateTime": 1615983911,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "191c4b0c1697dae3c4e40f073fc145409e57e390",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "012vrgcf5afz99avy1107z40ly4dbnvaldzmm60zm074ys2gpczv",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/amber"
+  },
+  "external/deqp-deps/glslang": {
+    "dateTime": 1615987577,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6783fc5a8cf6c9de8c29e9f2b3d7f5bb548ee582",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0m4pvypx9l7d16pslkf8imqm3k21jap1vcb05pm6213rwrgl11im",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
+  },
+  "external/desugar": {
+    "dateTime": 1613516544,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd4df200512948cb53d14a61e4ff69e17d2a8f54",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l24kgg5lm93aawfknf9igbhcag5jlacs0v1h0b2cwk7ffq6igyv",
+    "url": "https://android.googlesource.com/platform/external/desugar"
+  },
+  "external/dexmaker": {
+    "dateTime": 1613827223,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "912b4d9120ae6be6104eadd1e930cd1bfd1e9586",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c47k9acimibwfm46zkhnwxr9ijjhz300w14dwzkirwk6hacsmy4",
+    "url": "https://android.googlesource.com/platform/external/dexmaker"
+  },
+  "external/dlmalloc": {
+    "dateTime": 1588119024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "356ada6caace365363104ea2091d499a2ba09384",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yz7c4y6jppq2gxgc7bnrhis4na6r96w3i9y7rqb32hyh971ym8h",
+    "url": "https://android.googlesource.com/platform/external/dlmalloc"
+  },
+  "external/dng_sdk": {
+    "dateTime": 1613827035,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6828f5d4c78612e7e5a35a6f71b02719ab76dad6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n0kz9ffs327mwd06qj7msmfwrhyiabcvapxsr172az0skr9980p",
+    "url": "https://android.googlesource.com/platform/external/dng_sdk"
+  },
+  "external/dnsmasq": {
+    "dateTime": 1614816736,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "521c8828d514ea021488a1b000929f150eb289ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06lwhhpprrsv7bz2jysf1wjx50zmck3q7wpmnci28lc2r2b39xv1",
+    "url": "https://android.googlesource.com/platform/external/dnsmasq"
+  },
+  "external/doclava": {
+    "dateTime": 1620851375,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "371d855dce9a186f0dac9f0b5de843b1f1e2753f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1aa1aycv47aavy6j29wkivspdg6fxhrpzkb9fd7mpv7im2z134zi",
+    "url": "https://android.googlesource.com/platform/external/doclava"
+  },
+  "external/dokka": {
+    "dateTime": 1620860982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "831d13d425c2be30707a7c096c86e68bafa0b04e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n9lbm134yr4gd9lddlc6kykh0f18q4s3jvp3y09xy6r8hbilxx8",
+    "url": "https://android.googlesource.com/platform/external/dokka"
+  },
+  "external/downloader": {
+    "dateTime": 1614580415,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8fe2640d45369f31826d69e03147fc3cfab5a8b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1prbsya7mwnk2f6z7zmg4a62873kk5yfhjrki7dwb8rzwzq9mm5n",
+    "url": "https://android.googlesource.com/platform/external/downloader"
+  },
+  "external/drm_hwcomposer": {
+    "dateTime": 1613821637,
+    "groups": [
+      "drm_hwcomposer",
+      "pdk-fs"
+    ],
+    "rev": "45ca9c0553ac9eb56aa6771a862054ee1d7672fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ign732qcsnima7bv7pr63v7c58pr17pw6yrb4y9wip26jq5g54c",
+    "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
+  },
+  "external/drrickorang": {
+    "dateTime": 1613828272,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75a8c0eb82730c6528673858fe6e38943426d370",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c705icrhgcdkxlbz125yn61hglzbnyvmwj6prafs74l3jb9h2sf",
+    "url": "https://android.googlesource.com/platform/external/drrickorang"
+  },
+  "external/dtc": {
+    "dateTime": 1613830686,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cea2527ab2da06b2418b2fddf5c6cd6e3f77e57a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x6qsq1d8ay15is649cy900b6n4syl37m8705fk1x5972gm3s833",
+    "url": "https://android.googlesource.com/platform/external/dtc"
+  },
+  "external/dynamic_depth": {
+    "dateTime": 1617150017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f3de03274a8b1461231e338053efb0751584412",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11mw0dwirrrirgrap33k8dvngpilf6qdzwsz0phzbpr05900915j",
+    "url": "https://android.googlesource.com/platform/external/dynamic_depth"
+  },
+  "external/e2fsprogs": {
+    "dateTime": 1638503203,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0384df81fdf40ebf288ebeb1c1f4aa38becc4f7f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0vrpc53n7idkxcq5pbz7grmf0lmdxxpdqdg6xr63q7ggdvyz3wh7",
+    "url": "https://github.com/LineageOS/android_external_e2fsprogs"
+  },
+  "external/easymock": {
+    "dateTime": 1613934271,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3a5e1a07efbc1ee9839f057f34d495008594886",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13x8mwwilrqva7wknhcab80lhmh0j55mgdiha3w5v1crlk7nbgrz",
+    "url": "https://android.googlesource.com/platform/external/easymock"
+  },
+  "external/eigen": {
+    "dateTime": 1617150017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef69b4c5533b91c0ebd2cdb70cee010268b17e94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mja982a49hx7mzplq5vb3igzkyv659032hfha4qhg83qc5svpm3",
+    "url": "https://android.googlesource.com/platform/external/eigen"
+  },
+  "external/elfutils": {
+    "dateTime": 1613829389,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e96a913e880a4f68486955d42c605eb7df1cad4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1znxr9qbz5mgdl35g263c0n2k33siq2qhgdx0kilf566l9c7cjpp",
+    "url": "https://android.googlesource.com/platform/external/elfutils"
+  },
+  "external/emma": {
+    "dateTime": 1613587990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "539d53815aaac84ea62e1e972c435e3eb15df2bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q783p5xwhrw2hgq2lihxdz80n7gyw6pri9l8ryrzgdklxqgpdhy",
+    "url": "https://android.googlesource.com/platform/external/emma"
+  },
+  "external/erofs-utils": {
+    "dateTime": 1620783044,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c75a114a71962092481eb666b8b37c53e381b6ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jj89j02d66jzcf53yjvrv7rgbwcmfpbi8839ygab0m5zxjdlshv",
+    "url": "https://android.googlesource.com/platform/external/erofs-utils"
+  },
+  "external/error_prone": {
+    "dateTime": 1613814729,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d47030c31db0e191ddb2a3631585c53419345bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x5ikif1igni9sh9fcl9ma0k670a8gykvjv8bxl745mhzfnyfwqb",
+    "url": "https://android.googlesource.com/platform/external/error_prone"
+  },
+  "external/escapevelocity": {
+    "dateTime": 1613934267,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c358dffd344d18d35b158724d7996dcb1fc4a71",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12g3s6l40sncayrl9hvwkixb0diq5gkdf0i3j3llz8yi5i9bh1pp",
+    "url": "https://android.googlesource.com/platform/external/escapevelocity"
+  },
+  "external/ethtool": {
+    "dateTime": 1613591034,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8fb2798308b192709a435c8eb47e15ff547c18db",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17i4hhqfprqilra51s34l07rin3k32pzw36sb5xazmgr3g926giy",
+    "url": "https://android.googlesource.com/platform/external/ethtool"
+  },
+  "external/exfatprogs": {
+    "dateTime": 1636286479,
+    "groups": [],
+    "rev": "2f4a66f1eeb6284d5a5ae31d81b80d6177406a4a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "025kbrkq3namh1wdhph6cif9bjvf0a8q03cn9q0h8l5xx0xd2nk7",
+    "url": "https://github.com/LineageOS/android_external_exfatprogs"
+  },
+  "external/exoplayer": {
+    "dateTime": 1631098752,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1f27d9a2af6a294496ea362349fc54cf9a08c33",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r3zdplwd1h8x1phqmkws4ismz92vnmvvw11s3jyjpay80maqgh4",
+    "url": "https://android.googlesource.com/platform/external/exoplayer"
+  },
+  "external/expat": {
+    "dateTime": 1617411497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39ee0001990c524a17ba88806b97776961ac9533",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p1ckravpadk36lb04ahd40f2ivc921wrd21swq7n69c16g4a920",
+    "url": "https://android.googlesource.com/platform/external/expat"
+  },
+  "external/f2fs-tools": {
+    "dateTime": 1633072415,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7364459d074a03fdaa1ef18c16c1fd8b5f018445",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "062r7sgrg626wgg8wvzjimm5gd8pixd3ssm921zmw7ahfzfi9720",
+    "url": "https://android.googlesource.com/platform/external/f2fs-tools"
+  },
+  "external/fastrpc": {
+    "dateTime": 1587748082,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c96a7d480be9f2a929983626e0730bf7fe6390b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mfid59pw4qkv4zdj86g8mm0gsrdqkpc8kcwx6xbq8l42k9br4jl",
+    "url": "https://android.googlesource.com/platform/external/fastrpc"
+  },
+  "external/fdlibm": {
+    "dateTime": 1614863569,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31e7f68435db0bce2169f1b09836650354f20534",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cxx79d3l3w7p3b1pzlmnargzw8svaqx3jpl69a816ipq274y5kg",
+    "url": "https://android.googlesource.com/platform/external/fdlibm"
+  },
+  "external/fec": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a9320d1e3baf3af0df01c3aa1792ea24fa8a734",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j0s8xhs6hgzjlybzks1brkjq7xlwlr17xkvay6lkjqb57cdsqxv",
+    "url": "https://android.googlesource.com/platform/external/fec"
+  },
+  "external/fft2d": {
+    "dateTime": 1616810301,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6035f75ae29ef41fcf456b2abac3d9348c08bddd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "061p07mzli7srnhzvnz726j849446yyprlgxc300f5zwjla3cz3j",
+    "url": "https://android.googlesource.com/platform/external/fft2d"
+  },
+  "external/firebase-messaging": {
+    "dateTime": 1624818159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3466a7ce1751da8e029061e06a8bf88c031e0a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18c68j3cfc906x8glmlmcsxrbxfqy67dlim116grjmihv491zlsi",
+    "url": "https://android.googlesource.com/platform/external/firebase-messaging"
+  },
+  "external/flac": {
+    "dateTime": 1616794197,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "263f641d48c93b402556f73a5c194df28cfd4b42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bxl0m0kxfzwjk10nbm8i2fnsvn92d7793yv8bpwzqj4k7kcrg5m",
+    "url": "https://android.googlesource.com/platform/external/flac"
+  },
+  "external/flatbuffers": {
+    "dateTime": 1613821420,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1972551ef9662e03f1d112f0833147a89edb56a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0aqwlh168j42532l0klgx6gsbqw7lhj92l25b8b1380j2qgz23hs",
+    "url": "https://android.googlesource.com/platform/external/flatbuffers"
+  },
+  "external/fmtlib": {
+    "dateTime": 1613835257,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b040d6a6f0a78391eb919dd487a8c069ad66f38a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16x73827rr1sfvxpd4gg4rpx30vqfdp2r2md9ynmbl6lf2qwgqfg",
+    "url": "https://android.googlesource.com/platform/external/fmtlib"
+  },
+  "external/fonttools": {
+    "dateTime": 1617393047,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc599ad45a5240a5158f982698c4f33947ae88e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "082gbxzxji2hssl0h25yxvs0caf8cyaisjd6k09s2wcgvnvvc7n7",
+    "url": "https://android.googlesource.com/platform/external/fonttools"
+  },
+  "external/freetype": {
+    "dateTime": 1619138504,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b477d8417b8cc7a389dfd34c489555578b117b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1higwvkpvh6wz0ryjbq31v00fqxq14q9xrr3p7ww32q2nvkych80",
+    "url": "https://android.googlesource.com/platform/external/freetype"
+  },
+  "external/fsck_msdos": {
+    "dateTime": 1620240055,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b445b74ff829c292ddd1f53659533de5bd65180",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08js9q4kzic0i6sj67cdppga0q818277a3wivp7dpaxvz4anc40s",
+    "url": "https://android.googlesource.com/platform/external/fsck_msdos"
+  },
+  "external/fsverity-utils": {
+    "dateTime": 1613830694,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3cea3520bbbd4a385010aa8b1440e17edc4899e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v541yjbvlkkddynwnwakrhj77jmawm1niz1nwbr2ish612v07p5",
+    "url": "https://android.googlesource.com/platform/external/fsverity-utils"
+  },
+  "external/gemmlowp": {
+    "dateTime": 1615574435,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88233667706fa0cd97bf55417d2761148ab67bc4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dff6jrd314xnib7jhqwpfc4hyv6ycjgrmb92wwany30drmlnw9l",
+    "url": "https://android.googlesource.com/platform/external/gemmlowp"
+  },
+  "external/geojson-jackson": {
+    "dateTime": 1614664387,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cd075e217fd9d81d6b5bf04f256ae27324681147",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0qrp98sn4q997q5szpz37414hlm3yl6183r504sv14azfwm7ymyf",
+    "url": "https://android.googlesource.com/platform/external/geojson-jackson"
+  },
+  "external/geonames": {
+    "dateTime": 1605020923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c1c69b46966d4e7280098b728fafc2c11cd5ce5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xcdyb82cs40am7x477cavyczh1ijm5zx785fw2in1wkqah4zp0a",
+    "url": "https://android.googlesource.com/platform/external/geonames"
+  },
+  "external/gflags": {
+    "dateTime": 1613826979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "37fc0b964213bd74de9631e388eccf8a93efd001",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wyiic485x863sdm6834dsl3b4c40fqpagz529v091kribmmm8gz",
+    "url": "https://android.googlesource.com/platform/external/gflags"
+  },
+  "external/giflib": {
+    "dateTime": 1613591035,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "79b629f4e5af0bc6a8b2489fcbda5817fef12ab5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sibmcf4ld5cda63fyklr7bd0naydy5c39rszg0fp7iiivx3n8il",
+    "url": "https://android.googlesource.com/platform/external/giflib"
+  },
+  "external/glide": {
+    "dateTime": 1613513320,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3376a4544043387a12edea5493a95c9cd1df1bdc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b38i7kvsivigic627hxi04k9sf5iq6ry176drcx9mr6wkbysbvf",
+    "url": "https://android.googlesource.com/platform/external/glide"
+  },
+  "external/golang-protobuf": {
+    "dateTime": 1613934264,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3edaf3f0be56531237768597ec0094be54578d58",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1za35lgd4h3vfqhv0a9kjbi0arrq9k0phpks113mddzlfg7dxnbw",
+    "url": "https://android.googlesource.com/platform/external/golang-protobuf"
+  },
+  "external/google-benchmark": {
+    "dateTime": 1613835308,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "650be92e17c5b4452d2ac69e055e8b0d1ccf958d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jnb9fbib4gp3w9smw5s1nvz2snbz414yxxa1xb58p5wjp7fqx4w",
+    "url": "https://android.googlesource.com/platform/external/google-benchmark"
+  },
+  "external/google-breakpad": {
+    "dateTime": 1614735647,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4b73b205ac612c4e9fc199b500433d4272f9f3ca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13l54qb6a8ba4g80h59mk1xxbdiqa0219h4p78rxzx1j75cx7m6h",
+    "url": "https://android.googlesource.com/platform/external/google-breakpad"
+  },
+  "external/google-fonts/arbutus-slab": {
+    "dateTime": 1613835371,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "277a36a98802de545c5df5c8e69201fa2749b409",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18g7n073qp1ii4gx11n6fpsv8si0ima4ldrx7mraca9mdq72w71m",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
+  },
+  "external/google-fonts/arvo": {
+    "dateTime": 1613815675,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1333e8e929799b5a29129603373d16c43a0952f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "144j3kjdp9gm5qi9x0j571m88vnqs1lwm8672qh9l3m7lxxsy0jl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
+  },
+  "external/google-fonts/barlow": {
+    "dateTime": 1613835220,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26652d070d70791cc1dc8497fb7997a795d8188d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "029n04xijjbwwxmz8lbihwcl9a30bgy9czdzg82ybwylnwq9pfwm",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/barlow"
+  },
+  "external/google-fonts/big-shoulders-text": {
+    "dateTime": 1613823849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92e722b258c2ed68162a76c7e8c15cef18f02dcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jpm0ld79d3g66iwiwmx4dn2gxdlrgwsblynf4zwcgcq7ydi4zb0",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/big-shoulders-text"
+  },
+  "external/google-fonts/carrois-gothic-sc": {
+    "dateTime": 1613582534,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84d771641983def0c77f6327990e01110d0baeff",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "067xqhgd67ngvkr7frxdy1y774pfpzzkih3jjk7fj24wqnkc6d5j",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
+  },
+  "external/google-fonts/coming-soon": {
+    "dateTime": 1613582547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7486e33533a779086901dc5c43bb8ce079d2008",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wz6aji68kbhg58dbwn0zmjg2ywk6cfdq7j7awg38zl2q26nfmq9",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
+  },
+  "external/google-fonts/cutive-mono": {
+    "dateTime": 1617172207,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08f8aab020ae1f487e7d8f868cd61351dc1b4517",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00wfjacl0sqncivpa3za9jmki9wva9q0vf85ads6g2rz4z6nkrff",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
+  },
+  "external/google-fonts/dancing-script": {
+    "dateTime": 1617172224,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5a7a0d0ef1dfa462c626e2a9b8f0dec5e3d6008",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hdp4a0gn23n88gzdi65dfqq3pmvw3nadf1p8xnqxan34yv8adyl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
+  },
+  "external/google-fonts/fraunces": {
+    "dateTime": 1613827250,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0130e6a2e466a58ed131adec305f9005f4a3b77",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gr0x87wrs8qh2ykpggcvxkxc1qmd6hw0xq6hn6p6s8078pw5b6w",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/fraunces"
+  },
+  "external/google-fonts/karla": {
+    "dateTime": 1613828236,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "645f577ca22e7fe3e7aaaca2c1ca0a6b106289c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0c8ny537pvhjfh0b87lfpc0aga4x0mlry203wkacgx2a1h00irhx",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/karla"
+  },
+  "external/google-fonts/lato": {
+    "dateTime": 1613829266,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb31693eacca2b20329394cda918ae82a2e9d1bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hdy27r466jd7ik69257hiazjqsdzv0hbpzkmid6rq1gk2lkijgz",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
+  },
+  "external/google-fonts/lustria": {
+    "dateTime": 1613832697,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "daf93358a95e6a4cfac7c1c9ef584a7c838a8f37",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16i0vknh3z23mr79iilxyf6kqs5kqp198by9cx9rmzcg3phgx03y",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lustria"
+  },
+  "external/google-fonts/rubik": {
+    "dateTime": 1613828291,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d91d54c817ba29486ab8233129a97cb78d2ef8b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10ap1n0s7qs742m3xzxrs91xyirp0280xvg4wz8hmpyip631h7f3",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
+  },
+  "external/google-fonts/source-sans-pro": {
+    "dateTime": 1613827281,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ebc08757b20a96a0c8a4dc5c263badf6a51b7dbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nmdmb80pf2pzcdn369q5skspmlqv56sn9in0fcfhx14pib64w86",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
+  },
+  "external/google-fonts/zilla-slab": {
+    "dateTime": 1613821412,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "299be8918c89283e82432e827934b62e6670afc6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rm6wp6849wpw32ys5wbrx9836937j1zx310fdyyl07kqgx4vhmh",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
+  },
+  "external/google-fruit": {
+    "dateTime": 1619753669,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25531cf8554e5f421e6b12847acf69a9cba83f52",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wksa168xyk42yijf2idhpvzp8225ww165px3lc9ff9ph883g0ya",
+    "url": "https://android.googlesource.com/platform/external/google-fruit"
+  },
+  "external/google-java-format": {
+    "dateTime": 1613829565,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "554efbe39799b9060d80ad57a151172e0c756755",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g1i78c3km8lly0rb3b6axma754vxl9s9s48jfa0n2l565h2zk0q",
+    "url": "https://android.googlesource.com/platform/external/google-java-format"
+  },
+  "external/google-styleguide": {
+    "dateTime": 1588028419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4848c862d716a8449e1473b0933b7fd6dd5a11e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1krqv8srgkf85hrj0shwz9j4xs6nx4jbj8fzjsbwjg1f589dd8iy",
+    "url": "https://android.googlesource.com/platform/external/google-styleguide"
+  },
+  "external/googletest": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe4582ab5d3af5afe831a7f5b5554d4ce759f524",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hs29iy2v24vl66qqa85sdzvxlw7awjravhy53gjv9vnq2dzpb84",
+    "url": "https://android.googlesource.com/platform/external/googletest"
+  },
+  "external/gptfdisk": {
+    "dateTime": 1633984019,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35f7435d25e18b72b0c0020110618e0134793ee3",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1bvxn1h8k5q88iii38w3i4gcyldwz6dq3crn7pgd6hd0dxvsjgfx",
+    "url": "https://github.com/LineageOS/android_external_gptfdisk"
+  },
+  "external/grpc-grpc": {
+    "dateTime": 1616636261,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "25d9af0bedde9ca88a9abf9a5eb6d3b763f729fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b8mdx9x08djdm8fss25r1dc2xbq1hb70zdm782k2rmbwp47axa8",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc"
+  },
+  "external/grpc-grpc-java": {
+    "dateTime": 1613834327,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "dee79d6efe93cc1fa5e2ec9afb2aafc8a4b16e08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hwm7wb4zg81cx784piqc316ik0dihbm19iiyn3y22ahhkd3ma4r",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
+  },
+  "external/guava": {
+    "dateTime": 1613834474,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5efe41cd9e7240f0fc145af03a17864d0e4e9bbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hdvqppxkyafrpkv9qzs5c7kab57vi4xhqacbqbwfr7dj0plca56",
+    "url": "https://android.googlesource.com/platform/external/guava"
+  },
+  "external/guice": {
+    "dateTime": 1613822773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c3fd35cfacf8303267595e96703e132cb6b78db",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0f9k7ribhyf0n7p9ff2jqk18qk1gim4vbln1bhiazdlfs3v5laws",
+    "url": "https://android.googlesource.com/platform/external/guice"
+  },
+  "external/gwp_asan": {
+    "dateTime": 1620772439,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a03264ddb1e1360460aa7d0c069907ad8669655a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k71w8a36dhr4l5r661rvnmj4bxz49is9md78hndks4jqcnzn036",
+    "url": "https://android.googlesource.com/platform/external/gwp_asan"
+  },
+  "external/hamcrest": {
+    "dateTime": 1613934542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cfc467f1d521561e8a5f8604c379b1d954856ca3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0i05qdmz9zd904apqxk6kdbffbydgj7k7n9yjvgrlw0m7xbynadj",
+    "url": "https://android.googlesource.com/platform/external/hamcrest"
+  },
+  "external/harfbuzz_ng": {
+    "dateTime": 1613823679,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "7120de378dc06db22368b5941af8a4ae8d226865",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m7a4ln2v5dxy5dkcfdxyjsvsrsd3hjbxvmhb4gyx6am6lk6lca8",
+    "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
+  },
+  "external/htop": {
+    "dateTime": 1638132864,
+    "groups": [],
+    "rev": "8bf483c86f5dd171ac83a56712eff212111b4e5f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "11xymwmdjd2igzxqiixplakivf8nqb3ssfp1p95p6dl3939b5c6b",
+    "url": "https://github.com/LineageOS/android_external_htop"
+  },
+  "external/hyphenation-patterns": {
+    "dateTime": 1588207981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6ebdb94ca258f00dd0ccb2bf86f33ae16c7c400",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "184jm20gaz36kwskqkhax7n1allfjanax6rz3vqs70rjgsdvv5i4",
+    "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
+  },
+  "external/icing": {
+    "dateTime": 1626890988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ff0d99397be5d96f702275cbaed06185ce78e2b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "167siw8fxdjrw4dl6a4k25xilj3qv8y59ih2s9a7g5rb3sz6pfl4",
+    "url": "https://android.googlesource.com/platform/external/icing"
+  },
+  "external/icu": {
+    "dateTime": 1628888013,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aeddeb69080a16ff78aaac329dfa01d584522e1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17ncsqdp28q238a5hhpkw3z3yskf6yw34hf39cb4nfmdn858pa8s",
+    "url": "https://android.googlesource.com/platform/external/icu"
+  },
+  "external/igt-gpu-tools": {
+    "dateTime": 1617754617,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "131006b81245402dda837764dc860345e42bb2e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c5cw7jgcfny776y5cqx7jcy8w4sqanx4b0qwrza6zqhgcc2cqhi",
+    "url": "https://android.googlesource.com/platform/external/igt-gpu-tools"
+  },
+  "external/image_io": {
+    "dateTime": 1613827333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c0ea26afcfa3abbe4684e1e0c080ca648d829bef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0257h57ygzpj2vknj5k8whkznrsmqd2fhzzb9gl3rys9qgljjmvx",
+    "url": "https://android.googlesource.com/platform/external/image_io"
+  },
+  "external/ims": {
+    "dateTime": 1620756808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22925544cc6075997e845c6acd371c10f649a42b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1476c1dbyhsmvak2m5ffrgjxrf8ixigx5fsi5w805kfaifignmin",
+    "url": "https://android.googlesource.com/platform/external/ims"
+  },
+  "external/iperf3": {
+    "dateTime": 1613934636,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c91e80b7630b6f12ce904ef986bf79f778d4acd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1malr0g6ha2s0qb6qrr4cly161vcj2d4xy5wbnxj43pnhg0k4gqb",
+    "url": "https://android.googlesource.com/platform/external/iperf3"
+  },
+  "external/iproute2": {
+    "dateTime": 1622589724,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86cd9241daa4a2d16dc0f331c72db343e10e69c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1527d8lzl7px9b84fxm1742nvz6d4h0r8nwibjh0d18j62xhz1mg",
+    "url": "https://android.googlesource.com/platform/external/iproute2"
+  },
+  "external/ipsec-tools": {
+    "dateTime": 1613582540,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "def1488d68523e71f3f08863f9047b6bf1ba1b5e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qz2058mcb75x22jarlls8ki6zhh9zd422nsn9wdzq29xk4a9cg1",
+    "url": "https://android.googlesource.com/platform/external/ipsec-tools"
+  },
+  "external/iptables": {
+    "dateTime": 1622589761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0355d238630c5323b826806de53ccc037dd176cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0d2vfhzixszwl3nwch9f996yx7kafr9rn7fni41hbzrh8nra476y",
+    "url": "https://android.googlesource.com/platform/external/iptables"
+  },
+  "external/iputils": {
+    "dateTime": 1613582547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61b2d503bc54ac80fea0a0e221e063301f140300",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q24bn8swbjsaa19kc6jdk2fw93cbipi6xbdh95w07pdp3v1xazr",
+    "url": "https://android.googlesource.com/platform/external/iputils"
+  },
+  "external/iw": {
+    "dateTime": 1613516541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "866e8d025debeee64148cbc9422232c157b8bd4c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01k08an490nvpzjyb7f6p8l67gxpkkg9fnc44f1lcc6ygb1rymsb",
+    "url": "https://android.googlesource.com/platform/external/iw"
+  },
+  "external/jackson-annotations": {
+    "dateTime": 1616809880,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c91023d9d0c4ffe9a094cda3a6fdbe4d3473cd98",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0apc5cffr02drfhfxri1fqs449i6bsk62a5kb0yfk73maya5wlw2",
+    "url": "https://android.googlesource.com/platform/external/jackson-annotations"
+  },
+  "external/jackson-core": {
+    "dateTime": 1616810394,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b02b4c1c8c75d3c5cbb01aa0a43f9e43933a3fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c1amlrk7idijwhbhr2xvs822kc8cvfcmz2vxw9y03ylbicwnq42",
+    "url": "https://android.googlesource.com/platform/external/jackson-core"
+  },
+  "external/jackson-databind": {
+    "dateTime": 1616808257,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6d0559682b885d2ef20f403187caccc5cf5ec8b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f4qf4dy0cyjv9cbmsvqawq0xp3r68snv5nidhj00jdnxcixh5zi",
+    "url": "https://android.googlesource.com/platform/external/jackson-databind"
+  },
+  "external/jacoco": {
+    "dateTime": 1615234311,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "681e869d755e22fd459cacd1421e16ecf6032294",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v0gdd5rasmh1q8sbq2f3ckhrlra73h1n9m0j9p3j3zpgq5a4x9s",
+    "url": "https://android.googlesource.com/platform/external/jacoco"
+  },
+  "external/jarjar": {
+    "dateTime": 1613516542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6b4d6f7f382845a3cb2fab88e6d502c757a4d49",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vn1j4pmksskgdjak31yc2vc1l8ph4m3mw06nsm0ql7fhbmy00yg",
+    "url": "https://android.googlesource.com/platform/external/jarjar"
+  },
+  "external/javaparser": {
+    "dateTime": 1613516542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94908d664f9e8a7cc40093a52c9c1fd4f6acd649",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l5hikg3bhk5fasrbwgbiascl8jwimacmpj0if2yqmbzcr6bglzs",
+    "url": "https://android.googlesource.com/platform/external/javaparser"
+  },
+  "external/javapoet": {
+    "dateTime": 1613582537,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d0fc1c588274585021a0ca52f529a7770d34332",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kwklwk1xjnnvwblfb5hga4ks1p3jdmh9dc30c5mifksrp8fsyr6",
+    "url": "https://android.googlesource.com/platform/external/javapoet"
+  },
+  "external/javasqlite": {
+    "dateTime": 1613516548,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "924e1e55260f53dbc362855de52d4f8a54c55804",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1801cchvl1nys58y41qxk9if6wamrakpvpq6c2k3fj65053kizi6",
+    "url": "https://android.googlesource.com/platform/external/javasqlite"
+  },
+  "external/javassist": {
+    "dateTime": 1616864907,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "793778def89ddc855b52680e2ad212bde4f49ddb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zfcnqlgyl59pv4h0s0nnc8lhgljpq5dq4p05anay43lnrszn3ca",
+    "url": "https://android.googlesource.com/platform/external/javassist"
+  },
+  "external/jcommander": {
+    "dateTime": 1613516536,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5ff59e43ad0114ed9e4733ea8b3fd41fe5c190a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m4a69hc9k4ixn8sah9rz9n10xgbz06swcfcsx96cjk0svpqyw4w",
+    "url": "https://android.googlesource.com/platform/external/jcommander"
+  },
+  "external/jdiff": {
+    "dateTime": 1613591036,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "582327b730af8cdc85da673fd2333c786ecc9927",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1j5bnl4lmm2288dvbma7mxyx0x52d3jn5d9wpd6idg44ii9ra1ap",
+    "url": "https://android.googlesource.com/platform/external/jdiff"
+  },
+  "external/jemalloc_new": {
+    "dateTime": 1613832679,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "361a088dfcfbaa1960c03678b5caeaf397b77182",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xbgga8jnizv1588dh1bd2av005wfmc69xzh867269j0523djcdr",
+    "url": "https://android.googlesource.com/platform/external/jemalloc_new"
+  },
+  "external/jimfs": {
+    "dateTime": 1613516539,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b46a6ed198ffa3ad3b90a808867d3ffb7162bb2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lgiryx40d8a5854yczzvm5x6fydncj06vaclq4hw07rlwh7kvn0",
+    "url": "https://android.googlesource.com/platform/external/jimfs"
+  },
+  "external/jline": {
+    "dateTime": 1620248643,
+    "groups": [
+      "pdk",
+      "pdk-fs",
+      "tradefed"
+    ],
+    "rev": "9251052568548695534f92b1824b5ee1af53b699",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qxn0vwnbz0sh9ax9ad52wg7373f48dcpq624bgfiypjgxfniqls",
+    "url": "https://android.googlesource.com/platform/external/jline"
+  },
+  "external/jsilver": {
+    "dateTime": 1613516541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f1606513d1b994792dee3fdc7b8a0b40266cbb29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "198msf9yaqbjy52aj4wfshdnxy5nyf1jwn7p2l4gndn1212vkqa1",
+    "url": "https://android.googlesource.com/platform/external/jsilver"
+  },
+  "external/jsmn": {
+    "dateTime": 1613504480,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da0d696df523180c836ab37ba62999a65029c420",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0czn4n8j87svwm1kgsnjd8qzyriygcjlkwskqj2w79v1s113rlb8",
+    "url": "https://android.googlesource.com/platform/external/jsmn"
+  },
+  "external/json-c": {
+    "dateTime": 1637106784,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "75d63231d6dd530684cf96ca249b117410c5ca00",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "06w1ic9s2pcqdyzib6084k1jqxdhf8jn22hnwj4h9m835f54sji7",
+    "url": "https://github.com/LineageOS/android_external_json-c"
+  },
+  "external/jsoncpp": {
+    "dateTime": 1615589399,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "592ec82179026ea4835babfc2d9e4b14cfe32aa1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00985j9k2yspfp6vi5rhnb4pwbzig055l3p08mq8k1sqm3q47vqy",
+    "url": "https://android.googlesource.com/platform/external/jsoncpp"
+  },
+  "external/jsr305": {
+    "dateTime": 1613814611,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1c31016be6bcef7265a9f77464a50717041a0c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q8sc6rb67j35r6jk55ap37b9bbrgdca0a8dyyy04ipx07ccw05y",
+    "url": "https://android.googlesource.com/platform/external/jsr305"
+  },
+  "external/jsr330": {
+    "dateTime": 1613591030,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9007fc517bc854e4c04c4c333d19964e71ec9a8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1s0jbmdd3vjaprwalf10i06n8sfmg1x356y5gz0jfimbsknva989",
+    "url": "https://android.googlesource.com/platform/external/jsr330"
+  },
+  "external/junit": {
+    "dateTime": 1615460631,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1002ff53a1a0165971ce5dde386634d45a158f2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n7rfvpi0pg1m6qjh6wza310gf01p2kv564bnkf3dfsjsczfs0nb",
+    "url": "https://android.googlesource.com/platform/external/junit"
+  },
+  "external/junit-params": {
+    "dateTime": 1614210830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c70e5145254ad9384927356dae1984da03ba350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wda5sh5jy1ww8y50nfsw508ijw185h6g0mn5nba9iv95zs44zmq",
+    "url": "https://android.googlesource.com/platform/external/junit-params"
+  },
+  "external/kernel-headers": {
+    "dateTime": 1620154911,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69e08b26868d2d22064457c1770de009db750f8e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vj1hy930nr1pxrc0jdm9j4fhxnlcr05lcg6700ai5qqgz9i06rw",
+    "url": "https://android.googlesource.com/platform/external/kernel-headers"
+  },
+  "external/kmod": {
+    "dateTime": 1613814883,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a859b6968164411860dd29ce7a2e93fb595bb56b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xv7xwkz8mhn41fq7jv5hq2fy9r2l4srnwkcf3xbaca2ai177g1m",
+    "url": "https://android.googlesource.com/platform/external/kmod"
+  },
+  "external/kotlinc": {
+    "dateTime": 1620860981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d78618fcccb220764099612a05288cf516324f64",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0dzms659jz4zjm07pwissifi7v57xhmrlzkx7j63s9za6az63719",
+    "url": "https://android.googlesource.com/platform/external/kotlinc"
+  },
+  "external/kotlinx.atomicfu": {
+    "dateTime": 1620860983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "97230e837553ee63e1d2047468d8d2e3f27d3f8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "14zbi4fc70xnspx5kn6jdqq9yf8p177qmhx2bprsflrcdb1np9r5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.atomicfu"
+  },
+  "external/kotlinx.coroutines": {
+    "dateTime": 1620860981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9df3d935c045b2b4ee7f98ae576e41192c80f068",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xg0g0yn8qzk23p8vvh4laavmvinbmqch5ib1ca44g6fkf7f7df1",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.coroutines"
+  },
+  "external/kotlinx.metadata": {
+    "dateTime": 1620860981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5865a735da3f4f36121c81028f4cc8d730aca27e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0fz2mbsb51b6h5d8a1p099iccxi4ll2w4cnw3i8yikjmq5pl64k5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.metadata"
+  },
+  "external/ksoap2": {
+    "dateTime": 1613834160,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0617a2b91db0f785df127293b93f5aaedf9f7762",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kvfan6g57xczcv075439zlqaw3rxmi5mdz7rrfjxv2qyh3sp2v2",
+    "url": "https://android.googlesource.com/platform/external/ksoap2"
+  },
+  "external/libabigail": {
+    "dateTime": 1617708411,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0dfb9140231f6ec6c102ad6fc12d21b97637e4b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13rn7mvpwsvahryp1c8ka6rghblpa0vjsvrji3g86map3ij0shac",
+    "url": "https://android.googlesource.com/platform/external/libabigail"
+  },
+  "external/libaom": {
+    "dateTime": 1624328735,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e08b8d92ab9170c4a370c980382c2bed7551d9fc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01v88ya40i58w9fmwc0ak4rl9l2sc5rm9yyh7j8r388ynhy1rldb",
+    "url": "https://android.googlesource.com/platform/external/libaom"
+  },
+  "external/libavc": {
+    "dateTime": 1633482179,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0698053e88d9bdb34ea1c1fc7d4e68080b523eb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0qsn4fdl7ivhbmvvjspi9qj00vhl6x43cll46qj8cyvhnb6ajqpa",
+    "url": "https://android.googlesource.com/platform/external/libavc"
+  },
+  "external/libbackup": {
+    "dateTime": 1613834023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ce93fe4494046722604cd96c6a055067ddd54a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ll3ryrbrh2xz90b6r928jck1q0ghnq8wrn5zdy4y9w6naxjy8vc",
+    "url": "https://android.googlesource.com/platform/external/libbackup"
+  },
+  "external/libbrillo": {
+    "dateTime": 1619471804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0398940d5c5cbb12ede4c7e77c51399d590ad0ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p9fnd8xjv5xf7jbkp7vmqzfmj0ip219lpmp4d291wxzc1jhy1cy",
+    "url": "https://android.googlesource.com/platform/external/libbrillo"
+  },
+  "external/libcap": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7004b3f997cca6bd2fcc22fc1b5e8fbc9094a973",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f4jkab7ws0sjzfgfvrf6mwrrl8q3ghnm885l8nkrlghqd7s3j9c",
+    "url": "https://android.googlesource.com/platform/external/libcap"
+  },
+  "external/libcap-ng": {
+    "dateTime": 1613504470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fdcfa912bc638607f80345d21f8d222953921990",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dsr6r0s5m2aqm2wz9zq023abgvjxdrajjnsfrs8ssi30zxzrxyq",
+    "url": "https://android.googlesource.com/platform/external/libcap-ng"
+  },
+  "external/libchrome": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "05d507089cd4087e73b11fd6192a87f0be426835",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0mi55n6sb3wzc67a279cnabhx179s8dh4bh0j72ngwbaj9sln1fr",
+    "url": "https://android.googlesource.com/platform/external/libchrome"
+  },
+  "external/libchromeos-rs": {
+    "dateTime": 1613587988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c2b9b6698ae8b4f62e2809f1546523954b3d168",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0lkwghnsaniv3v9lbc1r011ff4dk9d0ja9xzxxk4b58xds6zjpil",
+    "url": "https://android.googlesource.com/platform/external/libchromeos-rs"
+  },
+  "external/libcppbor": {
+    "dateTime": 1624639530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22dfd038f93ab30f1c03955d9319c68d45d08bde",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "009j2acfkk6207s40y37xcp3aj9jd1m72162xpaqf0r62y4lby4y",
+    "url": "https://android.googlesource.com/platform/external/libcppbor"
+  },
+  "external/libcups": {
+    "dateTime": 1613822904,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5884b4a877be7dd135fe054ffdd949035fd82c60",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1986mbxc28sxi377ydjj8b7mdhwwvsb1df4n3da1cf0m9rrh90vg",
+    "url": "https://android.googlesource.com/platform/external/libcups"
+  },
+  "external/libcxx": {
+    "dateTime": 1633807197,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7cc0419541c95d9665fbba7b58389cf6238cb48b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "010r2b8zxaw7zam4l9050k7zr7q4w2y9zbyxwsf2afbgvsik4whs",
+    "url": "https://github.com/LineageOS/android_external_libcxx"
+  },
+  "external/libcxxabi": {
+    "dateTime": 1617665041,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2319d7cf7641f25436e360db18a50cf5e319f80b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11zz64d974bs5gm1b4vin5bjvq9a13h9gzjhk68lm4ksi1yaga96",
+    "url": "https://android.googlesource.com/platform/external/libcxxabi"
+  },
+  "external/libdivsufsort": {
+    "dateTime": 1613587990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "add0d06ea38aab0d03190012c0f1c8145ffd9fd9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lh8s06r0fvkjsrdb0ns3iv0n97sibvbv3jy97c9s0zp29mfi3wg",
+    "url": "https://android.googlesource.com/platform/external/libdivsufsort"
+  },
+  "external/libdrm": {
+    "dateTime": 1624402246,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "be7293007dc21d66abb4c8c91849db1c8f601fea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v85xcr4k6vmdplnq3apm20yvd3jzwsv1rh570prrj15ba552alm",
+    "url": "https://android.googlesource.com/platform/external/libdrm"
+  },
+  "external/libepoxy": {
+    "dateTime": 1613828159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b9cc8aa70269e6ad2bcd089ec3f2af6419907848",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wdjlwf9cvy1wz3xymrxmjxlqj1w7zxd2vxy0g90bnpslwcngc7l",
+    "url": "https://android.googlesource.com/platform/external/libepoxy"
+  },
+  "external/libese": {
+    "dateTime": 1613591032,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49fa5515fe5a7a8b753fcba55f998ad65adb5432",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g10bprh155ys18zvsxs0annjzh39cnyxfldy9zbxcpcj5dlvirl",
+    "url": "https://android.googlesource.com/platform/external/libese"
+  },
+  "external/libevent": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "722848c75aeafd568655533771d4fe7d0a906f4d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03gjyf91xycyd2g8nfkvvjg1kibvdm1dlzxn9x50sbhbig43i9gx",
+    "url": "https://android.googlesource.com/platform/external/libevent"
+  },
+  "external/libexif": {
+    "dateTime": 1613823967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1fae2ed9ca24f3e6ed15b753135af7ff0f56915",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ppfmlnbh8vmhicdnvs4vfmsfg608pvmq60g8yylbr44c2bg208a",
+    "url": "https://android.googlesource.com/platform/external/libexif"
+  },
+  "external/libffi": {
+    "dateTime": 1613835389,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c598060921bd572eb12d735faf4876c3c5911dcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kfagm0922z80061324a4w74231aic3p9wsw6qi67nasf7f1fbjs",
+    "url": "https://android.googlesource.com/platform/external/libffi"
+  },
+  "external/libfuse": {
+    "dateTime": 1620922263,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f5647225c85bf36ebe8530901bbc7e4810037109",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10c514vzj2mihk97d69zxzdqgxc65fyqkllyx5glfsqhsr156lwy",
+    "url": "https://android.googlesource.com/platform/external/libfuse"
+  },
+  "external/libgav1": {
+    "dateTime": 1619126646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "560f2c896aaf0076f4632cbd34f1226c319c545d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0w3rkagg3c83rf8j0i6409jxx0wya7yxyx5xx3kgq89axymlb7gx",
+    "url": "https://android.googlesource.com/platform/external/libgav1"
+  },
+  "external/libgsm": {
+    "dateTime": 1613830649,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5e37c49dd3a2c066a49f14d46bdc8811c795d2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13np111m5nqvzza0mllnvmm0frvazy1nmlhp6lfn31d00vdrn936",
+    "url": "https://android.googlesource.com/platform/external/libgsm"
+  },
+  "external/libhevc": {
+    "dateTime": 1625160832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9375fb8da8453a66fbd19305c63cd68f3c16d4bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pwsmr437jags5xyxpsdiqg4axjp3n9i5fpcfcp1d2mha3win6ry",
+    "url": "https://android.googlesource.com/platform/external/libhevc"
+  },
+  "external/libiio": {
+    "dateTime": 1613582533,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5255983a4d5f3aed0815c79e08434f9be6232e5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "049lcsyzmzympsk6s3rphcmql3y4rs2c1fsh6bfjpg4sdqjcf5w6",
+    "url": "https://android.googlesource.com/platform/external/libiio"
+  },
+  "external/libjpeg-turbo": {
+    "dateTime": 1620402017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6a8a5e020389ab2fa0af7e9e49ba6cca8f3b94e5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "003d689i5zbmfv9xqqi3bfc1fb0q9xl37x8k0lb5lv4pxr27i432",
+    "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
+  },
+  "external/libkmsxx": {
+    "dateTime": 1613832777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86c909970721e4035e6848c0e2914fcac9cc84ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f3vr8khghmcw1pr9kn71ql7s1a0vwnclmqgm2dl27cbkfzf4qmx",
+    "url": "https://android.googlesource.com/platform/external/libkmsxx"
+  },
+  "external/libldac": {
+    "dateTime": 1613834298,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a47463b3ff1ced85921cb3c362af052050ced836",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wsy4g8bllsnhdca0s4kh7g986qixrqc3x4pn0jlwg8hnzdc26bg",
+    "url": "https://android.googlesource.com/platform/external/libldac"
+  },
+  "external/libmpeg2": {
+    "dateTime": 1614986265,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "178791c15d899d3b8e4e8d16ef5eed3e5bb1578c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04qb3lvjnizsyzs59zdxw1i9ng1dibnn3a15szzw8dmfrdwdfjv9",
+    "url": "https://android.googlesource.com/platform/external/libmpeg2"
+  },
+  "external/libncurses": {
+    "dateTime": 1638132919,
+    "groups": [],
+    "rev": "a41f07e89e099bc7fb362dba82804c782a027d3b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0w5h34m1sdy9h1c0dbizzzg9gwqv650k8rz5d0arrc9rzj9210x0",
+    "url": "https://github.com/LineageOS/android_external_libncurses"
+  },
+  "external/libnetfilter_conntrack": {
+    "dateTime": 1613516547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b62e8c73f75f95f2a269e70896f80b732043b227",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v6lpqqw7h19l9jzs43apw4kws39av9bhikarzlvym5xs3b6jhm6",
+    "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
+  },
+  "external/libnfnetlink": {
+    "dateTime": 1613516544,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69c4d8aa3e6bd8d9f98feab0c9cc8409867b918a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c6w4mi3xc6gxly949fh30ni84yk5w0bwqmipv857hpbq4cl3p9n",
+    "url": "https://android.googlesource.com/platform/external/libnfnetlink"
+  },
+  "external/libnl": {
+    "dateTime": 1613823690,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c81a827c3fa0fb9dfac5d8e8aede6f22d512d2de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f54wdvb46iwmm725yx2hj6nmfh6g3sfiar27m6qd2i01ah8fb8i",
+    "url": "https://android.googlesource.com/platform/external/libnl"
+  },
+  "external/libogg": {
+    "dateTime": 1613582542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "031cb41644627356e2ba25cf059b293c92966cc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rdync9bnrw7gxwn69nkk1y8vn42il7145jlq9ry247qskd06hg9",
+    "url": "https://android.googlesource.com/platform/external/libogg"
+  },
+  "external/libopus": {
+    "dateTime": 1633072478,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6a81af01b817022ff58c8f40c9b8944394ba857d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0z39qr4nd2cgsckhzif4dbjchxqgq72xrql7ckjwyp769g599pz9",
+    "url": "https://android.googlesource.com/platform/external/libopus"
+  },
+  "external/libpcap": {
+    "dateTime": 1615009313,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e0035071e1bfed10946265461218f9da36a6566",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16pjxifk3vmzkb66ga85ngcwmx555nzbms57fwm66k19v526m1m7",
+    "url": "https://android.googlesource.com/platform/external/libpcap"
+  },
+  "external/libphonenumber": {
+    "dateTime": 1613821288,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "692a8b7c379f0494d97d3c09564c423f2f1ed5bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rn08wi8q4b6bb00rcchiv4zida0i7dz9vryfkadb15k4mqh79d4",
+    "url": "https://android.googlesource.com/platform/external/libphonenumber"
+  },
+  "external/libpng": {
+    "dateTime": 1616512499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46ed936d06d3cfd8ba40769d0dfdd2965bb685f1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "177jf1vizmmkp7zx4kh99jp66zaqqxkcj6zgk3n080qc91jh3xbx",
+    "url": "https://android.googlesource.com/platform/external/libpng"
+  },
+  "external/libprotobuf-mutator": {
+    "dateTime": 1613835196,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e96ef0c9ff1f31410f64f95dbf484e9d472dd74",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0qd6v41shmz918cv8h2jbgh3pvg65mk7c9m03afzz8gy26zl6rai",
+    "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
+  },
+  "external/libsrtp2": {
+    "dateTime": 1613834439,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b54f73d9908bb0e374ebde1bc969dc08d92a592",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mr1gb60ryh71makvab277w1lrwlk7bv6alhh369jikm5sj78dyw",
+    "url": "https://android.googlesource.com/platform/external/libsrtp2"
+  },
+  "external/libtextclassifier": {
+    "dateTime": 1626946953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e28f99a0b4bf610672d8cf908bed7700e2b730e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0grqsvf1zk2658a346pbrfv4mcc65j49pq4061wqfhsxad0gipb2",
+    "url": "https://android.googlesource.com/platform/external/libtextclassifier"
+  },
+  "external/libusb": {
+    "dateTime": 1613823922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e17e1c5f65fe61840fcf26d2e14329e5bfcf350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v007hjbbbs07mq2y84511mv31b8h8hhac7hp2lqmrwp8f2jldxx",
+    "url": "https://android.googlesource.com/platform/external/libusb"
+  },
+  "external/libutf": {
+    "dateTime": 1624322936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bc83ab3574993e31a192c8b775bcb07cd050b5aa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d0d5ljsb4amc6a8xwkx1hmzy712gww5vsh4fq0926nnl195vp8s",
+    "url": "https://android.googlesource.com/platform/external/libutf"
+  },
+  "external/libvpx": {
+    "dateTime": 1626119494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a0c68aedeab57e515b0276092f0e0ba331d8192",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y883jrkywpy64xay77kxh1j2ijc77lmggyby8860y608a1227f4",
+    "url": "https://android.googlesource.com/platform/external/libvpx"
+  },
+  "external/libwebm": {
+    "dateTime": 1613822832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aba1e4df5a8e700acb0ba3d726eb376aad43a735",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kkb0mm6vqbv1ri6br6d4xisvbgx947r8d9vynbbw9bl03g2fbpp",
+    "url": "https://android.googlesource.com/platform/external/libwebm"
+  },
+  "external/libwebsockets": {
+    "dateTime": 1618528182,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fed801d283c393360d7e2a954993d79a7be5dfcb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "14l852ww7vwc5vpi0b5vdqall31afz743qyqs67kdy1xdzz906mq",
+    "url": "https://android.googlesource.com/platform/external/libwebsockets"
+  },
+  "external/libxaac": {
+    "dateTime": 1614986306,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a62b0fb2760ddb4a86ad3076f2460b510f30eed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k85nq28kwa9jhma9xypm9i3p1317njryhcsvmiqk0w3cn5xxlr5",
+    "url": "https://android.googlesource.com/platform/external/libxaac"
+  },
+  "external/libxkbcommon": {
+    "dateTime": 1613814458,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26e0ffacde55c1521587d4450cdb6a43ee65308d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ffqp52cwhvb7kkkvr993sj0z63jk7cx0jkv4fb3apjczp8rlnlx",
+    "url": "https://android.googlesource.com/platform/external/libxkbcommon"
+  },
+  "external/libxml2": {
+    "dateTime": 1620938495,
+    "groups": [
+      "libxml2",
+      "pdk"
+    ],
+    "rev": "6fc2026f204ce12bb232567cc67b6f79fdacc946",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kni8714vrwwrrbh3pg3fa5q7fillik22qzsrgy2i2d8y1jsbgp5",
+    "url": "https://android.googlesource.com/platform/external/libxml2"
+  },
+  "external/libyuv": {
+    "dateTime": 1613821661,
+    "groups": [
+      "libyuv",
+      "pdk"
+    ],
+    "rev": "bc7cad0280b6aec240415e4a683d78e3712e92ad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wqd724hbmyk1nqyz2ixk14dq074897raqnb72h8zfbshkxrdvp4",
+    "url": "https://android.googlesource.com/platform/external/libyuv"
+  },
+  "external/linux-kselftest": {
+    "dateTime": 1619820969,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0b0979367624399237e1085f3f17919e9ad100ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wfr5vcjbswirbk0dla14bkz7q34imxd7l7r311c82vqf4wdk04b",
+    "url": "https://android.googlesource.com/platform/external/linux-kselftest"
+  },
+  "external/llvm": {
+    "dateTime": 1613814421,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b56e54f6a4e2159c397a61c9fcec624396614b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vsbyazjkpdd4gpmr9cbj94bl4f3ddhqx56rz9apyd50bzbi8dnb",
+    "url": "https://android.googlesource.com/platform/external/llvm"
+  },
+  "external/llvm-project": {
+    "dateTime": 1607536677,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8cb28bc3dfe43a8ed95cc56046af070c8647b486",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ikzmd238agp9ldng39y1yn4yj2nqah251h5nrsp3b97qvd05wk5",
+    "url": "https://android.googlesource.com/toolchain/llvm-project"
+  },
+  "external/lmfit": {
+    "dateTime": 1613513328,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eab2bc745e2489e080ca2e16b1b3b99b117fd3cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11nb4xcnbnqgq0b15hqdyppixhyri8kwymbvaznfi1y370jw66bp",
+    "url": "https://android.googlesource.com/platform/external/lmfit"
+  },
+  "external/lottie": {
+    "dateTime": 1623838088,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fada85ba3f151721b433fc579306c3f023c49617",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xbfmzrpj7j32s4m7ygvhbx4x4s3gdvzqn07jkh2bmi7r3kws8nz",
+    "url": "https://android.googlesource.com/platform/external/lottie"
+  },
+  "external/ltp": {
+    "dateTime": 1628888010,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d4ffc6dae7916cc53a271ad5d57fff5c2bd1c4a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0mqyz806pbqm0m40p3lnxjnbnkh7y4rasymk1n8c2a48dm6crxdf",
+    "url": "https://android.googlesource.com/platform/external/ltp"
+  },
+  "external/lua": {
+    "dateTime": 1620326634,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41afbb0a718ab8682298918c65c0dd06445d9d27",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pr4np5di8pj7r1yaab4nrvh4bb5fkakr4ddlv2f9h0jhx32y2yq",
+    "url": "https://android.googlesource.com/platform/external/lua"
+  },
+  "external/lz4": {
+    "dateTime": 1613814590,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c91c377b9fd83f149d7de820b6992bcc58a7b22e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z9qlmhzzd6zssc897sy2yz2iqpq812qfpyszxv5nsmj9ml48swq",
+    "url": "https://android.googlesource.com/platform/external/lz4"
+  },
+  "external/lzma": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca5e1dbbe851e6545304a0d30a530a2d05bde693",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08wi3bisnknkz26iw3r3lna9zxwnmbql6iz550793nbq8bnkvci3",
+    "url": "https://android.googlesource.com/platform/external/lzma"
+  },
+  "external/marisa-trie": {
+    "dateTime": 1613823730,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffec643eeceeb3bf79142ed95718f04ff0ffd0f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "131spy2m80s752028pqqkhylnd2y8ibz1bajdssxjhw6ybhfh4yc",
+    "url": "https://android.googlesource.com/platform/external/marisa-trie"
+  },
+  "external/markdown": {
+    "dateTime": 1588189365,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f5c06cd8812bf961ef1ec2a289e5d6c511210ad0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1g8ziq2pf7gnyqcv6cbpigs7vaghd269lxzqvq3gkmqq5nvvp51k",
+    "url": "https://android.googlesource.com/platform/external/markdown"
+  },
+  "external/mdnsresponder": {
+    "dateTime": 1613814437,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03b24cad4c8d5be848e6a1324aaec5e92888d0a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11fw71ghxij6q9zrn3bp7plz05yrw0a8w9yjkdcfjiicf4may28f",
+    "url": "https://android.googlesource.com/platform/external/mdnsresponder"
+  },
+  "external/mesa3d": {
+    "dateTime": 1619228223,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "15c21526468d152b3f53f7ecec4e0a8e7873ec09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gj14c9wnhqpfpf3wkvfpf967rcsf151clamr6d1prf36m917a43",
+    "url": "https://android.googlesource.com/platform/external/mesa3d"
+  },
+  "external/mime-support": {
+    "dateTime": 1613516532,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b7ca4e3cf396d9ae0c2678458a68ec41afefbc9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lkwshpnbp0hgz4azb63c83xdk8hrqywcbh501frjc8d5zgxvm6s",
+    "url": "https://android.googlesource.com/platform/external/mime-support"
+  },
+  "external/minigbm": {
+    "dateTime": 1623701689,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d0468d096574f00712fe0062d007ff9461ebff7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lbk54q5w1qad1qjyjn2rzkvn6ab85ibx7ixqxhkha3lm2i33k5q",
+    "url": "https://android.googlesource.com/platform/external/minigbm"
+  },
+  "external/minijail": {
+    "dateTime": 1620941758,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff37dce5f0b3f7103e79e6097f869bab429cf7d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18341lkx5k0svyj3z60cdv153h8aq0fvc00dssxm3rssim4ax3gl",
+    "url": "https://android.googlesource.com/platform/external/minijail"
+  },
+  "external/mksh": {
+    "dateTime": 1633616742,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b74300fd59ceb14bd372d8f659f3659c39505ada",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1rhpxafm21sndy53j2nv6rlj6mi4cyckzr42xqafyrynga4m87mn",
+    "url": "https://github.com/LineageOS/android_external_mksh"
+  },
+  "external/mockftpserver": {
+    "dateTime": 1613516542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a312b549d6a63d8fd82c7a304272993b5d7dba68",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rm29k2285ibqklbgijdmi4mp694pzg7pgj8n9zl9a1ar1cjv5nf",
+    "url": "https://android.googlesource.com/platform/external/mockftpserver"
+  },
+  "external/mockito": {
+    "dateTime": 1613821600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71d3bd6f1c0bd98679f07e6f74b714e9394593d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0fvgaw450rhb5cmq2blh2y4zi86x23jjngrskprz9k4is3yw8zn9",
+    "url": "https://android.googlesource.com/platform/external/mockito"
+  },
+  "external/mockwebserver": {
+    "dateTime": 1613504481,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ea7607fba2b8e3cdeb69811d17001bcc1abaefdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yxf1fgfkb7kgzz5pqac8171952gfviv2043njxnxbaysmy5sn1n",
+    "url": "https://android.googlesource.com/platform/external/mockwebserver"
+  },
+  "external/modp_b64": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2827c23395b93cb6649347485e9929798d05811d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l11d9qw0qlh6ab2ybwciscspqscdydj23q5998va4qxpapdcrjg",
+    "url": "https://android.googlesource.com/platform/external/modp_b64"
+  },
+  "external/mp4parser": {
+    "dateTime": 1613516543,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e6e66a4c28b15830534d216635e7ab493610630",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "167wv822ssx9n3z0bnbk72p532wy7ck7a0ayi0rrppz5whilg262",
+    "url": "https://android.googlesource.com/platform/external/mp4parser"
+  },
+  "external/ms-tpm-20-ref": {
+    "dateTime": 1613829521,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd40c19b94c2d1d1316d5b8b7333855963b9e656",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j5gdirvbvqr3kw0d212s35awisanlmc1avyfk2ky7rqa82yqp85",
+    "url": "https://android.googlesource.com/platform/external/ms-tpm-20-ref"
+  },
+  "external/mtools": {
+    "dateTime": 1619086133,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5a5e41d1eb00bc3e20b7c056677a93533073004",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0i0dbrkfj889qx63dz0iwvs6klablp5ydyria9s4j21bp3zmgzp4",
+    "url": "https://android.googlesource.com/platform/external/mtools"
+  },
+  "external/mtpd": {
+    "dateTime": 1622589542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c6508c390fe329609c5eb383519c1acb06d32c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kgmcl1ll4mpzfwnl95y2qhv7d825s4i3rkd36wgvg5h6jkf9zjv",
+    "url": "https://android.googlesource.com/platform/external/mtpd"
+  },
+  "external/nanohttpd": {
+    "dateTime": 1613582547,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a79b74bd23da48b6179594585cbf95c270b8a4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gq2hhgy0rq5ws42vjkqjdawn6dns6kl8cb5h46lx8psvh7pdgz4",
+    "url": "https://android.googlesource.com/platform/external/nanohttpd"
+  },
+  "external/nanopb-c": {
+    "dateTime": 1613701680,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "123c0ef2c35b7138c25e8ed9ecee314c52f1ee4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1089qzm6713npyb6q1zx1lmapjlhww36rc4b6lmzwgxv39afk5ii",
+    "url": "https://android.googlesource.com/platform/external/nanopb-c"
+  },
+  "external/naver-fonts": {
+    "dateTime": 1588181530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "100c4663421ff989ff800f35ce7cdf0f9a506281",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ihcg6mpzf8lnygnn82l5z8pv6m8iyw0mzsc76wmyn9j7wdyhg9s",
+    "url": "https://android.googlesource.com/platform/external/naver-fonts"
+  },
+  "external/neon_2_sse": {
+    "dateTime": 1588290974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "965188421aadd92b93ae738ab16ad2b5d68e054d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12ivga8rnf1ibchrwczfs38n8kpjrjkyrfn9hav2w8z3xdrhz8p2",
+    "url": "https://android.googlesource.com/platform/external/neon_2_sse"
+  },
+  "external/neven": {
+    "dateTime": 1613504480,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11b0b3df8254b595c1e4c045ddf1bc1f6e4738b6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wl4zg5zkcgnrj9lzvm6l49awpar07hny1admj6hi06k0w2id3f9",
+    "url": "https://android.googlesource.com/platform/external/neven"
+  },
+  "external/newfs_msdos": {
+    "dateTime": 1613582532,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fc67e7d870a8b06fe0ee4cf7219041ae740503f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0shrw82gl4bsvsdyk21fwmjvdk9mjg24ylng2jbabki63xp4dmgw",
+    "url": "https://android.googlesource.com/platform/external/newfs_msdos"
+  },
+  "external/nist-pkits": {
+    "dateTime": 1613516536,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7dbb70abaf2e98538206c4ad4e57773d52171090",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xdr99aqr4g7drh4gmr88ah0q2im8aq5cs8w834qanygpg694dr1",
+    "url": "https://android.googlesource.com/platform/external/nist-pkits"
+  },
+  "external/nist-sip": {
+    "dateTime": 1613582534,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1aea3baf6865e5d2c3c14e1364654ab57e673e96",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0k5qg8bbg2l6g3fv9x4bikpa7b0sf08lacayxgm3pnpyn2bmai43",
+    "url": "https://android.googlesource.com/platform/external/nist-sip"
+  },
+  "external/nos/host/generic": {
+    "dateTime": 1632270120,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a2b1771799f7f074e454a13cf5070a255ffe2a65",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jwxahjz1qib7l5bsjzinjl0a1incqvns2msrl469gszdawvix7a",
+    "url": "https://android.googlesource.com/platform/external/nos/host/generic"
+  },
+  "external/noto-fonts": {
+    "dateTime": 1625069473,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e62d0476e6220126ed893fea27f967f82f1126c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p0r230lik5kbmysq0ahwdsdj9qg8h8p8305651aw3zmn9ad23g9",
+    "url": "https://android.googlesource.com/platform/external/noto-fonts"
+  },
+  "external/oauth": {
+    "dateTime": 1613504473,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c31648be6d1b6572a1ff4796b09bdbe1f66348c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1iy7n0krrann5fkm46znlm1q598wzr4jlxv17d5xw4dwc5jp6p5n",
+    "url": "https://android.googlesource.com/platform/external/oauth"
+  },
+  "external/objenesis": {
+    "dateTime": 1613835417,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4fc5a9a9185388c74ae174bea32166f5402e9083",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cvmp0wrf5lqag44wfjil3bdq4zkdc3dm4fr49g6qcchd7h65gmm",
+    "url": "https://android.googlesource.com/platform/external/objenesis"
+  },
+  "external/oboe": {
+    "dateTime": 1626885362,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e6f19927a874c00ae290f91ee4d5773ac62ffcc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z95091yv1akx277a4fsy0hxdlav1b7kn969b6cn5z6cnzm66fyl",
+    "url": "https://android.googlesource.com/platform/external/oboe"
+  },
+  "external/oj-libjdwp": {
+    "dateTime": 1614856107,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "312a813e8597153ffb0f006c9fbfb7d5e1c6e78f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l4l046zxwqw991qadiawlwsrbv2chwh0rapbqry93l4ygikmbqf",
+    "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
+  },
+  "external/okhttp": {
+    "dateTime": 1628888010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5cc4e8c802f75a20bbf2e4df42856d64acbfbbd5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "097dqcz04kxb379dvrhzkgn7w3dm65lwpq0g9hadqaq6pv1ymf9r",
+    "url": "https://android.googlesource.com/platform/external/okhttp"
+  },
+  "external/okhttp4": {
+    "dateTime": 1612297295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "82727b44d508352c5a7c2dca7a88a151df2ff651",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/external/okhttp4"
+  },
+  "external/okio": {
+    "dateTime": 1619035267,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab29022d6d948873c2ba5f5e1c72884c1f34ed30",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ln8mr5cr324v8dzjk35hhy0333sa74j9ay3xns35yk7g2pprxbg",
+    "url": "https://android.googlesource.com/platform/external/okio"
+  },
+  "external/one-true-awk": {
+    "dateTime": 1617391809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "375403bcf36f35eff75fa9eae38c72f1c5d10b53",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1g7v3ayb691jhr8fpcrdz5a5396qbilf9gkddx5wvl52cxrfd72j",
+    "url": "https://android.googlesource.com/platform/external/one-true-awk"
+  },
+  "external/opencensus-java": {
+    "dateTime": 1613830444,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "3b3f1d41d534a0c359c8415f8f7d66037099fe8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1i22bm033fn223k4hjiqn55aj1xr3mvcgl6880cqhr2i8cnw7ij2",
+    "url": "https://android.googlesource.com/platform/external/opencensus-java"
+  },
+  "external/openscreen": {
+    "dateTime": 1617743515,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a4440d900c07cf08dc688bd54516809a5588300",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v1y1ar5ak3mn893gi7jxrfkly7wl45m84gyj33pspcni831bsfc",
+    "url": "https://android.googlesource.com/platform/external/openscreen"
+  },
+  "external/openssh": {
+    "dateTime": 1637776562,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "727e0c89e52aeaab06fef504f1e6def0e7e95262",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "19jppwzmi6p26x24qpg60v8ni4zjyk1mkqb2qbq6cs3c3azdb6ga",
+    "url": "https://github.com/LineageOS/android_external_openssh"
+  },
+  "external/oss-fuzz": {
+    "dateTime": 1617393061,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30c3c9062c945537f60274e8da7ffa2eacb13981",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12ysv0nncqlx7gry6m10ac6x34y1kqs3y9jg5bzkb6dsb677mi6r",
+    "url": "https://android.googlesource.com/platform/external/oss-fuzz"
+  },
+  "external/owasp/sanitizer": {
+    "dateTime": 1613516538,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c0492b8555b6c5d1fc54896b08e54ed19cbb7a92",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bw90dnh8irryj7sn0n0swlx9vllvasxj8r01gh7prmawi97lh9r",
+    "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
+  },
+  "external/parameter-framework": {
+    "dateTime": 1613516537,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "250cda028b3db08a860cae084a1b64aa2da28447",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bf4fjy9p4fz7rp2plga2zam62s2k8jcwgn8mg0qka7jkddf1qrb",
+    "url": "https://android.googlesource.com/platform/external/parameter-framework"
+  },
+  "external/pcre": {
+    "dateTime": 1613814679,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d2a480d370a1e85c602320113ffe343a547b365b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dpm303wwx264bc6hxqlrfkfmavqwzb1k914gpxmdgfn0iv7hn2m",
+    "url": "https://android.googlesource.com/platform/external/pcre"
+  },
+  "external/pdfium": {
+    "dateTime": 1616064242,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e5fe6c9fcedbd4320739a2aff38d77a5e043322",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1g50kxs8y74bklsmnjzazd4nk8ajhksyapm5r0g2qidb3nmx3cl8",
+    "url": "https://android.googlesource.com/platform/external/pdfium"
+  },
+  "external/perfetto": {
+    "dateTime": 1628888011,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92c29f3ee84dda0408ef8a0c698350af517dccdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05k7j5ynnfr7hpa9320jax8yiaka3va8q5v1iwzjpdln7bmi8jp7",
+    "url": "https://android.googlesource.com/platform/external/perfetto"
+  },
+  "external/pffft": {
+    "dateTime": 1613821464,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8dc7e84864a0537b02b0c43f44c361f3c5fb9f0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qgf52lcq58ixhrhqnwcpixkkbrd586n23r14yikvbqhspdfar0s",
+    "url": "https://android.googlesource.com/platform/external/pffft"
+  },
+  "external/piex": {
+    "dateTime": 1613828455,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffdd3f9653b9439632791f1043eb22ddbf9452d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05lyk7vmhf7kq9bcwpg07nwvx1pdadjv1g3c1ny2wq2l2jchbps3",
+    "url": "https://android.googlesource.com/platform/external/piex"
+  },
+  "external/pigweed": {
+    "dateTime": 1618948488,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a274820f23ab694ddcb3c54d8b86933472a0791f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zh25gjyykp19xpg9jh5xjqaz87j75nb5qzqg08gf7smspb34rvz",
+    "url": "https://android.googlesource.com/platform/external/pigweed"
+  },
+  "external/ply": {
+    "dateTime": 1613513318,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac9c5dee9bc3f229b6b44b7a5c2ce78dde293ce8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04ran6mcqvfm06d2pqw9x62vwdr782h14xmn9zw8c7pw0hqzkqfz",
+    "url": "https://android.googlesource.com/platform/external/ply"
+  },
+  "external/ppp": {
+    "dateTime": 1623048795,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e08297fcf7114df93fa4611ba9d8522634bac7cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x8kmf219svcclr8yv94f06y9m7i4hf1sshs4vw557l7g0c56rs5",
+    "url": "https://android.googlesource.com/platform/external/ppp"
+  },
+  "external/proguard": {
+    "dateTime": 1588698674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6078cc0cd98a40d2127b959bde9e3e7f23423011",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0y15jn4kysl40rgbgh68z7gy9d1g5jjhkvms6gz1jz0vql7a0izc",
+    "url": "https://android.googlesource.com/platform/external/proguard"
+  },
+  "external/protobuf": {
+    "dateTime": 1625626921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2dfd2492c59836da39e1936eef51b8a7dcd1acf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ikjv3r0yg4iffq7s13l87va3f8hhhbinp4bb37kl26wb6wdjkzx",
+    "url": "https://android.googlesource.com/platform/external/protobuf"
+  },
+  "external/psimd": {
+    "dateTime": 1613504482,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c44bfefbb0f99eb1d7b381a45db9acb052a7627",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rq4alzwxxvls4pb4jb02sapag63jpvijjpjh2g2gb3rxnh9kg8q",
+    "url": "https://android.googlesource.com/platform/external/psimd"
+  },
+  "external/pthreadpool": {
+    "dateTime": 1613835472,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6ff981f1d6fb1e1ca4d0107d84d7af17e7a7eb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ixzpaa6335mcn3sd2kqxrbfr3835fxnfrz2afdyq17h65nvx3b2",
+    "url": "https://android.googlesource.com/platform/external/pthreadpool"
+  },
+  "external/puffin": {
+    "dateTime": 1613834272,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f43e9eb4403dfc960977fe533ddc8954ecb9ac97",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02jrnkqcr9jp2s6igb1nz3gbcr5zsb28x1983p5la5wq8cvykvf3",
+    "url": "https://android.googlesource.com/platform/external/puffin"
+  },
+  "external/python/apitools": {
+    "dateTime": 1613934270,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7245ecd6abd522fccdda22be3bef16db09d89d70",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17caach33h2m4a25fwbdkfab2kmj8c5gbv3wf5zfzh84k27v18md",
+    "url": "https://android.googlesource.com/platform/external/python/apitools"
+  },
+  "external/python/asn1crypto": {
+    "dateTime": 1613832640,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ebc4daa8e4a46e1dce2617fc0f78e166a42e4cc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00a85gygijpclgdcpp6ggr9zyamxval6k6pkq5ps97c88d2av40h",
+    "url": "https://android.googlesource.com/platform/external/python/asn1crypto"
+  },
+  "external/python/cffi": {
+    "dateTime": 1613934277,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31e6e50836f8a4f1e1c2aa834f1e51ced4e1797a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m4cr3zy22iahhiskp5vpn0b60rp08a368vkg4jzbkvwcap1z6ag",
+    "url": "https://android.googlesource.com/platform/external/python/cffi"
+  },
+  "external/python/cpython2": {
+    "dateTime": 1615254126,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "735b5faef27cf08c729566d4d2a867bdfecde98e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jki6h7sgdaak46rff8iijzdcdf9phrdi5935j86595xk5a3d9vi",
+    "url": "https://android.googlesource.com/platform/external/python/cpython2"
+  },
+  "external/python/cpython3": {
+    "dateTime": 1615252816,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71b8fd4f439edd12be14ab88ed8ba260921765d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07asjr9d3wlbphfy1l55xbvkxdilc6wzm8fhjqkmha70a7bxj7vm",
+    "url": "https://android.googlesource.com/platform/external/python/cpython3"
+  },
+  "external/python/cryptography": {
+    "dateTime": 1613934265,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5a76dc3832fb2ee39943296b74d35fcb81f1004c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10dgm0mh4ljqaj3b5wl39a2v0lgch1jcsrsxbjzx3n25alph1cpw",
+    "url": "https://android.googlesource.com/platform/external/python/cryptography"
+  },
+  "external/python/dateutil": {
+    "dateTime": 1613934273,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4829ddf97d49e997c031b422c9f67c1cbccf3e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pjs7hnd3yd3wqqacxis72jyzjcwd0f2bq967ysg8j18vzwjsx0q",
+    "url": "https://android.googlesource.com/platform/external/python/dateutil"
+  },
+  "external/python/enum34": {
+    "dateTime": 1613582536,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "4bafc66ea3a0412bad85715b6143052e2d1fbe6b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xzl7iybydjfwj5wg6bmxzzmdxv6zpl6qn4w6aw0zws3mra6jhk4",
+    "url": "https://android.googlesource.com/platform/external/python/enum34"
+  },
+  "external/python/funcsigs": {
+    "dateTime": 1613582545,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71b1b530420e7d71ba1f003b97271964bee7ac2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05v4kd9697gpxiyh83gsghh8c2vwc2gn9zlc9naj8k3apnc9k2j4",
+    "url": "https://android.googlesource.com/platform/external/python/funcsigs"
+  },
+  "external/python/futures": {
+    "dateTime": 1613582536,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "bc38daeb69a24b91b7bf8103bd8543182ace88c9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y2dviz6khx9as8kk3fq1dci62mi08yddpqfcsca79nqsfwf6rig",
+    "url": "https://android.googlesource.com/platform/external/python/futures"
+  },
+  "external/python/google-api-python-client": {
+    "dateTime": 1613934264,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "be4ea189ee019a20de22aeb93cc3f7185012b63a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hc7mrg2sjghznm5fysxqwq2rq8wy55rw1r66g57ripnzrn8xbqm",
+    "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
+  },
+  "external/python/httplib2": {
+    "dateTime": 1613934268,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d70e5c374c354d0aca00d5123166afa5370f45d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jfbxrd2prjm3nv3bmwlqqwgx6iqna777ydd430ljki9dymchj4h",
+    "url": "https://android.googlesource.com/platform/external/python/httplib2"
+  },
+  "external/python/ipaddress": {
+    "dateTime": 1613934273,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c885fcfdcc0926f66805d110871ce855b14e992b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rvld36ky44qc8yz64a5k6g52qsss96dadvsdd8yqmrx8zincd0b",
+    "url": "https://android.googlesource.com/platform/external/python/ipaddress"
+  },
+  "external/python/jinja": {
+    "dateTime": 1614662752,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4b7eaeb80ac4e7da9735ae1d1997cc3b172ff93",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0syg2yndr59f4mf3hvw6vs43fx8hf60678ky4ha2liypymazf2kf",
+    "url": "https://android.googlesource.com/platform/external/python/jinja"
+  },
+  "external/python/markupsafe": {
+    "dateTime": 1614663431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "588e78ab17dfd3da5cbd68ac44e72d2d65ea4c28",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18qjh0xrnc59w7divzjrriz7ppclhhlisypzlgd8b8hbd4ali3rz",
+    "url": "https://android.googlesource.com/platform/external/python/markupsafe"
+  },
+  "external/python/mock": {
+    "dateTime": 1613934273,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7ecb5d681f2a1a7c3af31e1db86c7fc00482b48",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1c8fbmxnl0h00dnwqywba008lm6bs8zrmvhagnp7gpr84if60gr7",
+    "url": "https://android.googlesource.com/platform/external/python/mock"
+  },
+  "external/python/oauth2client": {
+    "dateTime": 1613934275,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "8c31ee8ba8a4dcaa070906cbc6f1e1e09785e5fd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0snxs8dzmx5farizh7dk6kyw3pnw9dwq4lgjf55pz57zdw4w5h7c",
+    "url": "https://android.googlesource.com/platform/external/python/oauth2client"
+  },
+  "external/python/parse_type": {
+    "dateTime": 1613934278,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "eebfe042b753b24c1e55e8d97ca7635c3217ecc6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jl9ij257zg68c3vbb8wnkpl9cqyr0k115374hh0xwl86cc38x5x",
+    "url": "https://android.googlesource.com/platform/external/python/parse_type"
+  },
+  "external/python/pyasn1": {
+    "dateTime": 1613934270,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0b297b6125a0b3b9944b0f683cdf68f7e266771d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0m5fjmifgskidmbvnnq4rvbqkwzkdmvhpi7pya6b58s3cwmrwc7x",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1"
+  },
+  "external/python/pyasn1-modules": {
+    "dateTime": 1613934265,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "6d264d9fc12b94d305c1c17a11ec9ad043f114d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0n7isv62gq7h7i605p3lpkp67hqdbmcnmzzv30jr2m0g8bb52fjr",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
+  },
+  "external/python/pybind11": {
+    "dateTime": 1613582540,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de5dcc88c433df119f3e066585df6f7452a5d8c2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r4s6cadrw8g60zhq9nh2cyzvbc52w1amj4ydp5apz2z4hz24fmf",
+    "url": "https://android.googlesource.com/platform/external/python/pybind11"
+  },
+  "external/python/pycparser": {
+    "dateTime": 1613582546,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65d708b4cc4a66b2dbb52ee4c68435b629de5852",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "120qdb67ag3yy0cgwdxijjc32s54irpvyid8dgmkd4jdl3jii7ry",
+    "url": "https://android.googlesource.com/platform/external/python/pycparser"
+  },
+  "external/python/pyfakefs": {
+    "dateTime": 1613934271,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80ee2ec0a73d5da1ddd0c72a58eb2fedc6c5d623",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jw07iqzrjac1p3vfs3r2g0lg4nsfqxxi6vkk67as939ggkas836",
+    "url": "https://android.googlesource.com/platform/external/python/pyfakefs"
+  },
+  "external/python/pyopenssl": {
+    "dateTime": 1613834234,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e19c452d036d4dfbfcaebd148864b0872a0d34f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0h50kdfwm9wp4c6vyhf34p3lirz0r69dckdm6hjw45h4piqafdwf",
+    "url": "https://android.googlesource.com/platform/external/python/pyopenssl"
+  },
+  "external/python/rsa": {
+    "dateTime": 1613934472,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "712dcbd5c410ce46977d1fb94c0fcc08b00562ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x7jflip5dcbxd4z9ax3pzlqd0lw1dmgbjjffrrrjbq3ms5vg88v",
+    "url": "https://android.googlesource.com/platform/external/python/rsa"
+  },
+  "external/python/setuptools": {
+    "dateTime": 1613582545,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f76ef766004d7f957067f3c80687482275d43e47",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ypsmnmng16c8sqx8g3nsiybw7qfxyykpd74i1nqkx0x8qdfs9pi",
+    "url": "https://android.googlesource.com/platform/external/python/setuptools"
+  },
+  "external/python/six": {
+    "dateTime": 1613582546,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "742a35d89132afc6ffb4b89452eed847bbe2cff5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j9sx6jph7hz7axrmrmd2wpyvlp8d1gn16ph94vnwcm3izx9a7vr",
+    "url": "https://android.googlesource.com/platform/external/python/six"
+  },
+  "external/python/uritemplates": {
+    "dateTime": 1613582540,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "ef5dc04bb2c49485bfc6228dbde42def61a6c1f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mzkgmy5lxgsbd1az98lvqz50z12l862zgqhrak5jvmgxy33asm5",
+    "url": "https://android.googlesource.com/platform/external/python/uritemplates"
+  },
+  "external/rappor": {
+    "dateTime": 1613591031,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "138ce469d5dd30dc6ed74afaa675df9911339500",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0k2pwhs721qh0h3x77z9jzl9vww7gvfdqf9ypxlgia2mha9m2y97",
+    "url": "https://android.googlesource.com/platform/external/rappor"
+  },
+  "external/replicaisland": {
+    "dateTime": 1613504475,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b475754e40212a60f13956d617a39aad02578e67",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16bi4iv9ya7ylwhf4qm7rnymzzcl6wjl68rrrjqrsp9my28h4mrx",
+    "url": "https://android.googlesource.com/platform/external/replicaisland"
+  },
+  "external/rmi4utils": {
+    "dateTime": 1619753674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff530931a4b6d48a8f7b08d2bd0537b130bbf189",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lwxkzw2xl6mssvzivzgrnn3wmxkpbm9r3hpd0iif8124ha02zq1",
+    "url": "https://android.googlesource.com/platform/external/rmi4utils"
+  },
+  "external/rnnoise": {
+    "dateTime": 1613828074,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f9cd9cbce2b7d366c0fe89726e7b6debf7d6804",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1flgs86w4k7vrrq7mh962rf7y2vxnzfwsd12hpa44375rc06lrm1",
+    "url": "https://android.googlesource.com/platform/external/rnnoise"
+  },
+  "external/robolectric-shadows": {
+    "dateTime": 1631203424,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "36d93a2f87bd9d540b53a437148372fdd1911def",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p96ghpc1ffq7mk4k81y346h2ky1x87mnv80c359mvl71ip1ai1b",
+    "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
+  },
+  "external/roboto-fonts": {
+    "dateTime": 1621977525,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "819e55c583cc01fda911c8ecaa696521c170a4b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ygzmkkp1nj8c4spq3rgbdjx40vgmhkivkywikrab3wp3c469lw4",
+    "url": "https://android.googlesource.com/platform/external/roboto-fonts"
+  },
+  "external/rootdev": {
+    "dateTime": 1613582548,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6d8821375fad1ac73042655b543ae71dcfdb387",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kyqrr4lavpbqz47ajvf03vylgxs72l1nhxkx93hpl52w1kyqih7",
+    "url": "https://android.googlesource.com/platform/external/rootdev"
+  },
+  "external/rust/crates/ahash": {
+    "dateTime": 1619214482,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eaf747cb5767d348d66f6ea7c1513f2d9a8358a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hq34bv8dhqq4dh16bqlv49fsszfp1y08llsycpv8wwxhjwjbc1f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ahash"
+  },
+  "external/rust/crates/aho-corasick": {
+    "dateTime": 1613834112,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa8c618a2ef09173ea82c890e77441d2f8a326e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pjnv2f5g34fd8qrzdkhqi9fz1x5mrcg4539gjrkr3kfrwbxsnb4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/aho-corasick"
+  },
+  "external/rust/crates/android_log-sys": {
+    "dateTime": 1620818112,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b34665f1ba0bf6162ad6d12abe8d16c0285969a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1j5zn9ckhs1l9n8wgq1j5r4ahk7z5wny7idxqg5zlpf4nn0m6kr3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_log-sys"
+  },
+  "external/rust/crates/android_logger": {
+    "dateTime": 1620820365,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a23af341934244fb26f9f31c1f8e4117b9b14eed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xvwcn8dy0nas0kx33k8hhxvirkngyd8rn5d37bl07xr8lnqw82y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_logger"
+  },
+  "external/rust/crates/anyhow": {
+    "dateTime": 1620819446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "825f0b9db9b370fb5b7fb1761c48b770a754a084",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xp7kx5x6kfi6ginshvg605h5zg3x2hldjfr36y4y5qj899039av",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/anyhow"
+  },
+  "external/rust/crates/arbitrary": {
+    "dateTime": 1617719150,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "465ec3dd77631bf35e30a72023e1d867bb2d8325",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zw3zrfzlwaidbzsl0d166jpmi2hywk1gfjrs2b9wr2dln61dg2k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/arbitrary"
+  },
+  "external/rust/crates/async-stream": {
+    "dateTime": 1614577053,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f88c063d656a7903697f725feadb9dc969bb4beb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1s0h4zsr8bkygz1d4i78cp5897yvm0bz5iaffbph53n1gryh8ddf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream"
+  },
+  "external/rust/crates/async-stream-impl": {
+    "dateTime": 1614577053,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf624248e30452fe0913f28579345c33798ede72",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d30bmadkkr0hjly1033l7f3jr0bl1a30q8sdz1l58nx93c2sayp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream-impl"
+  },
+  "external/rust/crates/async-task": {
+    "dateTime": 1621014737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bef9bab47cc75d1285bf7dfbf0d1513eeceb09ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1a0j7nxi30zng0i6q2dkqqkg70a8bxgbspl3pflv98bsxjhcnc19",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-task"
+  },
+  "external/rust/crates/async-trait": {
+    "dateTime": 1619027637,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0905ff1c17d89586e0eda3e41a9a9e9c9f37a5c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rfbqsx81bhz1arfgzgql5kggqgfqq13yc65h69k44z91lq18227",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-trait"
+  },
+  "external/rust/crates/atty": {
+    "dateTime": 1616512499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80697a14738a31b22867e7ff30b5976297fe930e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ypvk3r03x00sq5qxd7c358049mzv2f0z364zkj2lr15yakp40f0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/atty"
+  },
+  "external/rust/crates/bencher": {
+    "dateTime": 1613587987,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb7f2d77e55ebcc72aeb96828aba76bef289fb2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d7skrpb2ipsqlcdsrl46cgdf8q7jf8bv5izmxd6cnw733zf5sv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bencher"
+  },
+  "external/rust/crates/bindgen": {
+    "dateTime": 1618845744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42d165e000830486bc4cee6976d5cd0681c777b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "185wjwx64ldpyk4y3w67jjqd8q54pgy34pi0cif198zk6wjz0v11",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bindgen"
+  },
+  "external/rust/crates/bitflags": {
+    "dateTime": 1619647840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e2f52d4c035046d2509bda6f73565070e731aa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ahjp9jmjwm6gm9wgfi4znwvpjpyfkyixk9pjrkx88v7d5c3jmdj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bitflags"
+  },
+  "external/rust/crates/bstr": {
+    "dateTime": 1617385032,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0f0f525d6fbfe4705f936229440e91bc7544a6a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sri0n70g1iak5831zqmkh00w90kk3g70cypy86g4zpzpafyl250",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bstr"
+  },
+  "external/rust/crates/byteorder": {
+    "dateTime": 1617385051,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1eb52397318f093e26f8d969b0be543c198bb0ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z56bdlmm8jf5bvb88ddk95b386xlc6hdaczm530jrzi07r77xjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/byteorder"
+  },
+  "external/rust/crates/bytes": {
+    "dateTime": 1620818125,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f10d955e2243701d96939aef13909110784a1370",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f7g96awyhi3sj71rbllbsq9c64j228r2g4wabnncrl99clma441",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bytes"
+  },
+  "external/rust/crates/cast": {
+    "dateTime": 1616512500,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efe4f9d6764f07b8afd83fbb335a47625264b97e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17c2z30zxyfqni9b9j1778xxjc1lvrhafhzlaw6jajp9a6kwn61r",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cast"
+  },
+  "external/rust/crates/cexpr": {
+    "dateTime": 1613815682,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b43d851c3dca9473c607eafa2cbaedf2b9a7ef7d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xq9rrmn61yjwzjv61zad20b5irsznvz5w8c7pn5hnjw83aa64ac",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cexpr"
+  },
+  "external/rust/crates/cfg-if": {
+    "dateTime": 1619647842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "70945680e8e37350beb1fc9d3c206d9e63cfd7ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08666bjm2z2hagfmwbhy7nxa00fprq4dbv1si5slhi6mlkmhhxf3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cfg-if"
+  },
+  "external/rust/crates/chrono": {
+    "dateTime": 1613587992,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad3c9d62917a3aeaa681d35ea534da1f95fe0cb5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x8si59fb4z6xpmn5kg48lamfx76s76vd443pl0qgc37jcdxx0wy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/chrono"
+  },
+  "external/rust/crates/clang-sys": {
+    "dateTime": 1614577077,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "23997cbdbebf8b27a6bda275da2722821cd14264",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "15x52kc16ak83l3l08x0crp2rk5x594bj6jkqbjkkws4728d14xa",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clang-sys"
+  },
+  "external/rust/crates/clap": {
+    "dateTime": 1619647841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a80451c8482e6e880c6fc04f5111372b96c16bae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wwiss20xa3x2dxznfglzrkb36v0x38c651dbhl9h15swjirwqf4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clap"
+  },
+  "external/rust/crates/codespan-reporting": {
+    "dateTime": 1617345393,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c3d67fec2f90f974af73a2470b970c716824293",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zsiq4anwyv212zznq8cm32rcigvf5xjvn817zav4pmwnq0gjqci",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/codespan-reporting"
+  },
+  "external/rust/crates/crc32fast": {
+    "dateTime": 1614631699,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bed02bdbdf380cb56bc2a94e2443a97af385db8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0w1knl6nfgsbvf7syqayrs86hlqvx16giyg9pmi2gqvf03b1dfqg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crc32fast"
+  },
+  "external/rust/crates/criterion": {
+    "dateTime": 1618268703,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b9242a02c4f576177f11687957347c70f87012e9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rv1c32p524j7v0cn0lhin8g1qy0v8nnnn7670ak6w3vb3lvxb12",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion"
+  },
+  "external/rust/crates/criterion-plot": {
+    "dateTime": 1616512495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1e2a7c9d6613e6a7916bf28523e79875b14e080",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0a72appa3mnq7rjpv4q3kpnmrbmvv3hrk14yai12qbzw72v08syg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion-plot"
+  },
+  "external/rust/crates/crossbeam-channel": {
+    "dateTime": 1616512498,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c083e029baaf7c663c80ddc88ad0a5ec5a2594d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nj6qicjbdkdrkycc43fgg0w7gyskmy3ahl6r9zhsb0dpqhys6c7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-channel"
+  },
+  "external/rust/crates/crossbeam-deque": {
+    "dateTime": 1616512501,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d9e45eb26463d772f166ffd992949c1344df454",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q88z0w823ap29c1qv6fqy9bmgvb82zs836332hpka1lbrfw0c0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-deque"
+  },
+  "external/rust/crates/crossbeam-epoch": {
+    "dateTime": 1617898941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef84a7c629e7af669d5412fd2d112d26dfb90057",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gwdzc4f1p0ch46zbfdbmrk59mg9848nj1acas9x91xcrn447j77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-epoch"
+  },
+  "external/rust/crates/crossbeam-utils": {
+    "dateTime": 1618819104,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7dec3d9d191ebada7ccd966c4785b9ad9b88c281",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0n97x42nmc8mmwraz879ld6nqdgsq613wiahq066w5j8jvsn1ll6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-utils"
+  },
+  "external/rust/crates/csv": {
+    "dateTime": 1617385069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3762be60d7e7c5f9d5af000e06508da562152a46",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10z3nh974sckbcfdxw8ah7h8mxvx1c6mfcjvcfr6pw8vzbq84mdc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv"
+  },
+  "external/rust/crates/csv-core": {
+    "dateTime": 1616512500,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c3920c720c5369f821b9f886d94f9d4092ece621",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y6kq025hkpl5yl4vakqd3h08ipbx15n2yayvw654k3vwl9290da",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv-core"
+  },
+  "external/rust/crates/derive_arbitrary": {
+    "dateTime": 1617345405,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "172c12e405368a2c7aee2b8b2eaa5c3383981a34",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d83srj03644dvy59r5612779gcp8g9dj3r6c1gf7c03vlfpdm8k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/derive_arbitrary"
+  },
+  "external/rust/crates/downcast-rs": {
+    "dateTime": 1619647848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07cf2119b18a9a2be8cc5646783945bd277311d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1325khrkxyr04bzypvdf44azyq5fvbgf3rxxygyfwx8567vyjhcg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/downcast-rs"
+  },
+  "external/rust/crates/either": {
+    "dateTime": 1616512495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b724317f5039307e95e04336f42d509ea9646842",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jbnwc9iiiyyyf5pa425ysnjv14awhpzylc1f65xiw4zg16l8d6l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/either"
+  },
+  "external/rust/crates/env_logger": {
+    "dateTime": 1620818082,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e43227a56990e590b5e33f7b92f578d71c42d28",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j8s6pp9l87lpj5cx73cqkwsbxgza1hjv376h35sdf5zznv8gp1a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/env_logger"
+  },
+  "external/rust/crates/fallible-iterator": {
+    "dateTime": 1613821539,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0fa4e5fc9c5bc9521bf1d01d825b29df6fffb6f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wwq8gzcwmwn8nd25m0p7s165d2fpm3gd0bh5qvacca5krdwbapx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-iterator"
+  },
+  "external/rust/crates/fallible-streaming-iterator": {
+    "dateTime": 1613821447,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6aac860ea74d8ac5ecbebc40f74e3689a4190b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0934fiwj33yqkyya8fxlbkwncpm1p48xcvs4058nc8xz92jxms59",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-streaming-iterator"
+  },
+  "external/rust/crates/flate2": {
+    "dateTime": 1621898069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a6712c40c100dcc796705be3583aaec33009653",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1j5kchixqzs9axz3k0k27mp7bwayjln4xks52r59rmzp1vxnld0q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/flate2"
+  },
+  "external/rust/crates/fnv": {
+    "dateTime": 1613829189,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "003e24de6b3b3e41378e5b76cc902317988331a9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "176wqsijl9f64scdjgj92r1q4l9bb96s2wapsgj6ldg5d4sh04q7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fnv"
+  },
+  "external/rust/crates/form_urlencoded": {
+    "dateTime": 1619647848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5b5e795707ce6feb89beb8d869146ad2bd102a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bm74vin0rx5h0ihgzg258ihkxvmx2dsrac7wj76y8xgj99x2k0z",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/form_urlencoded"
+  },
+  "external/rust/crates/futures": {
+    "dateTime": 1619647848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc08b4f8ae97e3a085571bbe4642a0b6f3715525",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0d0w7s3rbb90x8y6sxzg22cqqlfy2zabcbbzyllq40dazg5f0rzi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures"
+  },
+  "external/rust/crates/futures-channel": {
+    "dateTime": 1619647846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "435eedfac831e67bfb0b4bc32f577a29fafa929a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mjrc60cjhkfx1s4qzd7xjwb44wfff41p1vh1l2ibvmq3f80z15a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-channel"
+  },
+  "external/rust/crates/futures-core": {
+    "dateTime": 1619647842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "821151551ba25c35fe7cc46cec66402bd66b31b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07fp7v1lcln8v4ajyafq71s80z0904i5xrmn5zqn4mv4q1az1r8v",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-core"
+  },
+  "external/rust/crates/futures-executor": {
+    "dateTime": 1619647850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cd67735be90a0263177d696657dfca4e5c41c2ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0myqw6i9ckl72hdb1yklxjn1ay4zs81pflshy5p8336lqfw7v7ly",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-executor"
+  },
+  "external/rust/crates/futures-io": {
+    "dateTime": 1619647850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15baf73f5a00b0cb608b723ed92f044df2aead9d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d573cpchcpahlcbgfjkmqj1mdlbn70p2yxhzzgnna6a931h358c",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-io"
+  },
+  "external/rust/crates/futures-macro": {
+    "dateTime": 1617385035,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f92236882d3ad3e17e2581851c30aae20bcf0d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p5z0scaqqsngwgwgrmy1m1dzavalj8al9566q48pnrsj6xr8lbc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-macro"
+  },
+  "external/rust/crates/futures-sink": {
+    "dateTime": 1619647844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84b146528059ab2a5b1bda18ca978a65d88da1bd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sm91gkcaif1qgalfv8pakak3jaf6x9ryy63w9hcb6vv1rj599k8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-sink"
+  },
+  "external/rust/crates/futures-task": {
+    "dateTime": 1620937860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1f357518d48737becd8c8c0ef3ea89377ba8be12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19p56hy20hrs8b1pd1ba6cpnhf3pcbpy1vz5hqsrnzhca1yb7mfr",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-task"
+  },
+  "external/rust/crates/futures-util": {
+    "dateTime": 1619647845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86465087a6b412a7ddb8a1ffdfe59ec6a124d4bf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v5rpkakmi3yqakzwmyn3n9dvla3phwjq2y1h5rn7qm8ymvkfgk9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-util"
+  },
+  "external/rust/crates/gdbstub": {
+    "dateTime": 1617399235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61a2a6ffb4d35b30e251ddfe0ee660f7d1cf5523",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05s1b54bwl1fa4hgh9kr4ip8513vccg8bppbkpfqcjqlr68nh31y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub"
+  },
+  "external/rust/crates/getrandom": {
+    "dateTime": 1616512495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50fc1cd6d6e2db76a70f324c324341acb5d4b1cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wzp0cy89g8kvsn2q5kxsfqa5bq1319kvcs6wjimm03zd9jpsbq5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/getrandom"
+  },
+  "external/rust/crates/glob": {
+    "dateTime": 1613822555,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9a2c7e8c67a733120902ec0a938d5a13bf8987d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sd6b3y7w2lhma4d0y4930sv3adi97pkyq6szd765mxzaxm5dh55",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/glob"
+  },
+  "external/rust/crates/grpcio": {
+    "dateTime": 1617399198,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9bcf0093bbea5fd198efc634ca72cd5a32139014",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dc2x1jl20lb93833dkrjksszkqnjlwh9lzf2z34kjib5whxyicc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio"
+  },
+  "external/rust/crates/grpcio-compiler": {
+    "dateTime": 1617385028,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "337b514f3110730ecea29251512e03a001819376",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xd739ka5f56zywd9xnm934z472c7drqiz6hqg64cw9qxgp96fyc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-compiler"
+  },
+  "external/rust/crates/grpcio-sys": {
+    "dateTime": 1618950341,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c648fd1971998c18179f735aa0914fbaf087b2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hmydw85ih7cjdb3rdmpv1hmfqqb6wvz24z4ba9kwxn2y4vf2hnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-sys"
+  },
+  "external/rust/crates/half": {
+    "dateTime": 1618255956,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b1eb07ed5166495f2135d5caa45a41c95632a8b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08l0jgdfi6qmbqp5v2q8hjpf9rwqmampl9ki7qramhin3p6c620f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/half"
+  },
+  "external/rust/crates/hashbrown": {
+    "dateTime": 1617642892,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88e88e3c5f8897e62b60abbe9bdd957169bd4924",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0lkksfn0kqd6sqjlm35m4h6nv8bx78fw4c1dbkj2q82sqy63r88j",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashbrown"
+  },
+  "external/rust/crates/hashlink": {
+    "dateTime": 1613834491,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "adbe343c2ab291f8b64bf8480a8a6dc9e5818c45",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m1zxa9kcq561wckji7m2rsrp7h32zcsl67nz8sm3crmfiih89p4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashlink"
+  },
+  "external/rust/crates/heck": {
+    "dateTime": 1613832769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2f350461bb9f923a8847095ddcd13a110ef96303",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0x4djw1sjsl4p906fpx8davjlrnxar843aiap7qph620fa8f5p92",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/heck"
+  },
+  "external/rust/crates/idna": {
+    "dateTime": 1619647846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf1b1e4d733113609d93e86145a18d1b9e8272a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ymmrdxp31wpqwhfcaan2rjfhcj0gv7zigshhpcai1xv5zfb9ax2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/idna"
+  },
+  "external/rust/crates/instant": {
+    "dateTime": 1613822781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c647a9181cf7628e3cedab3df143bdb9fd8e6c35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07w1pii8i6qkfnwvhsm4iivflxqq6hpbmiyq7jsw4qbigsrjjrc9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/instant"
+  },
+  "external/rust/crates/intrusive-collections": {
+    "dateTime": 1619647841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30cab3cc54694886abbaf1e2d6af6c812226744d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06rv3d12ds3kdnsxlzv4318i1nykvsmh9hcvcapvhpxc8av9xj9q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/intrusive-collections"
+  },
+  "external/rust/crates/itertools": {
+    "dateTime": 1617728067,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4e9608cd5141665f10a758097921c380811563f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0w0h9zdc938l057zjbsvai9s5mnhyx9nga55agwarflg39gr12xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itertools"
+  },
+  "external/rust/crates/itoa": {
+    "dateTime": 1619647845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3f7755c4a0052cfafc1caa05eb602d949d9a96a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rji01a0sfkfh18jx243hbm69mqjx9i013df0zwisnvq4680536i",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itoa"
+  },
+  "external/rust/crates/lazy_static": {
+    "dateTime": 1619647847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72848d1888cc2984b50dd45fa18c0e3bae798456",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wbi944w289ihsvirwzy9y0casx6xfnyd6vlbrlp6mrly8i9f1n8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazy_static"
+  },
+  "external/rust/crates/lazycell": {
+    "dateTime": 1613815618,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "045ad574f678072de3c6cadad60b85cc41b73e6f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06di56bnsz4msyj77nwha4g1mi08k19ymh15isd79wc6x44z9h5h",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazycell"
+  },
+  "external/rust/crates/libc": {
+    "dateTime": 1620937861,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d28cc9fc2ba931d2045ff7f6e26061de0081ae77",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zx4l0w87azhy1pc6mnvzw0ksbjbfrv6gvbvnn2d5g2plp3ssja0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libc"
+  },
+  "external/rust/crates/libfuzzer-sys": {
+    "dateTime": 1617642881,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffff0a6e67e400c2ed1aa90068b7a1bcae9ca1f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0f5a2zl26ydvffwzfw3yk2mfpy63qkhc97vbmg6nqp03jd3gxdhv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libfuzzer-sys"
+  },
+  "external/rust/crates/libloading": {
+    "dateTime": 1613822738,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e8d880a18bc879de6ee809189f8497a17d87ef3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "125hn4cvm7d73y1caagf2vm17qzrkl6hppw8icibiwzc3cvq509p",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libloading"
+  },
+  "external/rust/crates/libm": {
+    "dateTime": 1619647846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f529b930a56210851f291c370f449cb69d6498af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "111agfhx3rid2cgg0va4rblsdvr5xa0lpzwqbbk15nh184ckbn14",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libm"
+  },
+  "external/rust/crates/libsqlite3-sys": {
+    "dateTime": 1618938801,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c9c5de4bb1e0b0448b09ed99ab4b79ff8469c18",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zw7ak9v8fayazqi33nvy6laysh2rxd424l2c8sxb5sshp9csp8m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libsqlite3-sys"
+  },
+  "external/rust/crates/libz-sys": {
+    "dateTime": 1613814632,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "13817a29554d94d741592c83a06b8804f9022781",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1snrdfqxghyiwd3w7yxbp0vl0kpx6w1ciih3hhvwhfg83yh754h1",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libz-sys"
+  },
+  "external/rust/crates/linked-hash-map": {
+    "dateTime": 1616512493,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "900b8c2f6a57257fe9bbc855401ce141027ae742",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10avx3pavwvc6w9pwwbkazahbrjffkq1bw4rd48fwbapsx2c1axj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/linked-hash-map"
+  },
+  "external/rust/crates/lock_api": {
+    "dateTime": 1613835275,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "be5c6062e0975334a62596341b9c7c240469a70b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18m7p6hd57zbhc4nr0l63i38zk9riw8vkrs172j5zzwfc086v3vy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lock_api"
+  },
+  "external/rust/crates/log": {
+    "dateTime": 1619647840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84327b4e38afb1667ae5a397fe4700929980e64c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zzb335rk5bpi75jm4sb5pf8rmnpf6dznbd5n4nzl1i226zfqvz8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/log"
+  },
+  "external/rust/crates/lru-cache": {
+    "dateTime": 1613822940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "908860cb15788f07dd27bfe6cf002051d833e4ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1cba2cgnkp681l5dhppipfidlj244mzzv0iwgi0qmaja99cdyzfz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lru-cache"
+  },
+  "external/rust/crates/macaddr": {
+    "dateTime": 1616512498,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "122b5128ad498bd5cd3f5c3dd2f8a6e76c9d043e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ih34msm26vya16vkqxsvf0zrxxhbdgm3gbxb80md6wlv4vmskjm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/macaddr"
+  },
+  "external/rust/crates/managed": {
+    "dateTime": 1616512497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6a7c1a255e863ef9f961d35755c9ff142a798ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05a90v3jq9yw5bj547qjx31l5fm6fafdl1mbngbkglmmw0i2bzmk",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/managed"
+  },
+  "external/rust/crates/matches": {
+    "dateTime": 1619647843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71fe727fe054b7e82c5d89c9b6243bf783afbc54",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sp2ddidbl3h0hbrkbg194jpqpdb1l74pi8kdga3sxczp3dlmkyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/matches"
+  },
+  "external/rust/crates/memchr": {
+    "dateTime": 1620818120,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0051f410abc504e3c75cb6c141b791a1b0a0fd4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hwsviz4jz3c7n7lcf95m6brifngx1r6s3h57d1xkqqz6vz7y716",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memchr"
+  },
+  "external/rust/crates/memoffset": {
+    "dateTime": 1619647847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50a56cc0ca41f8fba604353af199930a74013175",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1vkrp3y4l7vxcsbgf8wxfl1w9icwnikb69b2jjw77cy3r16c43qg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memoffset"
+  },
+  "external/rust/crates/mio": {
+    "dateTime": 1619647842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9b54fa678bcb6940f7d683afa9700c772e3c6bfb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jhji521v8686xn5zzl3myy4q6jdnsw8wn3bh6fa0cnyl60gmpb2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/mio"
+  },
+  "external/rust/crates/nix": {
+    "dateTime": 1619647843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7d34193784879b8b9fabf36e48523741fc69aca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wvpj5950hvj55gajh3yp2pf514shscnp4z39h9md9rjzig9qwr7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nix"
+  },
+  "external/rust/crates/no-panic": {
+    "dateTime": 1613832651,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ba9c29e1e27f4e2a6dc908a8f656d1e954d3a85",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cz0nj5d58s0p03pf4j3k14d9my2iss4gap87ln7fkx63kll7l9b",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/no-panic"
+  },
+  "external/rust/crates/nom": {
+    "dateTime": 1613815575,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4e86f6748b8901d9c41007a9f5c21caf84644ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00iz5lgxgdlshwmsbppiw509y574dicmk3zfyba4xz0scd564xnv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nom"
+  },
+  "external/rust/crates/num-derive": {
+    "dateTime": 1613814599,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f256e4d38372fb388641139475cb5910113a1c8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07l72iv3aikhcfywfll8rjh7ylclndxr7cidcq6a8i0klxfibiv7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-derive"
+  },
+  "external/rust/crates/num-integer": {
+    "dateTime": 1613587988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "915de5875bfa1ead6b76a1bb9d366ccf0b855e1c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b0i5j8vgn1xvp66dcwdvfcq8hymn7hx04411lrbcha9v1zrjl23",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-integer"
+  },
+  "external/rust/crates/num-traits": {
+    "dateTime": 1619647844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c9cc9e6499065748f041e65644e55b93bfad7d6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05ar1k2x8pqqr9hn4cchy5kbv5cg80aaxq0k6xp794m3cn7j275s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-traits"
+  },
+  "external/rust/crates/num_cpus": {
+    "dateTime": 1620820354,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42ff0bf2d87c178696e29b1cd298b99f0e235ba8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13l3ss2303qgx780ppsp7y8zkz5rh78mznml1mbnhk1j177zdjwp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num_cpus"
+  },
+  "external/rust/crates/once_cell": {
+    "dateTime": 1619647841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ae220bbc3384c0693f4267727f06d33fb2a2acb5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pn4aj49f25r5jz4dm9wmdf1rmmghzff2yzplikbgkx4kl31q5zx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/once_cell"
+  },
+  "external/rust/crates/oorandom": {
+    "dateTime": 1616512496,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9cadaad3163c60f5dd5f66b8d995ec7c4c002b87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05xsrs0hvzh9z28lmfq3slmjzia6dg6nqlsx5qzwzn06qximykaf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/oorandom"
+  },
+  "external/rust/crates/parking_lot": {
+    "dateTime": 1613829208,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "715cd6132911c309d125d307388c5c0281fe4dcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lfv9la7lm4m8k5wln2xv4ghv1yv4z99mgzl2rx5hz1rfrgg38g4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot"
+  },
+  "external/rust/crates/parking_lot_core": {
+    "dateTime": 1613822529,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b734a16d2409bb5cbab654598007d64cabb601f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rkzqb6is3c3s08m4gf16s17i6siy5xhcc77s25rwlvx6waq4k8d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot_core"
+  },
+  "external/rust/crates/paste": {
+    "dateTime": 1617332493,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b2531f4269582c435619b02f02bd9f652e3907a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vy1knxk1rckadyjyl72dcyqc6wz8dvq0c986z3652cl0g0q1pji",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/paste"
+  },
+  "external/rust/crates/peeking_take_while": {
+    "dateTime": 1613835297,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50a35bc99be8e4c626c8d2165493b3c681d21aa3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12901vqlv7ciffpdq7bfdcfx2vpylwv16czvrm6174g7d9l68fv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/peeking_take_while"
+  },
+  "external/rust/crates/percent-encoding": {
+    "dateTime": 1619647849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2833dade6f0d56277e5ebd476fb55d17bd778b0a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vrdcvkv72306calx7q3hxmsk2b0kcac9hjn9s92l01am2svpa65",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/percent-encoding"
+  },
+  "external/rust/crates/pin-project": {
+    "dateTime": 1619647840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a626d1dd8a17a9f643c3e9cc43a4a27ed7a3c096",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y0037f6zw4qyjjmb8qgxr15mdf8a36iym0r2in978bx6vickbyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project"
+  },
+  "external/rust/crates/pin-project-internal": {
+    "dateTime": 1617399190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92b6db81914dcbc476b70e2e302f695b5eb7cec2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dyjczyl7rjyj3qlslhvks0cb5hfmiz98g6il06837sl7sa7r435",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-internal"
+  },
+  "external/rust/crates/pin-project-lite": {
+    "dateTime": 1620818116,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5b3a761ced98a30a1cd6a50ca9b71cad456a2c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19hx6g9vkwl07f5d65irylb82dj96w9sfcrpk2g5jnj4q35991di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-lite"
+  },
+  "external/rust/crates/pin-utils": {
+    "dateTime": 1619647841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a4a475f3259e69b670811b650700fd5673b18e6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wc5x25b440l1qlfslhpvnm9yppwxjmx284wy7s0wz9jr9ikdn3k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-utils"
+  },
+  "external/rust/crates/plotters": {
+    "dateTime": 1618268703,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1e36f62421a12cef0ba14811ee0e16204bfca04",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0w3hzsr0hz5zz7cyn9r6hscan9arf8nbiq6fbgjaw67vjzzgjamd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters"
+  },
+  "external/rust/crates/plotters-backend": {
+    "dateTime": 1618268731,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "78e2c56a727dd55853f36fc8e31555ee5447bed0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f6vxfgg2nb130cs0ykr4clhzwm9sd37hh87zk53v2yh1k2nsx63",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-backend"
+  },
+  "external/rust/crates/plotters-svg": {
+    "dateTime": 1617719155,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "558277bca89864c1bd380af5f5ad64b8ad9fbfb3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0knjd1657r31h5djbkacpiapax09adk2ryf8izayli46ifyx11bz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-svg"
+  },
+  "external/rust/crates/ppv-lite86": {
+    "dateTime": 1613827070,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bae304eb849488ab7efcc2265076e93487f53835",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02gkxcgik9jaw36hm59bs2pkgirrgz71ngsmxdda98h1ydip7i04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ppv-lite86"
+  },
+  "external/rust/crates/proc-macro-error": {
+    "dateTime": 1613823949,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee0fbdbe06962dc00731ceb2a41c7859e22a5fe8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1knxgc7r9x289qmm38vmrh6sdyfp06i4n4ajlknyirb7gkqmw2br",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error"
+  },
+  "external/rust/crates/proc-macro-error-attr": {
+    "dateTime": 1613835426,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0300302853426ab77c92dd7b1469aada426da25b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00zdh0yjlvp8lfc55a9vpf30b1q4m5cnyqdd1sfxxjlfv5fjbddc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error-attr"
+  },
+  "external/rust/crates/proc-macro-hack": {
+    "dateTime": 1613814642,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f885e797b15dffc2dc4a00352a7a20ca0998edb6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k1ljy6alvx8hq3ym48ajavdljr6199xfd75ql72926nwk9aszxv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-hack"
+  },
+  "external/rust/crates/proc-macro-nested": {
+    "dateTime": 1619647843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8dedf3e5c8c5b3890b2a35425588b91ecac1801a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1cm5csfpjbxbqs80javai4s0cdaz1d0a9i9mj45ck1dr1k9xzd5d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-nested"
+  },
+  "external/rust/crates/proc-macro2": {
+    "dateTime": 1620937860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e8c743e2ba0d90a36903bf75ef265a3ac9c11ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01f5n87cdwhmw31b2433hv8fq9345haqhpg6k54as37g5pf4r052",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro2"
+  },
+  "external/rust/crates/protobuf": {
+    "dateTime": 1619647849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7db42165e762da79e489444d10092b270c8512a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v05llm5p3y1w36vnxlb58n0p5bdg5k2sr9vjrcq14biqapcm3di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf"
+  },
+  "external/rust/crates/protobuf-codegen": {
+    "dateTime": 1617992114,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "32cbc1e8bd6b43853c9076574a1e9367307bff09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yp4dly0d57gcyh4jp76jkvwxrbnv5w8vdklfmdd2gnad3gg5qjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf-codegen"
+  },
+  "external/rust/crates/quiche": {
+    "dateTime": 1621584470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2a563bb322660011576793a79be3e31f18708e3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09r61vnj962kpz4s4r47mj21823244lnm60j0vnf9gp6yr10xv6w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quiche"
+  },
+  "external/rust/crates/quote": {
+    "dateTime": 1613828379,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f120bd117d609d692ad23a5c635a96b7aa4df872",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lmnm2xvq7sqz0vqprqfgah04rwfgs3jga4za3ijpzmqr4bfqxbs",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quote"
+  },
+  "external/rust/crates/rand": {
+    "dateTime": 1620926622,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1571a21cba2a11578c1c5e3e0f196456b7aa25d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1q0xgznpka23616c4c52jw87yf2yf1nqxk4nrbs37idvdax3370w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand"
+  },
+  "external/rust/crates/rand_chacha": {
+    "dateTime": 1613824026,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5bb948eb0c9ba45eecfc1e3a17a2420b345418ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11nlq925r5jay7akqzimrk5lpr38cyi5izlpzmjqs73jv6j21n4l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_chacha"
+  },
+  "external/rust/crates/rand_core": {
+    "dateTime": 1614390980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "27b8e0eff1875480615eeb20e4cde9dec31011b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yagpl8553a611mywlvf7zqdsqdgqh661y51lw0b9alh3m0dix5k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_core"
+  },
+  "external/rust/crates/rand_xorshift": {
+    "dateTime": 1613615865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c97af34bb7e17945a758a7fa556cc7d65b121f0d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0pxla85gls4kib4ydlpzzsj3yw2s7ryk1yvljgjx7avkam3ba86m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_xorshift"
+  },
+  "external/rust/crates/rayon": {
+    "dateTime": 1616512496,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64148297daec53566aaf3926246bb8d88f8e9148",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xffdyamd965vw93hl7zw6mgip01mybck8pfljr9msza39wfvp34",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon"
+  },
+  "external/rust/crates/rayon-core": {
+    "dateTime": 1616512499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "85d828fb59c13e152f7f8be2beb87b10897ee4c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kswciinmwn6f3xfgnxgqpnd6m3v6sm3m7d14vn2xp7938hi7s9w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon-core"
+  },
+  "external/rust/crates/regex": {
+    "dateTime": 1617399194,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "861d4cb36bf7c4988d08d7a1f42354a46c4edda7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0liqpk6bqwdypjawgcgwpdiy76a6ab5vvhi249430spb8552rvr2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex"
+  },
+  "external/rust/crates/regex-automata": {
+    "dateTime": 1616512494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b535fa94cfda4d4527abc8b8f3a5fd51aa681b6d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "060cvq9v43k2wca81bcyxyqspgyww0lw08xkiq0bznrql2vp7f04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-automata"
+  },
+  "external/rust/crates/regex-syntax": {
+    "dateTime": 1618268759,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff04e5ae2b51e2cdf1e295011cf16e376d5bc9da",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1amzxpm2072myiyzwqvipr1nsxbdikhz49pvm19kbzmasnnx7gin",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-syntax"
+  },
+  "external/rust/crates/remain": {
+    "dateTime": 1613827163,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0007d52adbcd9cba5ac1bd5c34e2c6b0e3f6de3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0d53xbgp935395b99anix9l3193ss2imi0dwzxqpr1b3x5imbff6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/remain"
+  },
+  "external/rust/crates/ring": {
+    "dateTime": 1617797211,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "330555e2947bc5078ef4bc115eb85d01ab6fe58d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1svc2bj08si0x9frpkz90i7zal3lxbfi4kgl20w8r4018hk30c28",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ring"
+  },
+  "external/rust/crates/rusqlite": {
+    "dateTime": 1613827206,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17376dc7d10bc3df237aa74de5a94708b44605b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vq390rcdxx95pnj75j3dp393irh0rxsc0frz6mwpcfy7qvlkz7k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rusqlite"
+  },
+  "external/rust/crates/rustc-hash": {
+    "dateTime": 1613830762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "822829f212c466c171e6318315adcf622ef2e88f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v30cz4b7ckpz4i6yzcz4xcnkjvvpfd9ijz2qf0xzfqjaybfhlyb",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustc-hash"
+  },
+  "external/rust/crates/rustversion": {
+    "dateTime": 1614390980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1fe9b300b2f7d8273b7bb0a62755e8ddb703028",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jjn769sm5h0j1g2ysxip2c3qn5fgiyklnc80kpwpbc8pz359vlm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustversion"
+  },
+  "external/rust/crates/ryu": {
+    "dateTime": 1619647847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1eefc0e81a57dcee102c12b0c74a1b6f051d0488",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0x7nx4w6pmy0bwbrlqgkdmjmbp4823gd1mfxxk240g0wy7zbpc8w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ryu"
+  },
+  "external/rust/crates/same-file": {
+    "dateTime": 1616512494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "619da2e2e7ef8e4e3c237eacbb5c56bb88ddf1ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hqv1pdqmjpnicwzmk5ysjicp552l61ppqv9liy201iz7bl2yagn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/same-file"
+  },
+  "external/rust/crates/scopeguard": {
+    "dateTime": 1613822862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43315394f224b6ceae302e840c37c85bcb48e3b4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0yc9w5xz3vyjyyw17la529kz4jy4ayk1s98js871ha4xkbjwh840",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/scopeguard"
+  },
+  "external/rust/crates/serde": {
+    "dateTime": 1619647847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4355ab871c989b6584b687d80d75e827624c421e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z74h4ir11fk52g0fs54mmalc4cd1ixycmngz3dam3li86hami8n",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde"
+  },
+  "external/rust/crates/serde_cbor": {
+    "dateTime": 1616512501,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc036af097bbb4d44427ba3ab5478b1dca57581a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hcd2xar0ymvly9qn9sxkwzg9cgx4isnks3v51dfdhz7np2rrj06",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_cbor"
+  },
+  "external/rust/crates/serde_derive": {
+    "dateTime": 1613834507,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da718a0f44420a955aa80024bba7aab72d5642f6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1api77r6ylamm2zlhl76n3jbfrzqkqbjq42kn9y3bq6akn7ixvw5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_derive"
+  },
+  "external/rust/crates/serde_json": {
+    "dateTime": 1619647848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2728575f485948232d0da452491532fe5ec2941",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qcw6skd8wqgy6mdh14am0wp30dlc7cwp09fg2ml0k3w6d6zrz62",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_json"
+  },
+  "external/rust/crates/serde_test": {
+    "dateTime": 1613513316,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30e1af9a30b5fe5c1e21c61de5054b895d451247",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07hdv8n29f5rrngjn7qxmq9dw37j1y5awlbpga204jzj52bg8sax",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_test"
+  },
+  "external/rust/crates/shared_child": {
+    "dateTime": 1619647849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0243e16bd00d807283c7d0657a144612d4c13b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0l52r5sxgr164fqmlhfhdk7hr5jwwqfrp558pk41h314y3pr1gg4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shared_child"
+  },
+  "external/rust/crates/shlex": {
+    "dateTime": 1613823841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8564ff5e32aa99319d1e67987b35ef6b835d1d57",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "135jawxfirwgh6dh0k25bl1k8acmvpwwpah62dcr775x3g885srj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shlex"
+  },
+  "external/rust/crates/slab": {
+    "dateTime": 1619647845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d7f7f173248e8df9238430d8498f748d932a9cb0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rvrph29d850l06wi8z0j3gzsnfbzlxnpgpqwxqwy3nqvvi90d9s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/slab"
+  },
+  "external/rust/crates/smallvec": {
+    "dateTime": 1619480254,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c8546456fb79589d0a242880b8a8479321fc1536",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02mvm1c3d9axdf9qkg2rylvhp7sgxcx9n338xfmaaq1c76wy0l7x",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/smallvec"
+  },
+  "external/rust/crates/spin": {
+    "dateTime": 1619647844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eacad1617de12955ab9d6023ef7e8551fd337964",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00kv0aicmq07y6i44hz382h4fzhz4gbl31ckbch0f9c6xyhm0g8a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/spin"
+  },
+  "external/rust/crates/structopt": {
+    "dateTime": 1619647842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "262c0cbc1ce62d5728d5be648a3ae4176e1d221c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0n6lk2i8z0brsrg8gilmlx58h58c6j02jhln9rm9x9r13vhy09fq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt"
+  },
+  "external/rust/crates/structopt-derive": {
+    "dateTime": 1613828504,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c107e396223c54dc79db164cfffe4d94f05568fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16yjhl98qilspdi2rk0bhs3ckav3rysdccbq7nm6w6zpvn4jm4zq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt-derive"
+  },
+  "external/rust/crates/syn": {
+    "dateTime": 1620937860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af8942f04a66575c4d8eac24f98d1681482f6476",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "086z6n4nkw8sdjwjfvnrzrsmiyahq2s6aw4fp776kgwg7lxl7shp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn"
+  },
+  "external/rust/crates/syn-mid": {
+    "dateTime": 1613834178,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6daf34f029f68785adea4fce15596027f15ec286",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hhvqxhk4rkwm0qkfh71rc1h3p1naldxw11691igmn6rgr8q94in",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn-mid"
+  },
+  "external/rust/crates/termcolor": {
+    "dateTime": 1613815582,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "476f054f1c23ccb04258dbc41d34168dfcb6074b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cqjgbwvccydjz2xrsrbsia3lmfzw275g1lmxw4jla1zfja4q9n0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/termcolor"
+  },
+  "external/rust/crates/textwrap": {
+    "dateTime": 1619647840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b3c2e54a3a06522213d1f5a94825e85ca8f9b29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hc46d3jlx6v5swfj4d0p9267snl4xx6wpwx26s3bb4s98z4bdfn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/textwrap"
+  },
+  "external/rust/crates/thiserror": {
+    "dateTime": 1619647840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe59753f0a5ea8975d17a1488a2d05d6f03b6cd3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02n6qiz8qpq972a06xdzgxs5bffpgs6mwx63chyxgnqy6726flh3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror"
+  },
+  "external/rust/crates/thiserror-impl": {
+    "dateTime": 1614577077,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f0790eaea25260ebd6de523cf6a446f5e0c416a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gg7s24ady7zlh46nffk7yh11rrddg8wvsdcr7c711dsbxxb5584",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror-impl"
+  },
+  "external/rust/crates/thread_local": {
+    "dateTime": 1616512497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4682be8e4de42d80923185cab50d0a5d05e3d94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ln79byy89kpxygpqd11bbi5xsjypy1n28wrp91hy6sx786hla85",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thread_local"
+  },
+  "external/rust/crates/tinytemplate": {
+    "dateTime": 1617990862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "99bb6bcd8b90d9a8c0fd938d564c029a55a54fa9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10wg6wj3bzynr1z9pb50bmr6pc8i7xq56lwjydgwilhwi6p2g96w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinytemplate"
+  },
+  "external/rust/crates/tinyvec": {
+    "dateTime": 1620817038,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed150e3a9e42f9965d0292fc3d1aec29470302cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1iarzdmdck0f5fdwidd665m45wxl9aj32s1lm30nd5379cprmrwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec"
+  },
+  "external/rust/crates/tinyvec_macros": {
+    "dateTime": 1619647843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "396092a96d062af04c838035cd0711c4d49f188b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0y1c5xaq9nbiyi52zaapdbbhm7vmq6hizxmg0kd0nlyagd95smsx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec_macros"
+  },
+  "external/rust/crates/tokio": {
+    "dateTime": 1620820358,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "376464b75080c0925562920a76cb4a35ad98cb0e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zjh0cik5kwp6vfisza3bifjyplp8ymc52navzgqyf2zc5x4lnvx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio"
+  },
+  "external/rust/crates/tokio-macros": {
+    "dateTime": 1613830805,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "262d7bab7aa20967ff5215c9173eee799e610c84",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0py405c2b4bci1gj7gf4swv8s80fzqncm8kppfv04xd78ph9mmwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-macros"
+  },
+  "external/rust/crates/tokio-stream": {
+    "dateTime": 1620928101,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4eac2ac9bbb8da8fcecae121b37532b7a69af30d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1369f0daiyy9yvbf9k3caifcnp7b2wjywy29if55kl0rb0pgs764",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-stream"
+  },
+  "external/rust/crates/tokio-test": {
+    "dateTime": 1620935669,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d3c9c6ec56e0adc1e8ad8b1c62de6993a8fec36",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r8ddxhlrqdi8qwwj9frqp40l8jzzp3jk2w3bmm31n97sp8ma0xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-test"
+  },
+  "external/rust/crates/unicode-bidi": {
+    "dateTime": 1619647843,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "06a9ea566c592bb3a6088a79a68ca80e03b964a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r6bd31wn5nbs18rrgaf47gyrivlxd2rni86qm78f4r7kabzadhc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-bidi"
+  },
+  "external/rust/crates/unicode-normalization": {
+    "dateTime": 1619647850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f483a39b82ca2fd9f506c4b9010ea989063c3fa7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z5amlnpv23q5n01093rx4j6byjc58yg1r1y0f0lcxxky293r718",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-normalization"
+  },
+  "external/rust/crates/unicode-segmentation": {
+    "dateTime": 1613829405,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f4830f1565f4565d02f73a5fd352310641930a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07fp8jn2fm4jpy523ifpc7fh9gsb1dqja1x9f508ggigmklgxhic",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-segmentation"
+  },
+  "external/rust/crates/unicode-width": {
+    "dateTime": 1613823742,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5a3f99ffcb4be0422565ff03a4fc30a4acaace6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xqr3v1kq561xbw126kj4xfvysd47sfj7rz4ld9pr9vm1nxmgr46",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-width"
+  },
+  "external/rust/crates/unicode-xid": {
+    "dateTime": 1613830797,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5bfb995a8122e99b4af17c3120024a92f740b73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11j24rxm4r9zykcidasjhgiy37p1lqrmkpa7dl0rdb7c1hyj7lnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-xid"
+  },
+  "external/rust/crates/untrusted": {
+    "dateTime": 1619647841,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3bba28be5317f43f24401ed843083debc63ced37",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "135jcnwi4f8a5lx7lphdc9w9qsdv0xj63lxh7wxgkkz00d12hh93",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/untrusted"
+  },
+  "external/rust/crates/url": {
+    "dateTime": 1620407240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67db174e2c303a65b1390cffe47737e8e0c380e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wm10msikrg7l999qkrwddiy6q609j07agddz71gk83gar6nfid2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/url"
+  },
+  "external/rust/crates/uuid": {
+    "dateTime": 1616512501,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8da5771d9e7a45ce53479e4ca2787f66a10f2f2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yi08nmd74fiixrpsjgrafqsa8lrzwcg7srhbsnf6j5sx7bql2jd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/uuid"
+  },
+  "external/rust/crates/vmm_vhost": {
+    "dateTime": 1620855832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "47d072cd3d43a54598498d19780194ed49e02fcd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vxy8rasfr2acj4p8hzg3ysaibfl4kz7f8sd8lp0frpph18v579d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vmm_vhost"
+  },
+  "external/rust/crates/vsock": {
+    "dateTime": 1613822488,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1d7eb958ae7a53a54064e4e458e66bf8eb0ee1b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13x5kiyz72rcssg5ldfdq77ss5xq2q6ixixijcn4sq5411j75dmd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vsock"
+  },
+  "external/rust/crates/walkdir": {
+    "dateTime": 1617399186,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6617d0b5e77e8ef25dfc597787f16cb200572be6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "081x2cvl8zh0xh0nb2402kgdv1pak1j5hijlh3iz3msndcsqgrmm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/walkdir"
+  },
+  "external/rust/crates/weak-table": {
+    "dateTime": 1613821619,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd2f8c4a9fec3fce8f2968d5365f51ffe5e2666b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18hkrqykf2rh7hbwzvxmwr58ixybbi7m6sl9mvb3pwk8yf2qzq43",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/weak-table"
+  },
+  "external/rust/crates/which": {
+    "dateTime": 1618268738,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2dafa0403b0cf2006d9f3a8eede326c200180b63",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0svgz9mn1d6a14dnhghvw102s82bjyk3s9kh5ja6h08kwch2yzv5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/which"
+  },
+  "external/rust/crates/zip": {
+    "dateTime": 1621664595,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d7475814fd03cb687e1bd19817c961435ffd0dc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07da00h2m2kar3r2r891jhc625d5z99jb03vb3c56135kiasnzqi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/zip"
+  },
+  "external/rust/cxx": {
+    "dateTime": 1617918922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a566790ce84c05459eed321cd3e932b2bb55f68",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jlw2bpzhynqzgdaw4f23j41njwxhd47gi3iy64g29z6hqicmdcg",
+    "url": "https://android.googlesource.com/platform/external/rust/cxx"
+  },
+  "external/ruy": {
+    "dateTime": 1615997763,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "54d025dab5d7835fb7a61584076aef43527f732e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sl38mw33dcla901rq0dmw98lvpdsnwyis8fsxr5qkvar7fsfai3",
+    "url": "https://android.googlesource.com/platform/external/ruy"
+  },
+  "external/s2-geometry-library-java": {
+    "dateTime": 1615311019,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9fcb918f1d61c4533dd9fb99ea2f2fd8c731132f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x5lyg0jhcnyh647vyyhn28l7x3qgf3x7b5pasd732rqi6kkcibz",
+    "url": "https://android.googlesource.com/platform/external/s2-geometry-library-java"
+  },
+  "external/scapy": {
+    "dateTime": 1614822458,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "81a4281f9e96199add9a12981a722d43cd7c94d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vq0sjbxagkkinxvzx77h6sxcvqlbl9fz9z5845q8kb9wrf2a0b7",
+    "url": "https://android.googlesource.com/platform/external/scapy"
+  },
+  "external/scrypt": {
+    "dateTime": 1612563984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "765ab9d40639c3881e1fc272aaa8446eb0d58323",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12y4bhrw9wbp470b6pzpwcnxgy8nvlaskwa13vvpskyydiwxwr4f",
+    "url": "https://android.googlesource.com/platform/external/scrypt"
+  },
+  "external/scudo": {
+    "dateTime": 1624562247,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa314c027aa5e586da717fb6bbee2b77761bbda4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02wxvm3fsg67aff80n5602ymxm45nwys3ygv7wrmifh1vk7rvbg3",
+    "url": "https://android.googlesource.com/platform/external/scudo"
+  },
+  "external/seccomp-tests": {
+    "dateTime": 1612563967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efd0d1b53e86af3a00c127d88e391fb18b6834c8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "150n3hfdna544dfxw4xcd74idcz1c6rzdfzpxz26pv88ki79nzds",
+    "url": "https://android.googlesource.com/platform/external/seccomp-tests"
+  },
+  "external/selinux": {
+    "dateTime": 1620996762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "90f71ab3bc71f757ff55ab8e3bda80a46bcb8cad",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19lc7df0wygsx22iljwg3528vxsib78ancc1rkq7xjdkhcv8nz7p",
+    "url": "https://android.googlesource.com/platform/external/selinux"
+  },
+  "external/setupcompat": {
+    "dateTime": 1623813582,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d562f5bb33b2e3ee7d1709bc4fbaef567e864fa6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rsphhzb4r70d2fp30q60d4zqpqlwcrdnvh3sg31m5nzrgljypmi",
+    "url": "https://android.googlesource.com/platform/external/setupcompat"
+  },
+  "external/setupdesign": {
+    "dateTime": 1624927300,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f8947d4120f1d2e66fa79e3be34a2c5b3b1192af",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p528d0ilgj0hmbzb5mss0zdf6qlrlzhzias8ppaw8l3zv6yq28q",
+    "url": "https://android.googlesource.com/platform/external/setupdesign"
+  },
+  "external/sfntly": {
+    "dateTime": 1613934583,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "bb24290d3b3bea5e7bce050030164bc86d99103b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kakd4icw5z61imziwk9xrvrmzr0kz0c3xkx7ajqf313jl9i895w",
+    "url": "https://android.googlesource.com/platform/external/sfntly"
+  },
+  "external/shaderc/spirv-headers": {
+    "dateTime": 1613582544,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1363fd1ff60402eaff412bcfb50334e0afce0b6c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1krwchhxqhsgjkj701884g0b40dh0j0ys78psi5g1mzvllbcnpq1",
+    "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
+  },
+  "external/shflags": {
+    "dateTime": 1613821628,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4db863f11a875bd4236327ca759604363891bb08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ffv97gprb7a2j3apfj97ss1ddj4l6zhpjacr63kxkwd4cd1sx5w",
+    "url": "https://android.googlesource.com/platform/external/shflags"
+  },
+  "external/skia": {
+    "dateTime": 1632183124,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "a4b0c916887704b201c75f5308fcb88e73b7cfb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06y1y8148wswb0y49ziax0yiw4d7v5glzp483dsx2pzn52ggkj97",
+    "url": "https://android.googlesource.com/platform/external/skia"
+  },
+  "external/skqp": {
+    "dateTime": 1613821394,
+    "groups": [
+      "cts",
+      "pdk"
+    ],
+    "rev": "87d185db6e17035d7c0df51afd03c2f2f34d9b52",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rbdbripv9gbym5rannpyjycz7jc02rdsnf92l3ji6xz1k962a0c",
+    "url": "https://android.googlesource.com/platform/external/skqp"
+  },
+  "external/sl4a": {
+    "dateTime": 1628804796,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ec2a6f8e499b7352d34fc2d06a32a04836e10a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0arkj14xx0hjmkffka5v076y6lj9ikjyvf41y5qlb2aj15142n4q",
+    "url": "https://android.googlesource.com/platform/external/sl4a"
+  },
+  "external/slf4j": {
+    "dateTime": 1613516549,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87b8b5d24bddca51b7fe8f4ca41ec4e29096ff59",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rqxhr85x42h7nl59j3hg9zdn3f8wgv44dk8g2nmvgzfd3l63ymp",
+    "url": "https://android.googlesource.com/platform/external/slf4j"
+  },
+  "external/smali": {
+    "dateTime": 1613832659,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92d1f8c876ab97ee78a9c89459f8c7737b6b70d7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m2z3hm7q7hyqfabnw21sglarig5g5kjhv4b12387ckx9lzyxz9b",
+    "url": "https://android.googlesource.com/platform/external/smali"
+  },
+  "external/snakeyaml": {
+    "dateTime": 1613582541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2d542c3495b626ddb8233039211f3e474bed3b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11fyx45gqx1rqbk9cghj8lliv7g7qhfrfdbif9r0zjrmq56ap128",
+    "url": "https://android.googlesource.com/platform/external/snakeyaml"
+  },
+  "external/sonic": {
+    "dateTime": 1612566436,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c9d99e1aec6e62ac825607ac2daf2ea57264893a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17yl2bd3zy8wf0s2snz5734w3appr33c5f3f0jayw9crzdb8kksm",
+    "url": "https://android.googlesource.com/platform/external/sonic"
+  },
+  "external/sonivox": {
+    "dateTime": 1633395939,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1a79d77efb2d06e1c223fb0b7e4e9554108779d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z3w30hz7782xww6qgk3l5h7j899cdbvmnxvrwq28hnpmdhqlmap",
+    "url": "https://android.googlesource.com/platform/external/sonivox"
+  },
+  "external/speex": {
+    "dateTime": 1613829372,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "038fc2a96f550ea061de87417d3ce1581c68fb31",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b4iafcxynjq2y0i6hh3j7wgqzr51bnqm09ngwql72d12g7pvx8v",
+    "url": "https://android.googlesource.com/platform/external/speex"
+  },
+  "external/sqlite": {
+    "dateTime": 1628891958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1008a44d384b174b03214778efbcf4b644a70e82",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0nfx4l4ip228y03p6wpd5rwyq0sl8101xscgr3nb981vn2b8nny8",
+    "url": "https://android.googlesource.com/platform/external/sqlite"
+  },
+  "external/squashfs-tools": {
+    "dateTime": 1613582533,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "025bfc5d3e64045b37416449f2430240e6906399",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18yry9s66q0569l6kgnavxd84lpgqqg2zh7wqad7i7ca8kppagqn",
+    "url": "https://android.googlesource.com/platform/external/squashfs-tools"
+  },
+  "external/starlark-go": {
+    "dateTime": 1618037818,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6534601415abb396c57346800d5379846be89893",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kq1npxz7skla11q33az976l0kk4n5wpf3djyrhw0kglcd176vi2",
+    "url": "https://android.googlesource.com/platform/external/starlark-go"
+  },
+  "external/strace": {
+    "dateTime": 1613591137,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a670ce285a73e037a7fc89369e0fba185f9ebca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rx0660d6z6s9id9mh8kjbmalm7qj38qrc3557k817iy81ac6n3g",
+    "url": "https://android.googlesource.com/platform/external/strace"
+  },
+  "external/stressapptest": {
+    "dateTime": 1612566468,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4958a37113f1e49af89cb96f6107140169c00da9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q9kbldax37x783ijnbwsr052kmqb87hs0m6z0cpnw29gdkmfai1",
+    "url": "https://android.googlesource.com/platform/external/stressapptest"
+  },
+  "external/subsampling-scale-image-view": {
+    "dateTime": 1615327434,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "251fe56a923c2175707da7bfca7441c39d2d1482",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0brk3l0gd33d4h8rjb06r7vnlaz821yc3bhpsyskvfv6inkpxh1s",
+    "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
+  },
+  "external/swiftshader": {
+    "dateTime": 1615834135,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1ae25c2a1ac9f604a2d86015048afa45db170d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19drp33i5ha2qlxj3xgv37s8lxx0h0gmzh834fga2ydiazc2lprx",
+    "url": "https://android.googlesource.com/platform/external/swiftshader"
+  },
+  "external/tagsoup": {
+    "dateTime": 1612563990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "06749bc5d1d1623772afa163af2e0206f2c0d96b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "092v7vx5md9lkgsnds9iaknsx7n1hm7daazy3icmahiwkq3fs684",
+    "url": "https://android.googlesource.com/platform/external/tagsoup"
+  },
+  "external/tcpdump": {
+    "dateTime": 1613591197,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d6ed158ab36b51666c18e0f55b296ac6c347ed1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sy5691a5g4lbdzq449jlywn2pl7g57bfc5a70238ivdi57351bs",
+    "url": "https://android.googlesource.com/platform/external/tcpdump"
+  },
+  "external/tensorflow": {
+    "dateTime": 1616627707,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dce31676bbf68acb6806c8d16e50133b2852e510",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "163p13dy1ghbpii05y2z2ljcnaf6w40i1cbd1ipv0wbf2pi57d7y",
+    "url": "https://android.googlesource.com/platform/external/tensorflow"
+  },
+  "external/testng": {
+    "dateTime": 1613516538,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e840fdf90e074878009318caae490783ce2061cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06hxhlmx7958xbfj925xcmmzm5h3s16jxwqcahh5yp4zzn19af37",
+    "url": "https://android.googlesource.com/platform/external/testng"
+  },
+  "external/tflite-support": {
+    "dateTime": 1616512496,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6bafe671403d9ab22c37ac64c6d202b7dc5905e8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00mj6sp3h53wpwgyfwmnxfch4j53sfbdijfrwg1n4g0ymafr2adr",
+    "url": "https://android.googlesource.com/platform/external/tflite-support"
+  },
+  "external/timezone-boundary-builder": {
+    "dateTime": 1595932940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "582fe290e64d938920896d5846e2b689c71f807e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09laamss9pk6q4fbl6gppz8d8ix47qvazqd3r8x4p36qga68n6wc",
+    "url": "https://android.googlesource.com/platform/external/timezone-boundary-builder"
+  },
+  "external/tinyalsa": {
+    "dateTime": 1625043461,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1957af17f7db99aab016796b7433cbaf92969c2f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ka8qwa9j78gsiygs7rlk78lf79yir26202rf0j26xwb5aq2rw7r",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa"
+  },
+  "external/tinyalsa_new": {
+    "dateTime": 1626438113,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73d1b1347fba03f2ce4421d30b90f9d70e3e85f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jjl611jjrh65kk92zdp5y5jar0qyfrcv2yz86wsf71rld5ljm48",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa_new"
+  },
+  "external/tinycompress": {
+    "dateTime": 1638557086,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cbeef6a42c701db169e51b8d9aa97f79fda055e9",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "05s9zabmdml3y74yr2fa1w4yhkxh7qyvvva0pbcxvdnr9zly5bw6",
+    "url": "https://github.com/LineageOS/android_external_tinycompress"
+  },
+  "external/tinyxml": {
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ae99d3bc9a335a44037265027cd0f532f92232d8",
+    "revisionExpr": "refs/tags/android-11.0.0_r46",
+    "sha256": "1h4c7ndll3jf2pwbvb55pwmwd7785hx83fdznv66g4gfbjlhachg",
+    "tree": "d75616c0b2fc059f6413bca771e4695e24e99492",
+    "url": "https://android.googlesource.com/platform/external/tinyxml"
+  },
+  "external/tinyxml2": {
+    "dateTime": 1613815717,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad28040d9dd954720c5c5850c9f5a508c0c7c6d3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02cns5hw21sqy0vdd7601aj8v4cdi4rzm08fvpf8xav04xc6n4k7",
+    "url": "https://android.googlesource.com/platform/external/tinyxml2"
+  },
+  "external/toolchain-utils": {
+    "dateTime": 1615355841,
+    "groups": [],
+    "rev": "8c091064d3ca02f62d183237cbaee2032acf2bf9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pi0shn1aqwn59yxids5v0jnbbhn3gafplfhp5iy9waazwhl3pfd",
+    "url": "https://android.googlesource.com/platform/external/toolchain-utils"
+  },
+  "external/toybox": {
+    "dateTime": 1620434600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4fbf4c014308be22199b3244e337670710efd1e1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19msz3f8ggk2qy0xif0m92aa528phlg74ibssy2b447yj735vkrn",
+    "url": "https://android.googlesource.com/platform/external/toybox"
+  },
+  "external/tpm2-tss": {
+    "dateTime": 1613516540,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08e6bb82bf4524881da2e2bfca28cd26bc6b457c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11niy75h4yrwp73sbrx24v36l20syyl77cvnfy8lnxz51khs73g8",
+    "url": "https://android.googlesource.com/platform/external/tpm2-tss"
+  },
+  "external/tremolo": {
+    "dateTime": 1633395950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bce535f9a9d105af7d02701708cc1a67c7f47d11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1aw5cmc27cclq7fb6mk5f3sljk7b5dplscmr0skh4wb6jwprgd80",
+    "url": "https://android.googlesource.com/platform/external/tremolo"
+  },
+  "external/turbine": {
+    "dateTime": 1613516542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd65cdbec2b6936cd4ce03bf25465b991ac769b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m3n7da7cg181nd9y80fm6zg7dr6i26baxg47yxkgls1agc0garm",
+    "url": "https://android.googlesource.com/platform/external/turbine"
+  },
+  "external/ukey2": {
+    "dateTime": 1613829431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c9bef63541fd544632dc9e84ab26fb6b085c68c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wprw0h3d5qvzikh24b019506fwmjgzah0j0lmdraiv24vqspldj",
+    "url": "https://android.googlesource.com/platform/external/ukey2"
+  },
+  "external/unicode": {
+    "dateTime": 1613821250,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "349f46635625fa1dd95893e120dc97715313dabc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12d79gr4w732rz15dnqmgmfxs0kji8ih5sp1l5pksh3ak0z0syng",
+    "url": "https://android.googlesource.com/platform/external/unicode"
+  },
+  "external/universal-tween-engine": {
+    "dateTime": 1613582549,
+    "groups": [],
+    "rev": "35d9cbeb4444e14c5b3f610f7f6954292bb9f3a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ah027mh8lgrsdcqp8pbv1l6gcxjxaj8ksyji4v244awrqdhmpx0",
+    "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
+  },
+  "external/usrsctp": {
+    "dateTime": 1613934499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "10485cbc0cfd402b1bbc38c2f14e58b9d6771145",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ys21xj86zc4rx0x49d3r62mdi8kwx4035xbyslxqs4qlrai618c",
+    "url": "https://android.googlesource.com/platform/external/usrsctp"
+  },
+  "external/v4l2_codec2": {
+    "dateTime": 1620787999,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2be28169417c457ebe4c87deac7d749b14aeb7be",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10j7qfbd5dn5mycywxr8a6j19px7rz6nwwxijr8kdkkxkr2lsb4b",
+    "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
+  },
+  "external/vboot_reference": {
+    "dateTime": 1613504473,
+    "groups": [
+      "pdk-fs",
+      "vboot"
+    ],
+    "rev": "2a1ded27fe5a0a87276a42afbd116d25bedfe583",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0dbrh8hy96vrfdxs7p4vz6y7k256sr6rk9dn1d0nk69pzf58xssa",
+    "url": "https://android.googlesource.com/platform/external/vboot_reference"
+  },
+  "external/virglrenderer": {
+    "dateTime": 1614986217,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f75841758bee9b9bf4d90ee113fbfe1b03a62a0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m5588rz56xb42hghfkqw5qp5s4mcwcwy97hqnrxcl4sbngmmpx5",
+    "url": "https://android.googlesource.com/platform/external/virglrenderer"
+  },
+  "external/vixl": {
+    "dateTime": 1620388241,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ec619fe31f636cd58f2f13200353459edc7975e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kgrgqmprmiy2rha9idcqljy7xixgn9cs64vwx3b8swpb08bymar",
+    "url": "https://android.googlesource.com/platform/external/vixl"
+  },
+  "external/vm_tools/p9": {
+    "dateTime": 1613828473,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "487ae2c69578867f99fcc9f49b28be83fc05054f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0iwq1zq7g03drxl6a8qn079a0ijc16s1yp6c3licqjdddqg74gx2",
+    "url": "https://android.googlesource.com/platform/external/vm_tools/p9"
+  },
+  "external/vogar": {
+    "dateTime": 1619700425,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b591cb9e0d75a54b37ca30bbd47ba7e0495645c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0pzid6jal940rcrimdf22128c458rkjqalnhz56k8mh0i049pzgg",
+    "url": "https://android.googlesource.com/platform/external/vogar"
+  },
+  "external/volley": {
+    "dateTime": 1613821503,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d547971f33073ea4a3b6f9c908ce8e9b4daead53",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1679hx3m8h1k6q8c38pqam01dsbdvrb9y16ylxahi53cc1xqj9c3",
+    "url": "https://android.googlesource.com/platform/external/volley"
+  },
+  "external/vulkan-headers": {
+    "dateTime": 1619578330,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc71347b2926d5b7dddb1b3bfd473317f9a2f88a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04dgizyvxg2p8s46n8ha24yhjmxrzqvaqy8w9v6q5q9v62z2qix0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-headers"
+  },
+  "external/vulkan-validation-layers": {
+    "dateTime": 1613821429,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a636bbc92901e3167b9dea7e5c64c60d5c057087",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b07rm2880j171mswhqmppf6mn2ijrdl3hz6bicaw41cixz4ckm0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
+  },
+  "external/walt": {
+    "dateTime": 1613815827,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd7f36ea3253647f10c8d2a1b5afa316e71d933b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04g2zdf06pyk0k6s9ss6yswannhjqhz2m60msq206nvl1qdz81l1",
+    "url": "https://android.googlesource.com/platform/external/walt"
+  },
+  "external/wayland": {
+    "dateTime": 1614986414,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "77876c86c9219ad76f558169765029a3e51cb40f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03wp3x0k8lys9jkm4arkcf0zkc9xal2jx9yhi2j9j3qk4h25pi4l",
+    "url": "https://android.googlesource.com/platform/external/wayland"
+  },
+  "external/wayland-protocols": {
+    "dateTime": 1624415708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a370133c69b3400c407f70bb71a1673451b32db6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1znvrprlp128kakcp5f1zqdx0r619hnbia9b64cmfqibmqfdhplm",
+    "url": "https://android.googlesource.com/platform/external/wayland-protocols"
+  },
+  "external/webp": {
+    "dateTime": 1613824010,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "ecf17565206810a3d2966bed4490a0de9ac2c80d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "15zv6w3wcw11qwx5f95p5cxb1dbrfkyzlmcl6w5dx9wn0cyxjd55",
+    "url": "https://android.googlesource.com/platform/external/webp"
+  },
+  "external/webrtc": {
+    "dateTime": 1613827215,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf74cacf7db81bdb7f25bb71b499e09edadc5cf9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00jjyl1zwgqdzmakvgsw6iyasiz1y9fwh2k3n2yff0050vk6499p",
+    "url": "https://android.googlesource.com/platform/external/webrtc"
+  },
+  "external/wpa_supplicant_8": {
+    "dateTime": 1639515120,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6b10f62ff51a1d3a0231dbd1c28342f62148dc8",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0xn3hahc10v8qkjl54lkb2qk2r1yjdbxchahlz0dgrf101319ghx",
+    "url": "https://github.com/LineageOS/android_external_wpa_supplicant_8"
+  },
+  "external/wycheproof": {
+    "dateTime": 1613060169,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5250c8dfb5205571f3231e6e94e6b81f74be216c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0waib4n8k684l4nl339w9h1f5g52461qh51kk1inknj2bpvy78vn",
+    "url": "https://android.googlesource.com/platform/external/wycheproof"
+  },
+  "external/xmp_toolkit": {
+    "dateTime": 1612566528,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e51131c36cd84534c9d65a612d1fe194ec0523b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vni2h737zxzcd9lg7fgxh3vv88508kn1kli04nh2cqmld9a9x1v",
+    "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
+  },
+  "external/xz-embedded": {
+    "dateTime": 1613513319,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4c875c23ca77276d44b377724575d5b2deac4ac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "073plk8szhih5chpaf91jfi9w3f8sgx3s38y79zk9g11mms40dpl",
+    "url": "https://android.googlesource.com/platform/external/xz-embedded"
+  },
+  "external/xz-java": {
+    "dateTime": 1613582537,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "57316b5ce8c5d2bb5577f400e1204b0427704f9d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "106wni1mvkx7jjag4401v8dkmqrl7kyd17a8nlik0wqwai9akmbb",
+    "url": "https://android.googlesource.com/platform/external/xz-java"
+  },
+  "external/yapf": {
+    "dateTime": 1588621644,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "a987369c65841b8db65e55f9cebacec4d02355ea",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04cxpdc46h0z75d2b8a73lx3x25k881qkps309sa7irxvqjlq4av",
+    "url": "https://android.googlesource.com/platform/external/yapf"
+  },
+  "external/zlib": {
+    "dateTime": 1620401991,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e23ea5216900d92c42960176e5ed2e676bb1f9c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12640wzjmqgjdya2zdb14ir5d3q1fds04hs878wsw8jw84aw3jkp",
+    "url": "https://android.googlesource.com/platform/external/zlib"
+  },
+  "external/zopfli": {
+    "dateTime": 1612566556,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e70b1bc83cf3839fa2a943e8a785c5b7f069b1b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y0lrn1mcw9233dr93361d0mjwpqlsrq4d31l1kgr1lyfdx2lf5l",
+    "url": "https://android.googlesource.com/platform/external/zopfli"
+  },
+  "external/zstd": {
+    "dateTime": 1613815648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d20c08c49c80f0a9f2be96282cf9febc6ed9f075",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0nc7pf97s580c66hyd11zjcj1ah7dd2ls3nkgdia3qmrfphwl74x",
+    "url": "https://android.googlesource.com/platform/external/zstd"
+  },
+  "external/zxing": {
+    "dateTime": 1613582543,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de657f14dfdb612a6b6b87e4e718bca345a6b9cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hn3cmj8msdwggbqzaqvscri38df1j35c921i2k518wikghi7wh0",
+    "url": "https://android.googlesource.com/platform/external/zxing"
+  },
+  "frameworks/av": {
+    "dateTime": 1642105268,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6046e9698dd267632c6d219ea9068df276f9fd19",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1pzxcysgb65kb91ycl54qcmfi4rbdbsrvaadxaga1m4b1v4g612l",
+    "url": "https://github.com/LineageOS/android_frameworks_av"
+  },
+  "frameworks/base": {
+    "dateTime": 1642213617,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "927b6c6e888dd7359300de1852a27759b73f0ade",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0vg0nwlah3qlc49v8vbqxwsfxag80sg4lwlj8jmqr7miarm85s54",
+    "url": "https://github.com/LineageOS/android_frameworks_base"
+  },
+  "frameworks/compile/libbcc": {
+    "dateTime": 1613828095,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a60a8975466f4848a0e81a24c1aded90145909ba",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n03c58wxfp76z0hk2y93r6jfhi7rvrbmv5iwnj6gy9aw6a5a4fg",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
+  },
+  "frameworks/compile/mclinker": {
+    "dateTime": 1620748411,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d6d49df764ced3e97b6843003d27c2d59c15f1d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "162nkr6acndsx278g31ygazpv9raxigb69qnic1sv97n94v7yyvy",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
+  },
+  "frameworks/compile/slang": {
+    "dateTime": 1620409385,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1e81eb7146f6ea588c40b4696161cc279cbb5a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16jzz2xrgipqlp8ixmssapxpqnhyz0x8rlwkv52v6g90psl25jl8",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
+  },
+  "frameworks/ex": {
+    "dateTime": 1628875406,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "63c10bd46811bd24ba42acaf8c1a321c617ff4c5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pr2k2a0hk47khbl1bp9ljxcw95k78b37qbkql9vh51r89hrhyis",
+    "url": "https://android.googlesource.com/platform/frameworks/ex"
+  },
+  "frameworks/hardware/interfaces": {
+    "dateTime": 1634259973,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6da080a13df98d6f642637c94e7f0ae7ab9ee332",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1031nf3zchb7jgx4jr3qrmssjr6l5jb54iwdalx616avaj8c9wxs",
+    "url": "https://android.googlesource.com/platform/frameworks/hardware/interfaces"
+  },
+  "frameworks/layoutlib": {
+    "dateTime": 1619018501,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4365306d353a909eafbf7dc0a6e5186cd71a4e5a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1cw2y7xcd3w1nzljvzgckli8d328y5xxj5ynmxpnszcrlyiymish",
+    "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
+  },
+  "frameworks/libs/modules-utils": {
+    "dateTime": 1623778244,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2e25fe41bf216bf59395896eae7e129b5aeeca09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0fsixxvkxw1g26jjlwmmrybbzzwgxl1gswbilyk73dmf1cnmx711",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/modules-utils"
+  },
+  "frameworks/libs/native_bridge_support": {
+    "dateTime": 1632513319,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed706257601168365401fdac1132437f086c6986",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lw018vdaf1imrgfz542752ddy9kz29x5lab3sgg1680r4fcw2s7",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/native_bridge_support"
+  },
+  "frameworks/libs/net": {
+    "dateTime": 1629157082,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "64dca368b41bdfb60054732a790cdb37987fc0d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0raxv23lflhvcgnz1ci2w6fn6gv5kyb6zx5fmmv8s8bqsq3sbsgm",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/net"
+  },
+  "frameworks/libs/service_entitlement": {
+    "dateTime": 1627490635,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5b34ce57ef4d23e0ed37729a1869e5283c1f0082",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z9kin6rn0dh7h1av6larf9swnzcni5ckjc4v8pzyrdvff9qj3l3",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/service_entitlement"
+  },
+  "frameworks/libs/systemui": {
+    "dateTime": 1629364203,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "47668892332b0e655ba27b25528910198214c617",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g7k9xz6k4ylnjkwy686db9alxhk7rpny4kkcvffglcsssmwlhmp",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/systemui"
+  },
+  "frameworks/minikin": {
+    "dateTime": 1623269926,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "dfb7649f7e12d5b7f2ca3381732f0168202540a6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gja9jpb28rzvjk25ii48vq8mzlnsrhv3ja9k9xmab0jhkpfam99",
+    "url": "https://android.googlesource.com/platform/frameworks/minikin"
+  },
+  "frameworks/multidex": {
+    "dateTime": 1613504479,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5ed98aade04197591e43dc74fce00611ccea7d8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xwqn0ik1in5rpwnr1xygbggjm8ysiknp2hvf2m24859zg90lng7",
+    "url": "https://android.googlesource.com/platform/frameworks/multidex"
+  },
+  "frameworks/native": {
+    "dateTime": 1642105278,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6650fc03f4047b2b64bace85715de2425a8ea456",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0h4ncxln91656pjjpih5vpq0cdywvmmxzclvcskryj4ma9d01kmx",
+    "url": "https://github.com/LineageOS/android_frameworks_native"
+  },
+  "frameworks/opt/bitmap": {
+    "dateTime": 1613504478,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "70898990912403141be52dabe383999aafec34b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ipvhhkj8d1fpixx5s51133k87riqdczaarw9lnr65anx4s781sb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
+  },
+  "frameworks/opt/calendar": {
+    "dateTime": 1613504472,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b4de6cc21542999d8340810fda4b4305791cf0ca",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jjj2y6qsj5q20fj4rr1kbx7cn233myv6yk5l2j23x41nryandd2",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
+  },
+  "frameworks/opt/car/services": {
+    "dateTime": 1625021065,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8a27e52439083986e0eb5f899e4f35f250559046",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "199qvczry0qcqzbdhfbjmfx2waz22g0hxm5kb8m11av418r0f9nm",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
+  },
+  "frameworks/opt/car/setupwizard": {
+    "dateTime": 1634087194,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d0981ceb4022dded36271669da0e1f22f7acf010",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0s08gq92ab0s70nzcayccmx9mm4p6ymbnwfp92hs6h7raf48r2dq",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
+  },
+  "frameworks/opt/chips": {
+    "dateTime": 1630732465,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e2903008d74be46bbc4709c9a4d2e17de47a038e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0scl3zcp7w2lvcn2dhl25zz3xnv6x74pdd332rhnccylvd4f58m0",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
+  },
+  "frameworks/opt/colorpicker": {
+    "dateTime": 1619137318,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0d137f37131b36c9ba8f9c57fa4d55e3d9270479",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vvn2sc29sc2yhvk5lz0gcdfb12321w4bcy24xkqvsnfsyddc877",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
+  },
+  "frameworks/opt/localepicker": {
+    "dateTime": 1619234741,
+    "groups": [],
+    "rev": "50a6bf8c43d229908dd45a45c5f884608e20ba44",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r125r6xswixm6b6d68bzc489h6xhb7s0bjgs8fnay4vbsq4419s",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/localepicker"
+  },
+  "frameworks/opt/net/ethernet": {
+    "dateTime": 1624272956,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "952c4f0affa9492441d2cbd61a1d42c979e844b0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1w5v0hr8a7qwrnf8f63fb6lnw19hggzjp7a1wrpfg1l539jaxv8k",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
+  },
+  "frameworks/opt/net/ims": {
+    "dateTime": 1630632189,
+    "groups": [
+      "frameworks_ims",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1403bd1c6e4cb4ebdb33e11c19e58a6af82bde8f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03k1yfcjhlssb9gv288ss8dzxsk9v02gz75isnjqp44l40336g1d",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
+  },
+  "frameworks/opt/net/voip": {
+    "dateTime": 1622590811,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b084cdfba7e191cf11001ecd1f0e5ead0ea38350",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y3mffpp81hgzkp9qlwl49s82b5zlb2vbznxc3x5hp5kv2p6i7bi",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/voip"
+  },
+  "frameworks/opt/net/wifi": {
+    "dateTime": 1632514989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "380d244292d5605826b6979a0b325dac0b23a0f7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1a9f0psy6la09q1r5c499zc6gzsvqc913a43sg4xv1gy7x4axzh5",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/wifi"
+  },
+  "frameworks/opt/photoviewer": {
+    "dateTime": 1629402972,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b4d84f2e2619ac06a1525b05542c926b73ecdf7c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09k0svr6wgxs9dras8ycz4lb1mf94l5q60cark0akggjsm6q0a9x",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
+  },
+  "frameworks/opt/setupwizard": {
+    "dateTime": 1618492520,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9fe5969610a92d096d9811cb0fdc58390cced940",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sdvs3n3nxd0dflqyjqqhf0g1drznwqrkbd4qv5za5n0g9dqg5x1",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
+  },
+  "frameworks/opt/telephony": {
+    "dateTime": 1635860784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf0c5520d671a41f5c025238bf25ff4fd55f37ab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rg3z0hkirzgfdp5nrbih7j2nddljmphy11w219w1csw5vg0zj0k",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/telephony"
+  },
+  "frameworks/opt/timezonepicker": {
+    "dateTime": 1639515140,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1ba5c2aaab95a49196889871885a8d6e29539b1a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1j9pd3343vcn5is8ap5vgr08839z0z4s9bgqml1gq1iqapz261v1",
+    "url": "https://github.com/LineageOS/android_frameworks_opt_timezonepicker"
+  },
+  "frameworks/opt/tv/tvsystem": {
+    "dateTime": 1620203497,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "89809de45766b13655f6ef3469782315cbd66b5e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1008lz757hs6yjl71xcblv8lny21xlkvsh70sbqnv7akbn4pk3m0",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/tv/tvsystem"
+  },
+  "frameworks/opt/vcard": {
+    "dateTime": 1613504479,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b17ab1c8e7fedada640bd3cd3a8f1c7a5770382f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ahqdbqw285rpk7cnsjq0fzb60jmpf5a5z32vz52apxlg68k5l1g",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
+  },
+  "frameworks/proto_logging": {
+    "dateTime": 1634353594,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "3f55c7fb09c8ec89d3d00d4e44f8295b94d57a2a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11rg4ghhhgk1msblksvzq4vkqm9bmzm05649bviv3xrvxwglgpxw",
+    "url": "https://android.googlesource.com/platform/frameworks/proto_logging"
+  },
+  "frameworks/rs": {
+    "dateTime": 1620177923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "056bd5fa7bcfd1157d0391642a97854e755af7d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gybw0hsp2p5mm7g2v737kg0ca5nys2f0333p9ma19sz5dyww3ma",
+    "url": "https://android.googlesource.com/platform/frameworks/rs"
+  },
+  "frameworks/wilhelm": {
+    "dateTime": 1623085907,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "598fe03926acfdd7180ee7a7293aca7c0287fc8c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nf5sx9zjs2ybcp4fqwzphgan379l83fml58dhs5x4f24rj80bxz",
+    "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
+  },
+  "hardware/broadcom/libbt": {
+    "dateTime": 1615848245,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd95c255ffa9baf735d4a11875597826ee41d6e4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12945i09sz39ygg91szzabmw7kmhasn9b18sb2v8fkxxzqcy7nih",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/libbt"
+  },
+  "hardware/broadcom/wlan": {
+    "dateTime": 1631059361,
+    "groups": [
+      "broadcom_wlan",
+      "pdk"
+    ],
+    "rev": "f6cdcab21874c47df8c7776987c272fa853ecaf3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0rmam26zvsz5k8bxqrqhjmy5fs0zq1ffwzqjmyas2y1pm7badchj",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
+  },
+  "hardware/google/apf": {
+    "dateTime": 1613842238,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "411c1485206d66866726e647fbb0ba1e6825c581",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "144hxkgnbh4jvm5a830mjwsj5zcp4z0g61731r9vj9kx8kaxqxrr",
+    "url": "https://android.googlesource.com/platform/hardware/google/apf"
+  },
+  "hardware/google/av": {
+    "dateTime": 1633482419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36005e9f6c2981b0c68f2dcbcd61792c6069cc57",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d3h8g5fbvqyxj8v7q1b2y049gi17wq8dd32yv2671f5rv5a668j",
+    "url": "https://android.googlesource.com/platform/hardware/google/av"
+  },
+  "hardware/google/camera": {
+    "dateTime": 1632527949,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "722c3ed425888370bedce3b5f484de11c3ab4626",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sh2sn1gc0mhpdrzkb0c4aa7cykaixc17mzyxf3x3bsszmhz4lra",
+    "url": "https://android.googlesource.com/platform/hardware/google/camera"
+  },
+  "hardware/google/easel": {
+    "dateTime": 1612566403,
+    "groups": [
+      "easel",
+      "pdk"
+    ],
+    "rev": "38ea87e272bb0f380ca9463b789dee7279991196",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0a8hgw2y5z36vqn9ifwsci7bn6qznz1kjzvswhzif2cag7249nvh",
+    "url": "https://android.googlesource.com/platform/hardware/google/easel"
+  },
+  "hardware/google/gchips": {
+    "dateTime": 1635860785,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "6b84f7ef573d6c38dcb6db13e035949aee3ba4a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0li7pzbp3la3r2084gf0y0skpls96ldlbhmsq5sk5qfjy3l0z2w4",
+    "url": "https://android.googlesource.com/platform/hardware/google/gchips"
+  },
+  "hardware/google/graphics/common": {
+    "dateTime": 1640531101,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "e6cd7d92d2dd925b8830d4c51e5d35b2d2a370cb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r83sm85w4h9didfd300vszw3hrmdj1nnmd1ylpm8bgsqjk87v3a",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/common"
+  },
+  "hardware/google/graphics/gs101": {
+    "dateTime": 1628696305,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "d4de1184a7a429bb50a834891f65d576753089b5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pywy3cap4sj2wmlf0yicm9ag79rv5vksnhqd9y8265mwz1gkabx",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/gs101"
+  },
+  "hardware/google/interfaces": {
+    "dateTime": 1626911509,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e4e57ec99704e7a1f8dd7bc1a03c770e3e841c7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0da22b907fa4qg6ldjyr24bj09ckaglg4pa2r9ycjc0frlnb6xwk",
+    "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
+  },
+  "hardware/google/pixel": {
+    "dateTime": 1642374395,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "e7d6b5ec96ffdb152691952d85e2cd2c95478c97",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "16q2xzwzr3bzz5xs6ixirmq4gkhlbn770wizxc4w3ykjw1m60wfk",
+    "url": "https://github.com/LineageOS/android_hardware_google_pixel"
+  },
+  "hardware/google/pixel-sepolicy": {
+    "dateTime": 1637089114,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "5b5c0535892c727b206619406adf66f499c9e0b7",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1r7xp98yf7his4f8n68ynlsvrr446359g3xvcp011sgr0rr2c452",
+    "url": "https://github.com/LineageOS/android_hardware_google_pixel-sepolicy"
+  },
+  "hardware/interfaces": {
+    "dateTime": 1635134670,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e971f96ab5714ade65095a18057a49128acee43",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0nv4k0q8zmd2zq59rv464ycvpljy31nxvm2lhbq3r9yp8bb4zbsx",
+    "url": "https://android.googlesource.com/platform/hardware/interfaces"
+  },
+  "hardware/invensense": {
+    "dateTime": 1613841778,
+    "groups": [
+      "invensense",
+      "pdk"
+    ],
+    "rev": "8d5af232a81839f1f20e8ca053b2f4b7ae1d218f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12sqj3i0avyqpl6nqi8flaskfqlsfvvxzllskkfa67n9cknnv2p0",
+    "url": "https://android.googlesource.com/platform/hardware/invensense"
+  },
+  "hardware/knowles/athletico/sound_trigger_hal": {
+    "dateTime": 1637522656,
+    "groups": [
+      "coral",
+      "generic_fs"
+    ],
+    "rev": "daeac2cc42d5d692667ba5853bcfa45e295bd2da",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1pl0qxdm1cw51y20mr66282smk1csf1fs6y497m6hq82z49xrhg4",
+    "url": "https://github.com/LineageOS/android_hardware_knowles_athletico_sound_trigger_hal"
+  },
+  "hardware/libhardware": {
+    "dateTime": 1638556771,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22915825f3fbb7af7cdc252b452cbb8a164d9a18",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0knbhv77k3cpqjlgra9dkxgmy1m50nw944s4nb0hlmryf391r9pb",
+    "url": "https://github.com/LineageOS/android_hardware_libhardware"
+  },
+  "hardware/libhardware_legacy": {
+    "dateTime": 1617192955,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9194f0742abcaf01b702d527d412a05b3a7702bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v6v220b8gmjz9qnpq83wjwd6jircnnlkr4grnj14d24bxy3b1ar",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware_legacy"
+  },
+  "hardware/lineage/interfaces": {
+    "dateTime": 1640527267,
+    "groups": [],
+    "rev": "7acc6525cf4a03fdfa67f3c13953f4de38ac2944",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1rry3vyi0qn3qrrgynza1kcy11a20q45rxi5m4km9r4fkw1g46ch",
+    "url": "https://github.com/LineageOS/android_hardware_lineage_interfaces"
+  },
+  "hardware/lineage/livedisplay": {
+    "dateTime": 1613534093,
+    "groups": [],
+    "rev": "3e298771b18d6c0e28350f50c7204c3c036662b8",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0glqxxsrfy6qym7w3iinb019556d17wapjxw4hih5j4ymv803bak",
+    "url": "https://github.com/LineageOS/android_hardware_lineage_livedisplay"
+  },
+  "hardware/nxp/nfc": {
+    "dateTime": 1633655228,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7d72645dd3f832385d3a45d38fd5defd9d59f4b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y2l4gl8ls44zm4bc8myx1iaiyfcg0ihvzg4kpm4vrzd38wy0n2d",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/nfc"
+  },
+  "hardware/nxp/secure_element": {
+    "dateTime": 1621898269,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87ca0480eb6fc726fab823da9455e6e21f152d4e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "063k3nh3vp9nffvq2gl3zirn2wx9hna8z67fkcdj30f9bm6vglcq",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
+  },
+  "hardware/qcom-caf/common": {
+    "dateTime": 1610014891,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/Android.mk",
+        "src": "os_pickup_aosp.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/sdm845/Android.bp",
+        "src": "os_pickup_qssi.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8150/Android.bp",
+        "src": "os_pickup_qssi.bp"
+      },
+      {
+        "dest": "hardware/qcom-caf/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      }
+    ],
+    "rev": "5bd19fac7133383aeebd8b601e1de3c0685bf240",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1jlpyvkgz65i5wmc6nhi4q2vkyfkpxjb9hljmb0g5l19v28ngzyk",
+    "url": "https://github.com/LineageOS/android_hardware_qcom-caf_common"
+  },
+  "hardware/qcom-caf/sdm845/audio": {
+    "dateTime": 1639189121,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "dd2e63dfdafda5cef8ca32c4836ffe845a919c1e",
+    "revisionExpr": "lineage-19.0-caf-sdm845",
+    "sha256": "106w9a2cfwr212lhrxq1r977n4sqkh1c61h0pvlh9p81d222n10n",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/sdm845/display": {
+    "dateTime": 1641321419,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "513d7d9a123d3cb45af3ae4302e44f61726ab7c2",
+    "revisionExpr": "lineage-19.0-caf-sdm845",
+    "sha256": "0dj11421yx5z1l0ix8vpsvb5f7f0kxq9a7nr2mnzq70w62fp2sk3",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/sdm845/media": {
+    "dateTime": 1639186231,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "0adee5d980f1f0b26a5b19090e3649ed8067b9fd",
+    "revisionExpr": "lineage-19.0-caf-sdm845",
+    "sha256": "05j773nq7758ljbp7zm5lqi2yax7ay12zaa4388vaafjlsrcp0lf",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/sm8150/audio": {
+    "dateTime": 1641603722,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "b7ba761333ec8c12659013a8cf90982e9d05bd0e",
+    "revisionExpr": "lineage-19.0-caf-sm8150",
+    "sha256": "067pj4dma36w4rr4bsp0vxvggqkn04mvcd080779i82xxw6845s8",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom-caf/sm8150/display": {
+    "dateTime": 1638293541,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "b21c1015fdae404e973bf79c6b5c2fa4f81e436e",
+    "revisionExpr": "lineage-19.0-caf-sm8150",
+    "sha256": "0s91ms7hj9adnilf8c8cj8bkgiv2g31svfym3km1zcidjffghrry",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_display"
+  },
+  "hardware/qcom-caf/sm8150/media": {
+    "dateTime": 1638802877,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "a3d287ba3cb415ec8f337921c228764e79c161ab",
+    "revisionExpr": "lineage-19.0-caf-sm8150",
+    "sha256": "1kz8pdjp3p8x0a3ck3gll1jdxp8bk9h9x77z670ap4fabwc4hvn4",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_media"
+  },
+  "hardware/qcom-caf/wlan": {
+    "dateTime": 1639023946,
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "816c4e675ac0d2c57577f434ee5545e20e6b8fee",
+    "revisionExpr": "lineage-19.0-caf",
+    "sha256": "02nv0n3wdhyhahwd52fvy7lwza37inlr3z61g2n3yq2a65449x2d",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_wlan"
+  },
+  "hardware/qcom/audio": {
+    "dateTime": 1636604197,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "4dc3279f605c13bd8820f99cc011976161631e85",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0p11l166p14lv2dig05122ffb2fp1fsvq8xd3ix18wbmg843ijx4",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_audio"
+  },
+  "hardware/qcom/bootctrl": {
+    "dateTime": 1613842340,
+    "groups": [
+      "pdk-qcom"
+    ],
+    "rev": "7fadaecbe0b4446ba1306ef47a24c607c81b88c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04dv3a0zj03af7g4c19kiif4v1gff0fby467kh3ji440y4z00r31",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bootctrl"
+  },
+  "hardware/qcom/bt": {
+    "dateTime": 1612566560,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "7147b0dd87f9e450caa3ff9b4df285b49b4c6ebe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0a6h3jcprciwxjq86nfiiij8f7475mah4qgxgsfdd2b54cy37jbc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bt"
+  },
+  "hardware/qcom/camera": {
+    "dateTime": 1636947089,
+    "groups": [
+      "pdk-qcom",
+      "qcom_camera"
+    ],
+    "rev": "5ac9295062d15f7d1ef6e2a19b2516a242532e30",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0ldhghwj637pbp84wfp5qy8mkmrb7bik6mdav8brfvk613j0if8y",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_camera"
+  },
+  "hardware/qcom/data/ipacfg-mgr": {
+    "dateTime": 1636604247,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "67c7f562072e42e9697c0df971d4c6bf9e8a348f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0xbszhfhqs3ia4l0srn72hs53h3pkfpjm94nbdsz0gkb62hzxb09",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_data_ipacfg-mgr"
+  },
+  "hardware/qcom/display": {
+    "dateTime": 1613842325,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "f01b4d21aa7f244f9b0c3b02cdb7df3dc0ba327e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1w8fr68drhj6wjqvla801wianxb71ybpxwfia4v7mjrf7krs09a2",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/display"
+  },
+  "hardware/qcom/gps": {
+    "dateTime": 1613822793,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_gps"
+    ],
+    "rev": "d00bb6042e9c1642b1823d761e33d936098320bc",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r99iirahalmj8w9v93cqi9lhandavj88jqwlcgd01czlrynwm9x",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/gps"
+  },
+  "hardware/qcom/keymaster": {
+    "dateTime": 1612567136,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_keymaster"
+    ],
+    "rev": "90daa64e30cce892b9ad47ee7f4dde5c54e85ce6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09882azkwai7h3xdr0krqv4d5k63qdyvpwzcw6d16wljbfkf525r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/keymaster"
+  },
+  "hardware/qcom/media": {
+    "dateTime": 1613842296,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "875de1a1a862ee5a3ac5242d0bbae8bf50c43c02",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1djq7k9gi7d359cdif0rysfprcfs16sjmfjqkj88a6px9sl0mdy8",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/media"
+  },
+  "hardware/qcom/sdm845/bt": {
+    "dateTime": 1613841789,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "23afc2a00f6c94f5197850a23c54120b390d8b5b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16wxyxlvywkqpvlxlch8czcdjchnqnza5z8qhb1qgwv0kylrh1pp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
+  },
+  "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "dateTime": 1615992147,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845",
+      "vendor"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "5b0ebd5110d874b35ebdcfc0ebda8a740188e42c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ymwzhq5n5cawc6cwspz5xbdc1vzxnxrp7nslmf9kc7mvln56hr4",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sdm845/display": {
+    "dateTime": 1638481799,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "0e5e1e8669e0fd06c7ea70f764e4481d070f6a80",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0ysvv6n26ig8sq29j0x64dgigc4iwbsqy9mw8l5n707azf9ggzf8",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sdm845_display"
+  },
+  "hardware/qcom/sdm845/gps": {
+    "dateTime": 1622445624,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "f63364101a27fa8a40839230fe2a27a1b03bf8ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "15ibil263invfsc8p2889lb92370zxi27gkgx14b8y0jnpf4jx14",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
+  },
+  "hardware/qcom/sdm845/media": {
+    "dateTime": 1638482891,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "a76ed1112d289ff177b14228566019d3db865940",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0nsh431ds6zqqy4q9ijs1kiy8b5w1d60w62qw2vqaq6w1az9ivi4",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sdm845_media"
+  },
+  "hardware/qcom/sdm845/thermal": {
+    "dateTime": 1613814737,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "21ece187edef5b6a58e9e6558b9b69dbf160cfb3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08jfmac2ac6zgfxg8hgvxmv70xk5mlz15vqrxy5xcfsg2f4q1c8r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
+  },
+  "hardware/qcom/sdm845/vr": {
+    "dateTime": 1588703755,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "3e4acf780d357794a7aa84de483facb5587dee63",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "06fbwha2qkigss5r7r5vmgnr3c64cxy3njdp2qlbsxgm0c07xy9q",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
+  },
+  "hardware/qcom/sm7150/gps": {
+    "dateTime": 1617084077,
+    "groups": [
+      "qcom_sm7150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "20315c7f7dc739045cfb3acbb84966d93c880c9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ilgf2rdxniq5b63an8asrbdir2f82yj05qcq8pg51gmkm2550nh",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7150/gps"
+  },
+  "hardware/qcom/sm7250/display": {
+    "dateTime": 1638810570,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "1f02727b6cc309be4705a8c1b1d3087b95033d1e",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "12pq67hkl8pxrfxg8wf1d1h2rw5nihd5zgbhhvfzk3psd084nfgy",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm7250_display"
+  },
+  "hardware/qcom/sm7250/gps": {
+    "dateTime": 1630483928,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7250/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7250/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "92190a33c08d8c77f8b2039e7e113757622e47a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0a4d7vqlj666q8sw6548fli1hcmviqaqv9xhay4a3l3g4ppgylxp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/gps"
+  },
+  "hardware/qcom/sm7250/media": {
+    "dateTime": 1638810651,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "226bd4b68ae48d7e87e881060b47b91beacf5581",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0gmqfkdgrcq9xf3sqr4zysnkvmdrnv6qhrfzzsccrx5gvsgdfh3k",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm7250_media"
+  },
+  "hardware/qcom/sm8150/data/ipacfg-mgr": {
+    "dateTime": 1638738970,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "d4176cb9ae9b7f1190d82d4a98f1ed4a0f9dcd23",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "10ggfgw7zr9w0scc5bcp3h0psiw10jh01qggqwawab1v6fwk1j3q",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_data_ipacfg-mgr"
+  },
+  "hardware/qcom/sm8150/display": {
+    "dateTime": 1638738632,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "53f04e30c211630c0457292220b6c8f21e30a79a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0kk8ll2ziwy0nnlj8m9wmx56j4fmpq5nw5s4rshrd6r6vhb706ss",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_display"
+  },
+  "hardware/qcom/sm8150/gps": {
+    "dateTime": 1627524317,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "08927d5e251296e9f8f87152dac1bd25e4a97808",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0d1r0yfdlx6af5yv17n8550mk48xksgw60ifpx4j4wg4ns788ic3",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
+  },
+  "hardware/qcom/sm8150/media": {
+    "dateTime": 1636936473,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "2e4989d299f2636b7fd2287aabc8ad4487757fb3",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1bl02ryic85xjq7vw1s8fbpah6y1p3hw6pxyf12iid61r1hvbzbl",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_sm8150_media"
+  },
+  "hardware/qcom/sm8150/thermal": {
+    "dateTime": 1613835352,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "65e83b2adb1386bec6fe4baf748ce05e985791fe",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "068aa9jpgn5b8gdy62jz74hhik1dh4yjgliaavfhvqmg1mbgn7d5",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
+  },
+  "hardware/qcom/sm8150/vr": {
+    "dateTime": 1612566547,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "596a9169407dcc696edf0083a7664d19d8024050",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k4dfzb7l3pk0zdxzad6y20kckyac5dl5i26b6rg03ip940ij7dj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
+  },
+  "hardware/qcom/sm8150p/gps": {
+    "dateTime": 1617084053,
+    "groups": [
+      "qcom_sm8150p"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150p/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150p/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "d5023e65bfa093f4538bc283b0777b162778718f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m43j0m0cdjn7xn81n1a9h9v2b3846vixqffamajb8qrfp25yvzr",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150p/gps"
+  },
+  "hardware/qcom/wlan": {
+    "dateTime": 1636064030,
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "ea5cecc62dbc3972dc657bdaac4b0c0b7242e1a0",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0s3c31f91f9c16z70s9fg142vvc2hxzszmjs78w03zshpkfr92p3",
+    "url": "https://github.com/LineageOS/android_hardware_qcom_wlan"
+  },
+  "hardware/ril": {
+    "dateTime": 1642073235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0cca7d9ef908b77acf7c4839075fbd0cc11dce9a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0459xhnwjylq800ph1nwyhrxzcaswx2wpgi3dpyn1vn83dyh8lcj",
+    "url": "https://github.com/LineageOS/android_hardware_ril"
+  },
+  "hardware/samsung/nfc": {
+    "dateTime": 1619531128,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a0363c5b49997628fb3e147c2be2f78d07852a3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mcsnjjngc7v1rb0pdf9fkjz5ww7smpdyxvll32yayx27nfmnsdq",
+    "url": "https://android.googlesource.com/platform/hardware/samsung/nfc"
+  },
+  "hardware/st/nfc": {
+    "dateTime": 1628149063,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d77a2529f646ddf943dbb760714beb88553fa906",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1r021x5w208zl95ldgja0ziyjmf7yad6pp7yq3rz9nn1a0pi8phf",
+    "url": "https://android.googlesource.com/platform/hardware/st/nfc"
+  },
+  "hardware/st/secure_element": {
+    "dateTime": 1619006432,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b979c55610c202ae34f87ff532b777b62abd4a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "043ca4c21n7jrrckdd2b6j9p1prg4y08k8giw7r90q8kk2bf4cwl",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
+  },
+  "hardware/st/secure_element2": {
+    "dateTime": 1619542024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c9d34df3c5b91a90c3497e1d01f40fa6da08993f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "183k0fmav5ndrkxkl7bnkm5mqyq0ddjjw6iilnl5y8122cg8phqn",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element2"
+  },
+  "hardware/ti/am57x": {
+    "dateTime": 1613841776,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "62d43157532dece513f74f821fc3d766963762fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gqn5lsyf7s420cdiga57w2c6g03zj048i5qq9r4904abcn9w1bm",
+    "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
+  },
+  "kernel/configs": {
+    "dateTime": 1633144053,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "8e9d68624740d4b84ab7fd8b4db332333d2dc15e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08w0m10d9ni4wazdr78gf1yzzihafqbzg4yxxjzpw1gwrv6qm402",
+    "url": "https://android.googlesource.com/kernel/configs"
+  },
+  "kernel/prebuilts/4.19/arm64": {
+    "dateTime": 1633907234,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ca774573c03e0223d70d4de3c3c06a741a1eae0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "00xf3wy11575mfa8bzkrx9lri4mj2dkq4gq1c2khmwzc7i1xprzz",
+    "url": "https://android.googlesource.com/kernel/prebuilts/4.19/arm64"
+  },
+  "kernel/prebuilts/5.10/arm64": {
+    "dateTime": 1633568903,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "829040e6bfc9f38b79f02a4464f206dfa550d194",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zy7dhy7wvv8igg6s0sxvxqfza8zjyqa8i71c10ycrckqvzhxm38",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/arm64"
+  },
+  "kernel/prebuilts/5.10/x86_64": {
+    "dateTime": 1633568904,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe2566a6606b84d5d3f4b85416ccb11ba219dde5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hwp77bndak86a5wxki0ss67x69b7b7rv0ajg7lc823v4zn15q4x",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/x86-64"
+  },
+  "kernel/prebuilts/5.4/arm64": {
+    "dateTime": 1632378761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b490ad5d4a23a22096c92ec89617ef22d00df2ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "014kxvw0xzn7swf96wa2w2lgmkkmvyyh3rykv6ywwbivvxa9waf5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/arm64"
+  },
+  "kernel/prebuilts/5.4/x86_64": {
+    "dateTime": 1632378761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17d7f1eb57085c1bf97ab684964b789593d430ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "167v0a8bb3k23d7lx7rgmwj67gdvm4aqp5s9lm41pvrf6ngpkxda",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/arm64": {
+    "dateTime": 1612209682,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b8b5f9fc5de3123efba066a32a065c90b2622f72",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/x86-64": {
+    "dateTime": 1612209835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8bc9a8401214392d2a8e96805a3ba846a7b769d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/arm64": {
+    "dateTime": 1633568906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "693c793bb71557e41ee2036d09a8fcbf3025a798",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0r5pwgvgdqcpxfx5mcicmpdljvnhs0wwsvvfsj0afmaph8gl7n2p",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/x86-64": {
+    "dateTime": 1633568906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "759696ad20b4f84bc5bda21d0d0cfad3fdbeced8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0facy0r5bxbia8mg7v1s4x0in8z84w9h7rqijpgwkda6l2ach6d5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/arm64": {
+    "dateTime": 1632378762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e099b2c4281438ca627bdcffc78f6c301159de39",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0s4ih5lz2c44h96yy4nm203gqnqi3np9kjl32ymqmlmh5qizjgbl",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/x86-64": {
+    "dateTime": 1632378761,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8266a593748b3dd4c762c6c13bf85cbb1d82d107",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b8xl47wic0kbwk6fm5vli54khr9zwh8nxk0spay6h9vhcl32k25",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/arm64": {
+    "dateTime": 1612210495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fffd58aefba2ab3a3598f3ffea9e8d73bd903f9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/x86-64": {
+    "dateTime": 1612210658,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec342d1c593dae585a06f7d5df815aaf72aaead9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/x86-64"
+  },
+  "kernel/prebuilts/mainline/arm64": {
+    "dateTime": 1623221383,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3d200945220b09b626df433b9b66291e6825e4d2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0pw66qkkcil7wmfamvikdjsdmsr4vysb4f0aby02ygix2kdwfx6p",
+    "url": "https://android.googlesource.com/kernel/prebuilts/mainline/arm64"
+  },
+  "kernel/tests": {
+    "dateTime": 1624417043,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d85b2ea2b84e8d0bfb89730515b467dec7b17f8e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xibcqrq89p12cng3qsg5hcc7lf2mdz90g5cbipz7rxwqpid2qc8",
+    "url": "https://android.googlesource.com/kernel/tests"
+  },
+  "libcore": {
+    "dateTime": 1630595751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf7203d7a5eee0b7fbdb150b4cc72b71502b51a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1k7xbp5nkayyf3ksynanzh1hi8k3dbp339hkvpyy8x3fz7rd04f4",
+    "url": "https://android.googlesource.com/platform/libcore"
+  },
+  "libnativehelper": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63facbd7dc049e14679b2a0079eab6da9386b1c1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1509vfazmfy60ny84mljzf1iw0m5hswg922z4wm8ac79gw5wsrf2",
+    "url": "https://android.googlesource.com/platform/libnativehelper"
+  },
+  "lineage-sdk": {
+    "dateTime": 1642000645,
+    "groups": [],
+    "rev": "b997b2bf5421249ab4f40a6962066b5b76c23e92",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0kdxbbgb2gzddrjpjj4n9dadjb8cjwgbkiwmzqhk36mldip7h7g6",
+    "url": "https://github.com/LineageOS/android_lineage-sdk"
+  },
+  "lineage/ansible": {
+    "dateTime": 1519795388,
+    "groups": [
+      "infra"
+    ],
+    "rev": "0196ba78e2f17b0b74fe34a890a8b49107aafe85",
+    "revisionExpr": "master",
+    "sha256": "0zzii9j2n310l6jjjaaybdyzbs7j0qag53bkcn8qyy1z3vrixnch",
+    "url": "https://github.com/LineageOS/ansible"
+  },
+  "lineage/charter": {
+    "dateTime": 1632714732,
+    "groups": [
+      "infra"
+    ],
+    "rev": "5c4d89287a1b2ba0f565750ac2a018cd226420c5",
+    "revisionExpr": "master",
+    "sha256": "02nkc0qa7mg6ql9bp8ikfaml1fsfj0b5q44s0fdfpknls3ps2xgs",
+    "url": "https://github.com/LineageOS/charter"
+  },
+  "lineage/contributors-cloud-generator": {
+    "dateTime": 1636230062,
+    "groups": [
+      "tools"
+    ],
+    "rev": "b4f0e2854ae40961b1028744df3503ac39792cab",
+    "revisionExpr": "master",
+    "sha256": "0hn2kqmf4myvp1vmcj9q9ikyvg4fj720kiy4ciqm5fqs2j2lrh3x",
+    "url": "https://github.com/LineageOS/contributors-cloud-generator"
+  },
+  "lineage/crowdin": {
+    "dateTime": 1629503989,
+    "groups": [
+      "infra"
+    ],
+    "rev": "d587f8d44deade414c57c2d2b00fae6ed4853bd9",
+    "revisionExpr": "master",
+    "sha256": "16m88cg42dxddnalb9wch4z4a2kkzj108cia2v8aaj140vrc5nl9",
+    "url": "https://github.com/LineageOS/cm_crowdin"
+  },
+  "lineage/cve": {
+    "dateTime": 1565678376,
+    "groups": [
+      "infra"
+    ],
+    "rev": "add764f52e21699dd07c574d637b8cda54a460d5",
+    "revisionExpr": "master",
+    "sha256": "1hkzpv0qqwimdfh8y7qrw7bmymmam021y3hzrq4nldvw5hixyhv7",
+    "url": "https://github.com/LineageOS/cve_tracker"
+  },
+  "lineage/hudson": {
+    "dateTime": 1639898998,
+    "groups": [
+      "infra"
+    ],
+    "rev": "d7edbfc7631fd73226726838abb2ed5eb4c08f62",
+    "revisionExpr": "master",
+    "sha256": "0yxs5zpvsbvm8zmpydn6w1r7kas25wiijnrwxqf9znznn5mn4q17",
+    "url": "https://github.com/LineageOS/hudson"
+  },
+  "lineage/mirror": {
+    "dateTime": 1642338097,
+    "groups": [
+      "infra"
+    ],
+    "rev": "406c93e9b85a8f9514a060d5a968c2da4dfc6e2a",
+    "revisionExpr": "master",
+    "sha256": "029ii9zz2f2p2ksz5bzqk79441ah58kf13yl4gkycqr7k65gcrrd",
+    "url": "https://github.com/LineageOS/mirror"
+  },
+  "lineage/scripts": {
+    "dateTime": 1641770039,
+    "groups": [
+      "tools"
+    ],
+    "rev": "9ece25863683787b736441f9a855fdd8dfca0b7a",
+    "revisionExpr": "master",
+    "sha256": "1nxv9q7ipggan5b8lv4gxxk9qzvq0bzd9cmm2zlwvx6xc47wl6g4",
+    "url": "https://github.com/LineageOS/scripts"
+  },
+  "lineage/slackbot": {
+    "dateTime": 1515511055,
+    "groups": [
+      "infra"
+    ],
+    "rev": "ec8ea4d5505905da2151c2dd4608c41b510dbc07",
+    "revisionExpr": "master",
+    "sha256": "02w945xskyka7ghpx15a344bigw0wj88qxpk91f0rrk7aw3myb7j",
+    "url": "https://github.com/LineageOS/slackbot"
+  },
+  "lineage/website": {
+    "dateTime": 1638835763,
+    "groups": [
+      "infra"
+    ],
+    "rev": "38a7e8484a21e2820f93dca683d9a99bed1f0ce3",
+    "revisionExpr": "master",
+    "sha256": "0k85c5qj1f3wx8p325kbfhfgrqwh2ypvnxa2gnzshhvj3rb9dfw9",
+    "url": "https://github.com/LineageOS/www"
+  },
+  "lineage/wiki": {
+    "dateTime": 1641982505,
+    "groups": [
+      "infra"
+    ],
+    "rev": "dada8fb035d987709053dbf8a734025469f9cb88",
+    "revisionExpr": "master",
+    "sha256": "12l2547axn56ddv2h26jygwfa6hin333cj8h8s9mhkh5vvr9l9r2",
+    "url": "https://github.com/LineageOS/lineage_wiki"
+  },
+  "packages/apps/Backgrounds": {
+    "dateTime": 1642000659,
+    "groups": [],
+    "rev": "63133eef26de8e7b8253d746bff46db8ec80e91b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "19w5v37z1q7h1gfqksn2m1gr6a8skq8fyxa5ybfgm1blkjj1lsgg",
+    "url": "https://github.com/LineageOS/android_packages_apps_Backgrounds"
+  },
+  "packages/apps/BasicSmsReceiver": {
+    "dateTime": 1629257446,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1e98b9bfbdd8b83f562aee9f05b3aeb1431b9e1f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13a8aj0lxiz3xw69iq5mf3kyc99v400x64gk9x2pgb6sqwdb8mn9",
+    "url": "https://android.googlesource.com/platform/packages/apps/BasicSmsReceiver"
+  },
+  "packages/apps/Bluetooth": {
+    "dateTime": 1641478604,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "37c1cfdfa768a1968451d73e86f5117d3a25c4ed",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1p09fw4zj8lm1rn32r6cnlyi4j11q39ipngh6s6aa5dri68x62pg",
+    "url": "https://github.com/LineageOS/android_packages_apps_Bluetooth"
+  },
+  "packages/apps/Calendar": {
+    "dateTime": 1633072725,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4308b4c8d62589d5d6226e8db1b9999f3a2dfe5d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0kfvxpgm706p2yqm52m0c13zzsq7l93b318jinphqkc9pknb44az",
+    "url": "https://android.googlesource.com/platform/packages/apps/Calendar"
+  },
+  "packages/apps/Camera2": {
+    "dateTime": 1642000688,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "44c6e703b0cb983b029d6b69db3c0c1dd057e2ad",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "12szc25kfyq41szxyk6ll5d13zpnrw6kl1p15bixiv2ayai1ib6j",
+    "url": "https://github.com/LineageOS/android_packages_apps_Camera2"
+  },
+  "packages/apps/Car/Calendar": {
+    "dateTime": 1633907245,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7a02fb122ddf482c8f23f5193a1a1f4faca8f2d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08phbcifdw93d6q91kry8rrqwsnasggga6n3yk3107vwiwphp22z",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Calendar"
+  },
+  "packages/apps/Car/Cluster": {
+    "dateTime": 1624667074,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ce858af6281f86d6864a8d510f54ed2abf799640",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1jmpvmk09bca9x4kcnaxxbskqdphv8fxwf1cjhw19c8qda8dwmb8",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
+  },
+  "packages/apps/Car/DebuggingRestrictionController": {
+    "dateTime": 1628015930,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5e6ba46d0ca4b927b060834f8c3935980a114cdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hl1gyk1x3if9vbbd57qi69xrkzlbazfd71cvna9my33aazlz22n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/DebuggingRestrictionController"
+  },
+  "packages/apps/Car/Dialer": {
+    "dateTime": 1633907247,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a58a296571f8ebb3cb5d5dade62f0708be077550",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j5akq6gscanvjfq9ajm81ayws4kpnfwxzaf73l446i0ynh9krvq",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
+  },
+  "packages/apps/Car/Hvac": {
+    "dateTime": 1612566565,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "83b8bd294cf6acf05fd9fb6db45e97adeb48df7f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1d2hqs0qqjihdjsqcpa1sg1k54rzdnzgj1y045mmxjp3sywd4lny",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
+  },
+  "packages/apps/Car/LatinIME": {
+    "dateTime": 1613841785,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "109b369f4aa6288fc31e2a2d36cbfccb63d3b821",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0386ikmn57maxfr4brily6klk0996d93yw6fahk0h1vlh1bhqgma",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
+  },
+  "packages/apps/Car/Launcher": {
+    "dateTime": 1630449945,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "41d8f537afa92650a0541a2a3d1ade2e2e9a0e2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01xigbj12hwgx29rf1xcc9cj8bq2c19qrq8i4wq5hq9c7b9x68kk",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
+  },
+  "packages/apps/Car/LinkViewer": {
+    "dateTime": 1619125457,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1853c8db652cddad119ed81cdfe05369e122db97",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z34jrm6jwb5wpvia998h5izbmx7s80k3vgk43kmizkpfkd99n9p",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
+  },
+  "packages/apps/Car/LocalMediaPlayer": {
+    "dateTime": 1624663495,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f70786d5bd8ca16734df9a7d5dd3f08f762b8954",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1q5kbq8p08vscikaqjhkx2dq4cv7i7q3x4ga9fvjfgjnpvvwcgla",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
+  },
+  "packages/apps/Car/Media": {
+    "dateTime": 1633907249,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ac24d54e7bff4e397f9bd7b56678161157daf7a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cqpvv9wssnb08k7bys4nzpx5bk20b5v60ff0jkcfp8inijgig1y",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
+  },
+  "packages/apps/Car/Messenger": {
+    "dateTime": 1625278625,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b99b08add99938e4495836ca46c872a86a62c50e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gfrnnp74byx7rcxx8sx383vbpngmd99bjswkdv6rf6v71pxghs5",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
+  },
+  "packages/apps/Car/Notification": {
+    "dateTime": 1633216077,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7e0cfac164c39f63204ea0732aca8f68ddfe5d8a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yvbxq5k6bhdjh32cxgdvw475j8lhzh0ss8dijflla8rczy2rx4w",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
+  },
+  "packages/apps/Car/Provision": {
+    "dateTime": 1614663424,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4c3f421608e687af926bb82cfafc61af58fa2058",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hfam8x8qx9ggli07kgwinf6l1lllb7cv0i8g1k7ff0fahm7frrk",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Provision"
+  },
+  "packages/apps/Car/Radio": {
+    "dateTime": 1618537295,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "127eaab5aedfe62e939aa4c5c571fa314b072dc2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1cnswjixyvfvv4hgsvdwb3hga5pzr2nljkx8rxqwjdpa0c8ny8dv",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
+  },
+  "packages/apps/Car/RotaryController": {
+    "dateTime": 1624473444,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5f61ec4a9272da19fd99cef631f37d75824947d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p4if21xgcj2if6ap4h67scxgy9rh42my4s1n82s9dqclyan7npb",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/RotaryController"
+  },
+  "packages/apps/Car/Settings": {
+    "dateTime": 1639515151,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8cdfe978a051648c27416110cb01a1828f7571a8",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1ldl3li4haqq28qcv9n6sya3qxnp1sls29w2nfbsimk095kslhz7",
+    "url": "https://github.com/LineageOS/android_packages_apps_Car_Settings"
+  },
+  "packages/apps/Car/SettingsIntelligence": {
+    "dateTime": 1623862905,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "feb0329906af211b18fbd32f77ce692dd20d8579",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12hhrinxbnllsqq8xm1c1glip9rccm28axw6h7pmqdr71z4nd7wr",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SettingsIntelligence"
+  },
+  "packages/apps/Car/SystemUI": {
+    "dateTime": 1629476788,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8e25de8087e6007cff8947e033321f4ac7d70fda",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xjgdsqbd0qbbyabk2l383wkf504apfbrxpz22gpc3jw2k9i3vfz",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUI"
+  },
+  "packages/apps/Car/SystemUpdater": {
+    "dateTime": 1624663223,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5cbee695783178dae8a58c5973093f0ef7e86e7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0c5i2y5p3y5gmbdi4fl3k6nrifr9kp1g15115i92fg3vh78f4g0x",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
+  },
+  "packages/apps/Car/libs": {
+    "dateTime": 1633655275,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e181dac6d9b39dadf1818ddd7224b5cb36a6bb8d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hs861hidar3a5ib6yrqfb92kz5nyxshpj8f9gl0kwi1cv57paz7",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
+  },
+  "packages/apps/Car/tests": {
+    "dateTime": 1624659459,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d5909a7ddf81331c3d0a481b549202991e44a6b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03cwfjb13np93vfvpidvbwrx57d41hb673ddrwh9rnqk1h1sj0z5",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
+  },
+  "packages/apps/CarrierConfig": {
+    "dateTime": 1635860786,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8fc9861a66a3c281b864a6bb10e93b6f3028367e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1i6my1iy8k5xxswk16jvfg0cma4vsi43g8256gvx8y98ymcm6ih9",
+    "url": "https://android.googlesource.com/platform/packages/apps/CarrierConfig"
+  },
+  "packages/apps/CellBroadcastReceiver": {
+    "dateTime": 1633216082,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bdac19da393f2da01a4f72381f99f6f18e99ea42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kdwdiplag1zfnzfns7cvj3cm1ixq9q560ql328l787p4p2frl27",
+    "url": "https://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver"
+  },
+  "packages/apps/CertInstaller": {
+    "dateTime": 1632503464,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6e9403a68710c8fb0b44b4b1972720598526cc2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1h6aiddwy7jpyk0rlwjj9590pqcwpshscr9i2ylhq44yfax9qb67",
+    "url": "https://android.googlesource.com/platform/packages/apps/CertInstaller"
+  },
+  "packages/apps/Contacts": {
+    "dateTime": 1642000700,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bb6dd984d682551b410b14735b7fda3b402c7b8f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0glw0qziln5brphf8kflx2603fgj5jiqb7dz3pn2y70416vi5lqx",
+    "url": "https://github.com/LineageOS/android_packages_apps_Contacts"
+  },
+  "packages/apps/DeskClock": {
+    "dateTime": 1642000712,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ecbf1b88f142319a37b688b1e9a40725c000a57d",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "114h9jiz48j6z9w59lla6g94zc9nfbir2wvr8cs7i5bbrm630y8n",
+    "url": "https://github.com/LineageOS/android_packages_apps_DeskClock"
+  },
+  "packages/apps/Dialer": {
+    "dateTime": 1642105335,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "74364b9eab0311c5d4e0021ffde9bb4bd5994e4f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0l6y7r77x7x0hvqhhbbdnpc1vjddcc61hglwmw8vss3rpsiibygh",
+    "url": "https://github.com/LineageOS/android_packages_apps_Dialer"
+  },
+  "packages/apps/DocumentsUI": {
+    "dateTime": 1639515160,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1a16c5d108d1dad87db9598d5af0f0176cc438f8",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1gc5hyvvkvygyvpnpzk6wyjgwkb644zvw2nad7aigy6cmpbfwbc3",
+    "url": "https://github.com/LineageOS/android_packages_apps_DocumentsUI"
+  },
+  "packages/apps/Eleven": {
+    "dateTime": 1642000732,
+    "groups": [],
+    "rev": "e3fa1af7839b6d514aa7a4316ea80bf2a177e361",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1b2ivpmm0gyxxs987vjig40hkm0ddy0n5al7mg4fnypbcygnwzsp",
+    "url": "https://github.com/LineageOS/android_packages_apps_Eleven"
+  },
+  "packages/apps/EmergencyInfo": {
+    "dateTime": 1632148195,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ebfa5587032448c18cbc9fc250cc06542622dc3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v7fcmd2qbb7p9j1zm45jrqwzxaapmap05pdf86nx2055yxz8r7a",
+    "url": "https://android.googlesource.com/platform/packages/apps/EmergencyInfo"
+  },
+  "packages/apps/ExactCalculator": {
+    "dateTime": 1633529363,
+    "groups": [],
+    "rev": "5bec5891cea2fd177d841e925a7fe5e09d6a914a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1lw3k6k3mrkm5gxi6afm8bd3gwy3kc29rpikw89q2v6z7imxhmg1",
+    "url": "https://github.com/LineageOS/android_packages_apps_ExactCalculator"
+  },
+  "packages/apps/Gallery2": {
+    "dateTime": 1613842710,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0392cb2240a9dc07aec700994036fd10737744d6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0867dc7j5diqyivnd9j6s8c4iwjgml5r47s364s8c8z7jz2haicf",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery2"
+  },
+  "packages/apps/HTMLViewer": {
+    "dateTime": 1620159861,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "93bc3980683853b36f919478acce8990e2e00055",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p8kx6jf10ga48l7sbbn731yp8rfy9z2l2n5kvxwwc7vflbybi90",
+    "url": "https://android.googlesource.com/platform/packages/apps/HTMLViewer"
+  },
+  "packages/apps/ImsServiceEntitlement": {
+    "dateTime": 1632355343,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0a01690fb5e678490b5cc31a75d4b9ec2caac308",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10awzbjfzx3pvc879rrf28vrnhmj8iz830jxxah38l63sr1x4y1v",
+    "url": "https://android.googlesource.com/platform/packages/apps/ImsServiceEntitlement"
+  },
+  "packages/apps/Jelly": {
+    "dateTime": 1642000762,
+    "groups": [],
+    "rev": "5993fda5f2ae14fa2e21a07258555851cc6395ac",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1yam23xn1gm32qqvhmqwiisisa6bc2ykw2jldzwd7a9grwajaj0w",
+    "url": "https://github.com/LineageOS/android_packages_apps_Jelly"
+  },
+  "packages/apps/KeyChain": {
+    "dateTime": 1633568929,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "87f73c9b854c60d51ec7dadcae0f1c16205f0534",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lcdnsmyf9qqfbafbc68w6alyaxp2zxg3mb1cfdcplwx7bhng50i",
+    "url": "https://android.googlesource.com/platform/packages/apps/KeyChain"
+  },
+  "packages/apps/LineageParts": {
+    "dateTime": 1642634628,
+    "groups": [],
+    "rev": "e360edfa6b48150c7c6d9e36acff16c5d378fcb5",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0jgs9bsfczh3fwi05jibj1jvypcsmizbhnvj0flxpaplznxksp6w",
+    "url": "https://github.com/LineageOS/android_packages_apps_LineageParts"
+  },
+  "packages/apps/ManagedProvisioning": {
+    "dateTime": 1640531102,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d867fc36176dd2c804bbcfbedd3dd0e69eb01433",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0cd6qy9nnbvla5lf565cjb6scpbhpg8gn2csha6smbfaa5vnw6i4",
+    "url": "https://android.googlesource.com/platform/packages/apps/ManagedProvisioning"
+  },
+  "packages/apps/Messaging": {
+    "dateTime": 1642000790,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "68a07f1af0552551c813fd840636efbb4e0ad282",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "13aai6b8dwf05y2lp72rrikjrjil1s1si2s52as8hp9hsrj4x18p",
+    "url": "https://github.com/LineageOS/android_packages_apps_Messaging"
+  },
+  "packages/apps/Nfc": {
+    "dateTime": 1633568932,
+    "groups": [
+      "apps_nfc",
+      "pdk-fs"
+    ],
+    "rev": "f2fe63716d5d285eb17aeeea277e8318fecec7ff",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j5snrhyd3apk5rpnyc8xzjwqznh79czh5hp6zh9a1vkfarxg4bl",
+    "url": "https://android.googlesource.com/platform/packages/apps/Nfc"
+  },
+  "packages/apps/OnDeviceAppPrediction": {
+    "dateTime": 1613934452,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "cb51631578c2fbd731f249ed7654c0a521e4704b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1fkf6vkd884q62xl21kayi6113ggay9yla8v89nq1dyp2k5w3dna",
+    "url": "https://android.googlesource.com/platform/packages/apps/OnDeviceAppPrediction"
+  },
+  "packages/apps/OneTimeInitializer": {
+    "dateTime": 1612561058,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f560d872c05e39b403ad9b990eadcdfd4f04001a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p5xhhljcd2bcpb57b22h65rgsv6k11l3xdi0bc4jaim9p12sikp",
+    "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
+  },
+  "packages/apps/PhoneCommon": {
+    "dateTime": 1630268878,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c26921d9a36f5f7af6f43d58d6e3ccc8e21d5b13",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rkb6bjjvjivfi6inz82wlg0pcasywciw5szdxra95vgh1fxq3w9",
+    "url": "https://android.googlesource.com/platform/packages/apps/PhoneCommon"
+  },
+  "packages/apps/Profiles": {
+    "dateTime": 1642000804,
+    "groups": [],
+    "rev": "a6199bc777ff65d3c2380e979ed1da8d0cb72823",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0lblxilj8hq7q8jbbala4xk76x3n1q4ikasgdsn6jns009pf3xxm",
+    "url": "https://github.com/LineageOS/android_packages_apps_Profiles"
+  },
+  "packages/apps/Provision": {
+    "dateTime": 1613841788,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "edfa0a39591e067643658431e1cf329f7755fac4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1b52p9b9i19cg8pip9ykfj5finlvxxv9ikwjfjpk022pzg0p0zz2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Provision"
+  },
+  "packages/apps/QuickAccessWallet": {
+    "dateTime": 1632515932,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "30e868c0caf969b0753674221c2ad7ce4d7f09b3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z85rzf28s2f28jxpa89ja51yl8kf12z43a1k72lb7q7cgma6w9a",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickAccessWallet"
+  },
+  "packages/apps/Recorder": {
+    "dateTime": 1642000816,
+    "groups": [],
+    "rev": "0db1b52c466ba38f1c09964d369c498ec6c49cee",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "06il50cy4clnxngfgjbinmyaagxvf4nlwybsqg765vyfgm2xw16v",
+    "url": "https://github.com/LineageOS/android_packages_apps_Recorder"
+  },
+  "packages/apps/RemoteProvisioner": {
+    "dateTime": 1628476460,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ed833974e3b1fd8512da0b65749dfe14da959f2c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1z5khrz27380n6rrjm290nj8cv36ngamj52zbzffy26xi7haxcwq",
+    "url": "https://android.googlesource.com/platform/packages/apps/RemoteProvisioner"
+  },
+  "packages/apps/SafetyRegulatoryInfo": {
+    "dateTime": 1629521007,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c617559b15691407f2635997cfd365e26adae573",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1r88hq0ak16arp7nkn6ihfkdly07ypl0l0f2mnxw9s2c1sj0j5rz",
+    "url": "https://android.googlesource.com/platform/packages/apps/SafetyRegulatoryInfo"
+  },
+  "packages/apps/SampleLocationAttribution": {
+    "dateTime": 1620147500,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0b26337dd5235449474aea7884f6a584678d71f4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rl5fafh4w2ly59yby031ag1h5b1i7fp01i89qlsc85x5c4k3ash",
+    "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
+  },
+  "packages/apps/SecureElement": {
+    "dateTime": 1620126396,
+    "groups": [
+      "apps_se",
+      "pdk-fs"
+    ],
+    "rev": "1a86d34812e9fb7599ad72b32d61184297e0690a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0csvapdfp737y40sywzxbk87bx20dn3j7ppalz6wigc25r2a5wz8",
+    "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
+  },
+  "packages/apps/Seedvault": {
+    "dateTime": 1641580213,
+    "groups": [],
+    "rev": "c47aaf20183e4d5a14ba32c5048a8f9e342e15bd",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "11fhhvqm01kcrcfzjr9wl02nwmfz4y7nlg68ffzaviia86ba5k7r",
+    "url": "https://github.com/LineageOS/android_packages_apps_Seedvault"
+  },
+  "packages/apps/Settings": {
+    "dateTime": 1642183143,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6ab46a64c0cea9f5305d1538c0aa358a46d03e17",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0zpamc3warhqrm5bslbijpmgr9rkyslkx91waf27mfl0fnlsvwbv",
+    "url": "https://github.com/LineageOS/android_packages_apps_Settings"
+  },
+  "packages/apps/SettingsIntelligence": {
+    "dateTime": 1633805236,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "899bcddc7fd854e99d9c1790f62a4ff9e0c1186f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1ki6lvyx979pnyf9j6q5j96illr5a0bzg5yzqbnasxycfkpf5445",
+    "url": "https://github.com/LineageOS/android_packages_apps_SettingsIntelligence"
+  },
+  "packages/apps/SetupWizard": {
+    "dateTime": 1642105199,
+    "groups": [],
+    "rev": "3d7c828448dcb4f72a6e6c4cf1f1bd97e99e13fe",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1bfqfgda92m8xcwmgcd1x52j717907p2f4w4vj10s1xll5i7rxl8",
+    "url": "https://github.com/LineageOS/android_packages_apps_SetupWizard"
+  },
+  "packages/apps/SimpleDeviceConfig": {
+    "dateTime": 1633479375,
+    "groups": [],
+    "rev": "82d31b18dd2550e05f89248f128cb571eecc863a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1fc7bpnpvmji1apdnfwq4dhlkf39j43rhvsndrhg85kd0gss79lx",
+    "url": "https://github.com/LineageOS/android_packages_apps_SimpleDeviceConfig"
+  },
+  "packages/apps/Stk": {
+    "dateTime": 1639515172,
+    "groups": [
+      "apps_stk",
+      "pdk-fs"
+    ],
+    "rev": "9294a31b2ec7adf0b652cee69d2675a569299208",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1lymi4d4jaq17dkp6y1pfj7fh3bgi1hws8na1q8qgf8azbbgp2bk",
+    "url": "https://github.com/LineageOS/android_packages_apps_Stk"
+  },
+  "packages/apps/StorageManager": {
+    "dateTime": 1634353670,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "197f711fb0f8377264504ed4f71d0e83a791d29f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pshqbc597ljw2m0c7113pb4dhxv3ikrkqy7p2l717sdib7jn4b5",
+    "url": "https://android.googlesource.com/platform/packages/apps/StorageManager"
+  },
+  "packages/apps/TV": {
+    "dateTime": 1620683181,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe56d3cb87b779ed0d65bc27300e64e397a25ca4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0qx3r6m8crigjdxyhxbbfvmrs6r9yjjsjkz5i6aclg2l02hmrqq8",
+    "url": "https://android.googlesource.com/platform/packages/apps/TV"
+  },
+  "packages/apps/Tag": {
+    "dateTime": 1632504416,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2da6d18d655756947ef7a19b94887719f4ac302f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0f8rbw0h448islyq3p7hdl4r779lhl4b0lkh4yspmmsz3z2azqik",
+    "url": "https://android.googlesource.com/platform/packages/apps/Tag"
+  },
+  "packages/apps/Test/connectivity": {
+    "dateTime": 1613823670,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65f770df0643a47741d7ac4a9600393070ffd57f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "10mb5gqc3lyi02r4i68yqhqxiwik1xdi87ik9s6lr9b04clf1fax",
+    "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
+  },
+  "packages/apps/ThemePicker": {
+    "dateTime": 1639515176,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c951bf52302d585bce1eff404b4321309020fde1",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "094yxbvb6s33pgd3j2briy00vpymbjk5kglw5mp9d9j8niwb2lv1",
+    "url": "https://github.com/LineageOS/android_packages_apps_ThemePicker"
+  },
+  "packages/apps/TimeZoneData": {
+    "dateTime": 1619035266,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bcaffe59921770d4011f6a5fde0553440026f1a7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07ap27ilgs63idvgw1lyzy64djz657ad4wz273y0pibgh3nm5fj9",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneData"
+  },
+  "packages/apps/TimeZoneUpdater": {
+    "dateTime": 1622749914,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72a2c703559879af84c9e2584d6e1151264b4998",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12ir26ysn4n8q1mvyhxp0lmry7k51zam3n2pcdkg3v3g1s344g80",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneUpdater"
+  },
+  "packages/apps/Traceur": {
+    "dateTime": 1634353673,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4856f4b3411a455f10202fa3afa0c807a0608092",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zj5q2y6mkd6aklbbz0g9az871xisxxa85zb6id4l64pddv6p2yg",
+    "url": "https://android.googlesource.com/platform/packages/apps/Traceur"
+  },
+  "packages/apps/Trebuchet": {
+    "dateTime": 1642468646,
+    "groups": [],
+    "rev": "137e88b5241e95690b9014f9959442dfb71863bf",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "12a5a7in26n5rvkr57jcc7slm3sr5jrc4zgq77fgxz5xgsklk982",
+    "url": "https://github.com/LineageOS/android_packages_apps_Trebuchet"
+  },
+  "packages/apps/TvSettings": {
+    "dateTime": 1642213658,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4442bd7d03d96da1d411affef0b53ac4623d8bcc",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0xkkm9x9a0slpw3p4d4j2y4ha7hpv70rp5bqyizs5rfwhd0byc0r",
+    "url": "https://github.com/LineageOS/android_packages_apps_TvSettings"
+  },
+  "packages/apps/UniversalMediaPlayer": {
+    "dateTime": 1613934678,
+    "groups": [],
+    "rev": "c2f78bd5aebd936cdb16611e187e38d239fda722",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bzyk8zck067snc55bknnd4rsmsqkx3y41yg5w9lm410a7vr7bgz",
+    "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
+  },
+  "packages/apps/Updater": {
+    "dateTime": 1641995217,
+    "groups": [],
+    "rev": "7f584e9c081e667ad349aa95d9755c073da3e97c",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0qkhjk5vqdn9130dvkkd7r8jf12a6ascx8iyj3l6w0hbxncql80l",
+    "url": "https://github.com/LineageOS/android_packages_apps_Updater"
+  },
+  "packages/apps/WallpaperPicker2": {
+    "dateTime": 1639515179,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2026dd376aef0213075aae30d2cb9e96397bbf1f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "018ayfzaw35f2smrd7l0vwg6z7griwicpa7z1mb1xc6c06jykicg",
+    "url": "https://github.com/LineageOS/android_packages_apps_WallpaperPicker2"
+  },
+  "packages/inputmethods/LatinIME": {
+    "dateTime": 1641995219,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "189311c2d67909013ee8f63e9e7e6508f175dc5d",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0498b37k3nykq3cshh61s0j19yarf3bwnpjdpzvgz8y4n4cicyp1",
+    "url": "https://github.com/LineageOS/android_packages_inputmethods_LatinIME"
+  },
+  "packages/inputmethods/LeanbackIME": {
+    "dateTime": 1612560903,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "26136094b101bf5ba61323e66dfb19e4a4345eb1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "19wfvg8izsyvb2fwy1gl21vfk7v9c1icbpw542pqcjdyc6dyb672",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
+  },
+  "packages/modules/ArtPrebuilt": {
+    "dateTime": 1625256038,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "89536bc5e60bb856be8983530453ace3b2098a15",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0i9lnw0byhqxwz242kbr5dhi8dg91grhkycp9jp5icdpza28l66b",
+    "url": "https://android.googlesource.com/platform/packages/modules/ArtPrebuilt"
+  },
+  "packages/modules/BootPrebuilt/5.10/arm64": {
+    "dateTime": 1610155294,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4897a6a51a9c9f8c2237ed9bc7820a096d74af66",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1n7apxd43m3i2sqgjcp80garn9zznfcsq67gnm0nywp0bbi7wd58",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.10/arm64"
+  },
+  "packages/modules/BootPrebuilt/5.4/arm64": {
+    "dateTime": 1613824002,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42b59fd038624ae55347c87f845ecc905ab7e07a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13gs7i4dcwmjwld93q0w47ar1gcah0kaqbkxacwlc404axfzqg72",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.4/arm64"
+  },
+  "packages/modules/CaptivePortalLogin": {
+    "dateTime": 1629521001,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d6a7c145b8b141398103ce0656ac3da007b264cd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wrrk7lzh101lgavicb3ghnzvkgr6dd7irxf1ibhlrnkbkfg3q3l",
+    "url": "https://android.googlesource.com/platform/packages/modules/CaptivePortalLogin"
+  },
+  "packages/modules/CellBroadcastService": {
+    "dateTime": 1631221369,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9cb5a58f584f5199f226d62306eff2a0018ddc7a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0slndn640xczh9ry6lplyf9im6b26z9n6v4d367ihbv85kn3yhib",
+    "url": "https://android.googlesource.com/platform/packages/modules/CellBroadcastService"
+  },
+  "packages/modules/Connectivity": {
+    "dateTime": 1640126558,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0c3329cc60856c10e899315b347462b8c877d107",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1h24hwc2h5dbczqxwywycni1v1snlhysrvbqpa05ysxz9x79g569",
+    "url": "https://github.com/LineageOS/android_packages_modules_Connectivity"
+  },
+  "packages/modules/Cronet": {
+    "dateTime": 1624437564,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4af3e015d1c8f33ff31550ffc96d7d66ddf20f0f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Cronet"
+  },
+  "packages/modules/DnsResolver": {
+    "dateTime": 1628258794,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "84411433a5d58c041d1af2779345e5e302bcdbb1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ckllgahhki8dcx3md37x6jcyjm5maxmh98l43d107h14h1bva10",
+    "url": "https://android.googlesource.com/platform/packages/modules/DnsResolver"
+  },
+  "packages/modules/ExtServices": {
+    "dateTime": 1634000875,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7edc7b080443124236aa2c93feadab6c4653ceaf",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "112sxv4lymh9sx4n1ai9hcxd56wpjc9fbll1ih6bvx2421y65ar6",
+    "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
+  },
+  "packages/modules/GeoTZ": {
+    "dateTime": 1623872217,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ff5b91bab9452895dc069e6fca8a902dbec93a3d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1xw9s4x82r3aa98wcr5cbmclcw2cmmc22palh14ylsypcvpb4zip",
+    "url": "https://android.googlesource.com/platform/packages/modules/GeoTZ"
+  },
+  "packages/modules/Gki": {
+    "dateTime": 1622030690,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7aed682df9d52c7495f203f0b60e292d06539ae4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1snci4l616cvznfbgw3xvmkvsa3i95q1v3fp882327wmv65nrqww",
+    "url": "https://android.googlesource.com/platform/packages/modules/Gki"
+  },
+  "packages/modules/IPsec": {
+    "dateTime": 1628888010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8dc668ff5a90331027820887bcf70e8ed31351a2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v2qw6hjafasjn9vby9wac9kp204nfn0y3j0abhz2i591jnbzkdl",
+    "url": "https://android.googlesource.com/platform/packages/modules/IPsec"
+  },
+  "packages/modules/ModuleMetadata": {
+    "dateTime": 1622030724,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f8143db8de7e668ea962c04a190f64fc3c6be9e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wl1mb6fmnym4yyi1w4fc0zni7awb50mh9w91a6plp5j1rmy3x87",
+    "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
+  },
+  "packages/modules/NetworkPermissionConfig": {
+    "dateTime": 1614071034,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "99104d9117e5f22912c2d7fb9567af2db2fee600",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nz2xs3rmpvbfwka7lxr87chqpchq57cc8r25qfgymbhnkkg61pl",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
+  },
+  "packages/modules/NetworkStack": {
+    "dateTime": 1631452622,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4812f11869e69277fc70c5c819fd553892206ff9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "139xx8p1kjg0p0l2zgpqxb7d6pprqzmsyb2jjmb4w2lzka5jm5w9",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkStack"
+  },
+  "packages/modules/NeuralNetworks": {
+    "dateTime": 1632862953,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6e15ee5c500f658ea0851c67deb6d4f73b310829",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1aamf7piyca89ri2xahgb2zbqdwx64qyslllnanpv6rq4zvf5pqm",
+    "url": "https://android.googlesource.com/platform/packages/modules/NeuralNetworks"
+  },
+  "packages/modules/Permission": {
+    "dateTime": 1633907289,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "88bb8f6a817f8f4c1df28c0b1097393904c5b1d9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kg161m9cfhfz0y1iixrmyzgj5pa2wxw7r5gmvsvclznaffnnpzc",
+    "url": "https://android.googlesource.com/platform/packages/modules/Permission"
+  },
+  "packages/modules/RuntimeI18n": {
+    "dateTime": 1623704087,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2be2a40cb3fbdd2a88b9644bf549d5c1466df2e2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "016clxna7xjxwy42chxfdcp48ny0j3g4nyxg57zvqglgrlx8cqp2",
+    "url": "https://android.googlesource.com/platform/packages/modules/RuntimeI18n"
+  },
+  "packages/modules/Scheduling": {
+    "dateTime": 1627009218,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "534595c58531bdcfe3e8fc60ba3d2180a69c768e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hl2d5b5nybidak1pwiw26sm08il2nb5jflj419f765p3g9r5byf",
+    "url": "https://android.googlesource.com/platform/packages/modules/Scheduling"
+  },
+  "packages/modules/SdkExtensions": {
+    "dateTime": 1628268818,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "55df9556ac814c327aca3b99682680ecc95eab87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1m4pl0v7f56g74ym76qrq198g6pnd93w8zh05bynvyvarwbajphd",
+    "url": "https://android.googlesource.com/platform/packages/modules/SdkExtensions"
+  },
+  "packages/modules/StatsD": {
+    "dateTime": 1633482510,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "58d133e7a2b2047098dbdea058217c8f628a6efb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g7y0v46pa2650m0rd9697gzp5zrlmlg70hhv0f2p3ap6q8y80gx",
+    "url": "https://android.googlesource.com/platform/packages/modules/StatsD"
+  },
+  "packages/modules/TestModule": {
+    "dateTime": 1539195664,
+    "groups": [],
+    "rev": "41a212ed3a89f56fabea901bddb367c69f99af08",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
+  },
+  "packages/modules/Virtualization": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba76ce28778c2e59fe9ff3ab15b1ede457c5ed11",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1i7h4ppc6clrz7q992fmq7wsw7pznpai9kinwb2w87b0m3yzplk5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Virtualization"
+  },
+  "packages/modules/Wifi": {
+    "dateTime": 1635134671,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7fcd1099ab2928c82c405f430944d05f38975098",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yx5yam0rqqx1mjj4jshdchy55i087n28mdyap2jb9nk0nbygi2v",
+    "url": "https://android.googlesource.com/platform/packages/modules/Wifi"
+  },
+  "packages/modules/adb": {
+    "dateTime": 1641503274,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ea98c652d33b3ea3e916585566d15b4703ead56",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0v9vwf7q811y09gc6ywzfh9zmbbhwmh55x4r14cpvvvkz7rkl8ny",
+    "url": "https://github.com/LineageOS/android_packages_modules_adb"
+  },
+  "packages/modules/common": {
+    "dateTime": 1640118556,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "114d162934b6807cc86dde933e16937cb1b61e57",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1ch6nwiz43vgjmbr63gr5s1i27ficdy2v6m8izbbikswk79c40ax",
+    "url": "https://github.com/LineageOS/android_packages_modules_common"
+  },
+  "packages/modules/vndk": {
+    "dateTime": 1623704209,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b8bdf93c5328b64363bbc3db079fe798d77794b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01y5wlkqvj6qcplkjmwazmz8q964k9x32kx8v85kq7w5vgnlc33b",
+    "url": "https://android.googlesource.com/platform/packages/modules/vndk"
+  },
+  "packages/overlays/Lineage": {
+    "dateTime": 1633965976,
+    "groups": [],
+    "rev": "9f2762868fbe6a59e73fa3515eeb81e225a9c962",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0crgp2nxz1hmspdflzd9g4vmnb59zk5krhaa88xrgky213xfzwa9",
+    "url": "https://github.com/LineageOS/android_packages_overlays_Lineage"
+  },
+  "packages/providers/BlockedNumberProvider": {
+    "dateTime": 1633623900,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7d095bcd7968e9f6696aa386922f6152e11b243d",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0i2ls4050sk1shpirbiwwn4xkm4brd81hdk71pg4fhx25ar9dnix",
+    "url": "https://github.com/LineageOS/android_packages_providers_BlockedNumberProvider"
+  },
+  "packages/providers/BookmarkProvider": {
+    "dateTime": 1633623937,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a409f9216436d5593ee6df03e7429ab847d644fa",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0yc2s9639gpbdxqsq271h6zvxsqpkqsn0rf9xj7g6bwvr72i0q95",
+    "url": "https://github.com/LineageOS/android_packages_providers_BookmarkProvider"
+  },
+  "packages/providers/CalendarProvider": {
+    "dateTime": 1633623967,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "07fba237b0a769046074eb61da73476240fe580b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0dhzmp8vi5qcqxvpfqss4l6bbp4ylf3ajk2cph3d0g9g8jk6lhli",
+    "url": "https://github.com/LineageOS/android_packages_providers_CalendarProvider"
+  },
+  "packages/providers/CallLogProvider": {
+    "dateTime": 1633623997,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "af189f442e0e69dedfb8d170b492a295ba3ed6bd",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0q0d92kwh3p9bsvgd7h3x4b4n9yjblw40mj7fgn7xgv3rfjmf8ml",
+    "url": "https://github.com/LineageOS/android_packages_providers_CallLogProvider"
+  },
+  "packages/providers/ContactsProvider": {
+    "dateTime": 1639515192,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ab3f8baa244bab7426ca3a064c38de8074727062",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1lqzalmbbgmnzxjdqn1wz4vrbl4rg1i3r70brbrqaagscsz2ibk6",
+    "url": "https://github.com/LineageOS/android_packages_providers_ContactsProvider"
+  },
+  "packages/providers/DownloadProvider": {
+    "dateTime": 1641995222,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0f796e6b62406b6631ff4e79239308f9ea8969d6",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0ljh6h35cdiw8h6pzs53axg6rp2j4bnlh9zhzq13n6qflrs51f7f",
+    "url": "https://github.com/LineageOS/android_packages_providers_DownloadProvider"
+  },
+  "packages/providers/MediaProvider": {
+    "dateTime": 1639515201,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "88d13cf097de5bf40454b8aebd95e289a118dc61",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "08ixqskff5h8f86ar4h3npq9bby7s8r7yvydbvkpkf4rivw4h6dh",
+    "url": "https://github.com/LineageOS/android_packages_providers_MediaProvider"
+  },
+  "packages/providers/PartnerBookmarksProvider": {
+    "dateTime": 1613934274,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e247fcdd3bd157c0231affad76158bf09773a424",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12s14vcmpypbk2h116n3spvqg4akj6xizjrw7vilab7ln8wp89i5",
+    "url": "https://android.googlesource.com/platform/packages/providers/PartnerBookmarksProvider"
+  },
+  "packages/providers/TelephonyProvider": {
+    "dateTime": 1642084869,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "33af7b794cc00cf2d34d48c704c8de9278991c83",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1fh0fdm6ssdh775203sxlhrplhqrkgk8bv09v8nrlah8c7iia4iw",
+    "url": "https://github.com/LineageOS/android_packages_providers_TelephonyProvider"
+  },
+  "packages/providers/TvProvider": {
+    "dateTime": 1629521014,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "dca8b5d2832e1eff82f6b370b1c2f459a3270288",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0mkp75x3a22b4gyhw3j3lyc2xwd32xw6xhwkgi4iiql3kwqq8w7b",
+    "url": "https://android.googlesource.com/platform/packages/providers/TvProvider"
+  },
+  "packages/providers/UserDictionaryProvider": {
+    "dateTime": 1624300796,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9c2e23634083ac8e2c4574d4ec3a740df0083b75",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0nkkxj3mm39lp6ga1icachqykkcarfslxi3jngxj8v1rriqa710w",
+    "url": "https://android.googlesource.com/platform/packages/providers/UserDictionaryProvider"
+  },
+  "packages/resources/devicesettings": {
+    "dateTime": 1642111551,
+    "groups": [],
+    "rev": "67b3bedd4d33292b7f25bcba3584edea212ee2a2",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0c24pnin9wiychdxa8df2815w1bvlqk73szbr6psh9rgn4ihxyll",
+    "url": "https://github.com/LineageOS/android_packages_resources_devicesettings"
+  },
+  "packages/screensavers/Basic": {
+    "dateTime": 1622529042,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c0e1b53e325c672968dc633162b95fd38b32038c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03wkn8gl92cdcqkykb1m5kpmmzmc46hlinz4gyprpacn8wgr6zqx",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/Basic"
+  },
+  "packages/screensavers/PhotoTable": {
+    "dateTime": 1634353696,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "37031d861f737f6114932a5fc432dc548534e442",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bp8pwc5sz6l9mlwwj24ngxkbcyds9gba9c2mpb7zsls46agqpna",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/PhotoTable"
+  },
+  "packages/services/AlternativeNetworkAccess": {
+    "dateTime": 1630520767,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ec983a48b31b86ed2a6cde44ac81dfe07173772e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16b84vhvra87k6ricz42wi0i3byvb3bz9ivn464fc486j5vkgs49",
+    "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
+  },
+  "packages/services/BuiltInPrintService": {
+    "dateTime": 1631453299,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "54ff1e4df5072ad564a50d8960176c17708c9ac9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04jkplcn8m16k0hcnzahpqga3dxxfmhqsrzac814kyihkxysk28z",
+    "url": "https://android.googlesource.com/platform/packages/services/BuiltInPrintService"
+  },
+  "packages/services/Car": {
+    "dateTime": 1634353697,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7053f2287e3f04733087c539fe0f320ab03fd7b9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ls0b17nsj6na2yiqv53gzdaa491dqgd5flxgg5d7km28xkd85ik",
+    "url": "https://android.googlesource.com/platform/packages/services/Car"
+  },
+  "packages/services/Iwlan": {
+    "dateTime": 1628733391,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d5e97db86d3ad51bd2d69d7644dfff7a56876883",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1l7f39npsjsy6rgaypz8c33y29y8b500m7ssrp1w0b3injj5ddy1",
+    "url": "https://android.googlesource.com/platform/packages/services/Iwlan"
+  },
+  "packages/services/Mms": {
+    "dateTime": 1641995227,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8fbdae08e4842a59988e7cb421c774ea0390494b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1rl8ai7fmv6ayprw0lxp5m7v4vwrfxcxmci5f09hbgc5mnlshr2v",
+    "url": "https://github.com/LineageOS/android_packages_services_Mms"
+  },
+  "packages/services/Mtp": {
+    "dateTime": 1624269588,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "071b381d0a99b0c0c03e1b8b2caf87d535db0874",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0581pybyfy4npszpycjkkphir38nvj6b16zfl4ciz8fxg6dcwgqz",
+    "url": "https://android.googlesource.com/platform/packages/services/Mtp"
+  },
+  "packages/services/Telecomm": {
+    "dateTime": 1642105398,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7497edd389ba0769ebc3b646d993908cef6db84c",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0nyay8ic9r4naw65iwzdmi9lc1r8a8hd9s3yidwakqk1bxg1fszv",
+    "url": "https://github.com/LineageOS/android_packages_services_Telecomm"
+  },
+  "packages/services/Telephony": {
+    "dateTime": 1642213681,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c057258f3dc7c2fd21773692b5e54bd00d669ccd",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0fc5mgjylgv845q4p5rz464206p4b2qc98dsrc0v7mnwmbjgsllm",
+    "url": "https://github.com/LineageOS/android_packages_services_Telephony"
+  },
+  "packages/wallpapers/ImageWallpaper": {
+    "dateTime": 1571790197,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a8f56e359d00ce7cc32635afb7db62698a0a4846",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/ImageWallpaper"
+  },
+  "packages/wallpapers/LivePicker": {
+    "dateTime": 1639515217,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ea231f12fbeb7b862365a4082f232371532a1c7c",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0717x9fqqc3p4yq7w007a2nzyjr1x5kfgj3nnls01880wryymnqb",
+    "url": "https://github.com/LineageOS/android_packages_wallpapers_LivePicker"
+  },
+  "pdk": {
+    "dateTime": 1619035269,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f31519014dbb9bdf58ad7d692426872155467a12",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zxgc4qgxsz4vn8qyzmp8m4zqy98fcsgjsn6abhlagp3ihjh27hv",
+    "url": "https://android.googlesource.com/platform/pdk"
+  },
+  "platform_testing": {
+    "dateTime": 1634353701,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4348504da36bee7c3058e9a12874021056370a3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0dz7kxb15dgldyj8326n338qaahzsdy29gcxr9prssjcbarv5sbk",
+    "url": "https://android.googlesource.com/platform/platform_testing"
+  },
+  "prebuilts/abi-dumps/ndk": {
+    "dateTime": 1623682548,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ea7d8fc96958dd62b904eb3e08c334e24e007cbb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1422gwmj2f08z664xdzvjzi0q03v2irhxl7cl25yjxvr26gpgb7p",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
+  },
+  "prebuilts/abi-dumps/platform": {
+    "dateTime": 1624659733,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a27f69c91ad94bf9f5a72c8902d612e038c37fe3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0256schrmrnmjnip9r6na9hhci6cqydgy3syx3qafpg9mavzy5lz",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/platform"
+  },
+  "prebuilts/abi-dumps/vndk": {
+    "dateTime": 1626889471,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2dd88e51e7b5b35758c5fa83d0983cc760d79a3e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1lss4fhd3g2323xl7v0jlfy69pg6x6fagpmvi0i06pjjgypq5nii",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
+  },
+  "prebuilts/android-emulator": {
+    "dateTime": 1629405212,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "122fc06513d35cc48fb32cc1f3914b932bca9380",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18s3ns14ar9zg89ydis0hyif9djjhngm29i4zxpac79b144iywj3",
+    "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
+  },
+  "prebuilts/asuite": {
+    "dateTime": 1628011448,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6fd8b18b154d2a95a233363b014f23ff594fc700",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "012s3a4fb2gsd7rwn8vzf3b7k38zk1kl6i80r2d4cys5a9vmadxy",
+    "url": "https://android.googlesource.com/platform/prebuilts/asuite"
+  },
+  "prebuilts/bazel/darwin-x86_64": {
+    "dateTime": 1615544621,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "ddfd8a933d3b157009233ad2074c2d2b01415634",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wcwyr0n9m0v9mfyjb8f3ljck0w3payq39iv33f2w7n0kihqalgk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/darwin-x86_64"
+  },
+  "prebuilts/bazel/linux-x86_64": {
+    "dateTime": 1615544621,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "fdb89fa5e9727b70fbeea876fecf097a9bc1e928",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mf45cyj47xqfpxp3cvdibwbxjswb2n10gpdydvyb5aynpwg492g",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/linux-x86_64"
+  },
+  "prebuilts/build-tools": {
+    "dateTime": 1636372828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36b93f12a381e5d6d6d7996e9b816ed23f0d2f10",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1hp3ri7lv8vq5wg72zwz1r6bf0c3lqyk86fjbdn64wj9kjbrwg4l",
+    "url": "https://github.com/LineageOS/android_prebuilts_build-tools"
+  },
+  "prebuilts/bundletool": {
+    "dateTime": 1613815600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "457356f1cbf57e03d507db9777fa40b0882964b8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kg4bhhflbbzp2gkdf1q8yicsnfnm44z4yfh8y2wwzvlgxy87wmk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
+  },
+  "prebuilts/checkcolor": {
+    "dateTime": 1586493700,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2213c3afbb7eed19bd88c5abfb33235dcb682cdd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zaw6nl6k2l1d9g7rz45vybgi6yjmbxzfzz7kwrsgaymc27b060r",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
+  },
+  "prebuilts/checkstyle": {
+    "dateTime": 1619204254,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44042b40ba529801c88eabdb7702ae46618681ec",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j0apf2ddqkxi2v3qqsbjbk9w5b6i7frjfyashymzcwvaz474p50",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
+  },
+  "prebuilts/clang-tools": {
+    "dateTime": 1613834091,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f90dfe70889a0d23e1f4231b5d3989c7c6f5b1ee",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18l1ppiv14asv6bv2ivshdwmcgx6r100jjyrxjzl5hpi8zwm6wlm",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
+  },
+  "prebuilts/clang/host/darwin-x86": {
+    "dateTime": 1624581601,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "320de8d454913c95c0f57eca37faa38bea1ea0b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0ks4mbdskbwr2r8mxk3ymx68709ccm96j06hgq2wvmc4bb9ajyx0",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
+  },
+  "prebuilts/clang/host/linux-x86": {
+    "dateTime": 1632330734,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "62efefb25356364413653c88c736102a2a2f8f4a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rjlvygqj9hfkdbmwcwfwb8frq1q4kwg3gp4n16qzxh7cdfxi8xi",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
+  },
+  "prebuilts/cmdline-tools": {
+    "dateTime": 1617890084,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "14e9373fe7ed5c1c5e9192e57295751f00f14d13",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1h7r0mi51dgsgz61d3gmh0364zw8a3fgrg46fv26vwg2vj4dcp5q",
+    "url": "https://android.googlesource.com/platform/prebuilts/cmdline-tools"
+  },
+  "prebuilts/devtools": {
+    "dateTime": 1561663933,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "61f3dccac575257b2c86873c68085726cc38b530",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1yr6acnwdmwygnvd1kljs27pnhwywgm8gv7qp1m6ir23axwydx0s",
+    "url": "https://android.googlesource.com/platform/prebuilts/devtools"
+  },
+  "prebuilts/extract-tools": {
+    "dateTime": 1614104859,
+    "groups": [],
+    "rev": "2ffd09a03179514217dbdb7305418a1c50daf677",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0xw02hq9v42qhjhb68ghjpzihdp2magkx4wddrvw7nvyryvk6lng",
+    "url": "https://github.com/LineageOS/android_prebuilts_extract-tools"
+  },
+  "prebuilts/fuchsia_sdk": {
+    "dateTime": 1604451501,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3d324fb26f98bba1ed4e6836fbea2a0cb14ac5a1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j1rnznlk5z0c985xb1fl8mxk52kwjl0c0vask9hka2bqwxcj7xw",
+    "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
+  },
+  "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1636388012,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "bde6053ede75d819106d6a4eec630578c8752437",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0k46bds7x0jxlyjll64iapaksiks9d2xa2d60k36ka2wv31hjq6y",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_darwin-x86_aarch64_aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1636388110,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "a31eb43552b4500d1db8010d02f2e3b21b5ed2eb",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1y0idprbq32ibnh203kprjwr8xn20a3c60y509bkcnmxc8k5iz6p",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_darwin-x86_arm_arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "dateTime": 1578436765,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "a354a4c97c761ac85a97bcc6aa1365c00475ae19",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
+  },
+  "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1636388097,
+    "groups": [
+      "darwin",
+      "pdk",
+      "x86"
+    ],
+    "rev": "5b0581b807d844f6f7dd43e8813199223dd8043e",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "12dabsqllkn9wycw71xp5ywdziql355nc2zqh7ngad6pqzj2i9dv",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_darwin-x86_x86_x86_64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1639183996,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "5e030eafe024784a73cdf47e6936ac0dbfc763dc",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1hnlrqmsyfxpikgmh3iiilk46cx5mgpkylyhj67v2m4b8h9da5cc",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1636388053,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "111258a10e017f067b27e6cfcea7619d753f3309",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "090fzbp8mx5h7822pkd2rrpdqkflnvax3n584z76sfy59h1wvspd",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
+    "dateTime": 1618517370,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "4dd8082a5bad9bd52a8615ba2673c0cb101c8018",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bccbfl7imas5i47cnj5ms3lvsqkhp4nx37nbips3ia7d6fskjcs",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "dateTime": 1612560992,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "45c2d2c74d21dc0746f6742abb3b22a070e3a063",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1a0ls85jsic0xiyifqaxsp15s046j3a28p8c5mih8ya0hbw80x7l",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
+  },
+  "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1636388084,
+    "groups": [
+      "linux",
+      "pdk",
+      "x86"
+    ],
+    "rev": "5c8aca3781d423cc450c1c05b6ff0813812d65bc",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "116nihfxjnq8c4kjk87mzgjlzvi32y801s19xmb72mc8z3d7r7kz",
+    "url": "https://github.com/LineageOS/android_prebuilts_gcc_linux-x86_x86_x86_64-linux-android-4.9"
+  },
+  "prebuilts/gdb/darwin-x86": {
+    "dateTime": 1575581434,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "b27d876221d012f1fe20590b7ea7eace5849dd3a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gs89dnw1xkpb94lism8s8arhlkyq52h7w1v530a3zdj656h7xrv",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
+  },
+  "prebuilts/gdb/linux-x86": {
+    "dateTime": 1575587382,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "3fde237888fbbd16431d288b891f40065eb710d5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v8y9rdivi8ydrbcvxrkdlzc8snjpdjwgzra2s7qrjpd2qg4k4k2",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
+  },
+  "prebuilts/go/darwin-x86": {
+    "dateTime": 1614014454,
+    "groups": [
+      "darwin",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "a92c322627f3339dcff095ea378358440f88f989",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16hxbnamn9cayw4fv940m22k6k3yz4m9nf3liy89z7bwl008s2yk",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
+  },
+  "prebuilts/go/linux-x86": {
+    "dateTime": 1614014463,
+    "groups": [
+      "linux",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "da07b89b9e625ce67679b829b29966b2ea4f054d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07dv2mwbxazin9kf32fv6s30ac28q4khswfavql8d78zcmacgw03",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
+  },
+  "prebuilts/gradle-plugin": {
+    "dateTime": 1617920158,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1c152ffc3a17b98d4d494cf329eef036dddcd84f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1sap095xg08fz10f6rxhnnd0c5d2xlld1zphp41hbdga5fhsn8gb",
+    "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
+  },
+  "prebuilts/jdk/jdk11": {
+    "dateTime": 1615410185,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8cfff489f1170149365ec6f472733b840239d076",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03wsqba6nzghhrqsvsi33rfjh8hdzx98vjkx2as0l601l21cks8n",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk11"
+  },
+  "prebuilts/jdk/jdk8": {
+    "dateTime": 1551002778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "28d9bf8fd5eff0a09ef6851a29a2aa3040889679",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
+  },
+  "prebuilts/jdk/jdk9": {
+    "dateTime": 1600160960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da4547fea61530f79f639e16349e355bc7b26f91",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0f7b8cydz6j6pvgxln6g0dp62qz0g1768zszdiwswk8zcvzk80l0",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
+  },
+  "prebuilts/ktlint": {
+    "dateTime": 1586494587,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d368445cb3bfcd8d6943e4b5a40f76cf1ec1694e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11rsh1vvx4k2wyn6cmhq7s5inrg0nrvavvdcx3jpkrvdh3lr1laj",
+    "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
+  },
+  "prebuilts/manifest-merger": {
+    "dateTime": 1613841783,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20614295c47346340ad04c63318fdbbac70ea75a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0agc0j0mvr9fbi72x9dbf4dwsf9y8k4sniajzmdnkpyy5jlixd7d",
+    "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
+  },
+  "prebuilts/maven_repo/android": {
+    "dateTime": 1572476701,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0b1ee646897c2d98222b3489e57ae8466780adf1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
+  },
+  "prebuilts/maven_repo/bumptech": {
+    "dateTime": 1613841787,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6323cfeec6d18990845b3fbd54273b13043373ed",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03wzcxnixq9gfzciy09qjxw97d46zdhzihgx3g5lqv6403il1lf1",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
+  },
+  "prebuilts/misc": {
+    "dateTime": 1628890118,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3d4a4b90da0962e094ba9ce2beaef18afe39da87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1l0kg1lc81hfd890k5pba2ipbb1sjm1g62nrb1899xmd2zd6hl9z",
+    "url": "https://android.googlesource.com/platform/prebuilts/misc"
+  },
+  "prebuilts/module_sdk/Connectivity": {
+    "dateTime": 1634173787,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86f52fbc7f1f5e707f836601bb216fd0a66119d1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wlblay3x1ichlbd3vd0vjfihvnkm7dfzhh8vih645f4837rpvmk",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Connectivity"
+  },
+  "prebuilts/module_sdk/IPsec": {
+    "dateTime": 1634173787,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b3a8e75e8657600aa46d9182ed15b50b6f526f0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zkdxzm1m0c023hp95pzfzx5mdg6f05p09wivsi0c2x4z966gp1p",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/IPsec"
+  },
+  "prebuilts/module_sdk/Media": {
+    "dateTime": 1629124011,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "105d58a2efeccbf8129fa8866dd426a408853a73",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0fjxn8157kmafhizglaacknyi2ddalic2agi1plwmilm2s30p16x",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Media"
+  },
+  "prebuilts/module_sdk/MediaProvider": {
+    "dateTime": 1634173788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b5c660225989f42f4031fd25d808229d78a5051",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1a919bdsm1vlb7imdsdbpzf2wxzk0xmfiqzvmcp4lr9g493ipq2f",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/MediaProvider"
+  },
+  "prebuilts/module_sdk/Permission": {
+    "dateTime": 1634173788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fbd096f34af36b1a9e7732c3f9a61b931874f0de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0g41b6w6mxvv34wcxycfmwpzrpqf2lxhhkkfipyjp1p1clbcm198",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Permission"
+  },
+  "prebuilts/module_sdk/Scheduling": {
+    "dateTime": 1634173788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "346bfee46208f1b520ce70aa3bd79a06c7a775c0",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "15m40phmcmybqnwvk12w3lvkd3ljlr5zbp3lqyjy8ssv5h7yr1fi",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Scheduling"
+  },
+  "prebuilts/module_sdk/SdkExtensions": {
+    "dateTime": 1634173788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6a3dc344d17bc21dc3fc84f78cc849c2ca6dc56",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "193r60ly9ka9pgzy69zldx6ndjwh1fmcs6rsjgl3217hx5xw3r0r",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/SdkExtensions"
+  },
+  "prebuilts/module_sdk/StatsD": {
+    "dateTime": 1634173788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac6a34ac5e654fd97fdf158416c6edf6f57d00ae",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11qf23h9125spm855byd6rlmik68x29w61hms9g8k4jln91r995f",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/StatsD"
+  },
+  "prebuilts/module_sdk/Wifi": {
+    "dateTime": 1634173789,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "355f0b33b3759e45929ff49b17af6940fcd348f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1vs3ai0jkvv7nw1as6ywn12wip724zinrsa10hg6kfh5zirf8lwc",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Wifi"
+  },
+  "prebuilts/module_sdk/art": {
+    "dateTime": 1634173786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a0a33c7d882136bdada08d98f901895a73e01571",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0iggz97jf5mawbx78lfyypzgbfm48a9jiblgybhkwp9fnqjamspj",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/art"
+  },
+  "prebuilts/module_sdk/conscrypt": {
+    "dateTime": 1634173786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9081b1411993498aac11f78ac174c28f6abf5e42",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mqhl63iv07dhla56w0i00qx86b01qyih84niiyipa8idm7z8khm",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/conscrypt"
+  },
+  "prebuilts/ndk": {
+    "dateTime": 1617325083,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87f284319f684d60541ab86ea9a75a1bc518725a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18g58y7abpi4kgc8zphv08yg89pcs6wazzm54v89lrbry6shhdp5",
+    "url": "https://android.googlesource.com/platform/prebuilts/ndk"
+  },
+  "prebuilts/python/darwin-x86/2.7.5": {
+    "dateTime": 1446753806,
+    "groups": [
+      "darwin",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "de0ef2c8dcb0389d80436a334bb1fcd0e24e0472",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
+  },
+  "prebuilts/python/linux-x86/2.7.5": {
+    "dateTime": 1551111763,
+    "groups": [
+      "linux",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "67149b36e91b1e2b62797456fc640fc80feafc94",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
+  },
+  "prebuilts/qemu-kernel": {
+    "dateTime": 1613842620,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3433d798f907a2099da26c865cb32a5b60099c2e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "174ffmr45kn5qkzbfc8a9irk8p2ksxzj5rylbbisswhlk7419rpq",
+    "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
+  },
+  "prebuilts/r8": {
+    "dateTime": 1625839157,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e77842f0b7a216ebeffbab78fcd3240f1d9a7ec8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "052xbmqp69pbl3p9q05jpnnzj7mws57rscgblmp2h55hnm6ay8fg",
+    "url": "https://android.googlesource.com/platform/prebuilts/r8"
+  },
+  "prebuilts/remoteexecution-client": {
+    "dateTime": 1633569004,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ccbad1aa8c87ba8b613f4e95ee33eb0ba691158",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0j1xhd15nx0bhrp03bd0sxlmqsi8dyv4scpdqqzql8c54m4av8yx",
+    "url": "https://android.googlesource.com/platform/prebuilts/remoteexecution-client"
+  },
+  "prebuilts/runtime": {
+    "dateTime": 1624546103,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3d95e012199f2b722d45a83109bb2f0680a245a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0yyl276b039qmbz3b7mqnl4h3mqk5ggv0yq07k2hli9v09w55dha",
+    "url": "https://android.googlesource.com/platform/prebuilts/runtime"
+  },
+  "prebuilts/rust": {
+    "dateTime": 1619640274,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c14f883d70057e0411393dc03aa3b10833aed9f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0k1vw6hallcd3fhl6scgq89qqpi198pxwd6vd4r1rlklpm4p2xyj",
+    "url": "https://android.googlesource.com/platform/prebuilts/rust"
+  },
+  "prebuilts/sdk": {
+    "dateTime": 1628868096,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "275722017d043ffd4477a6c478a56260bb31132d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1139ri4kkbd9wnih9w78gswy5qavymwjr8ay04cj924axfs2z8s7",
+    "url": "https://android.googlesource.com/platform/prebuilts/sdk"
+  },
+  "prebuilts/tools": {
+    "dateTime": 1626462024,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "0f8077c0a92b916846e3e16444b7b8625f3534c6",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0gqaix187cmkrnk0ydd2hz5mph334zi164jlikhn19bkgw8g75yl",
+    "url": "https://android.googlesource.com/platform/prebuilts/tools"
+  },
+  "prebuilts/tools-lineage": {
+    "dateTime": 1609113656,
+    "groups": [],
+    "rev": "214ba0cba1a5abab0a17a298a53653c9585a5350",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "13s3kckvyi37nxhay8zwgqvdsga8z5x8f3vblyviqmp10b9ljl5l",
+    "url": "https://github.com/LineageOS/android_prebuilts_tools-lineage"
+  },
+  "prebuilts/vndk/v28": {
+    "dateTime": 1614588566,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ec5a6d097238b3cfcddd0431f49eab07a494535",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "18yxf5lk692292w99xijjyr545r928lyfxclkg1hpdvf5vk04a9g",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
+  },
+  "prebuilts/vndk/v29": {
+    "dateTime": 1614588566,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0801f7c332aa60409cb66baca485f368fe9d035c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wl0lsbf5hr6kignm6fgb9mc0p7icyzz7yd8yl7h6ngqajdzh5lb",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v29"
+  },
+  "prebuilts/vndk/v30": {
+    "dateTime": 1613992393,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa3b4b5ef72e407eebb7e97a173b115570c5858f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0c1ni4axai052b98pp6d6pyl0pshbz9sczcm6y0mlfhgvmlwk7wp",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
+  },
+  "sdk": {
+    "dateTime": 1613437328,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9f89c6e6af4785195f5ef701dd640afe0e574146",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1x4v7n0i9pcz91q5ii4lpwrmqr9v0hpwjv86mcqjzjw22rzi5rxa",
+    "url": "https://android.googlesource.com/platform/sdk"
+  },
+  "system/apex": {
+    "dateTime": 1627579554,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b169ab19adf118acb6594098288081ebb926ba5c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hilaxanwsiqaq95i7qsdrirx2nxlgpisxb8djfvf6vkc062n3yy",
+    "url": "https://android.googlesource.com/platform/system/apex"
+  },
+  "system/bpf": {
+    "dateTime": 1625568612,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0162ba51ad3f611cde583e0d9d5820f69a551bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qp4zl4hzq1xdm7j6qd44bx2fb821j746vyxz9296zi6nwqaj0hf",
+    "url": "https://android.googlesource.com/platform/system/bpf"
+  },
+  "system/bpfprogs": {
+    "dateTime": 1613835230,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ba8d8a39ddc308778bcb9809079616de65dfe29",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "059l6k1y7jpjbkfamq83pjj8nzmghc5pqkz1p53pn556w1hr34jk",
+    "url": "https://android.googlesource.com/platform/system/bpfprogs"
+  },
+  "system/bt": {
+    "dateTime": 1640531104,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d5bf6729984ca77b4fc72a60a558e9af51809e7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0h723is2hbrxpdsyi6hskwqrkrrz9z6f9vnxrqhp2gl9vs77hr5a",
+    "url": "https://android.googlesource.com/platform/system/bt"
+  },
+  "system/ca-certificates": {
+    "dateTime": 1613828482,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "544fecca995685415282f480ef86fb613803866f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1rz4x4mrsv112csx3bykgi78rrf1sc4g8p5yvma2yyrcn7j0vxq2",
+    "url": "https://android.googlesource.com/platform/system/ca-certificates"
+  },
+  "system/chre": {
+    "dateTime": 1630355989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7fb5286e9da8f48002b0d401fce29c964ea93734",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07karyzhkmbfpwx3sf24wzq51c7v47ikq228f7fg9r8jdfgb9qy3",
+    "url": "https://android.googlesource.com/platform/system/chre"
+  },
+  "system/connectivity/wificond": {
+    "dateTime": 1628804096,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e02ac2f254cab370bfe2282cc2352cdacd9dcf76",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0lymnj2i95lcb3xmlawm1gpvrbr82y3kgggj1a71vcn4776bs7j3",
+    "url": "https://android.googlesource.com/platform/system/connectivity/wificond"
+  },
+  "system/core": {
+    "dateTime": 1641336159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2aad99eb19a9314a9cde89b52d6ec17f3d796b19",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1w8rw0gs2cf2ck2wjkg97v3cz5hrdf02fyawjr2n1sdr0bywlsfc",
+    "url": "https://github.com/LineageOS/android_system_core"
+  },
+  "system/extras": {
+    "dateTime": 1628888012,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1768bd3228c8c9980c76a6a697e86decbb69a457",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1nbb1gpdxpm2dhf52p59f284ss9b9vcb1qpax14p4s89s7cr1had",
+    "url": "https://android.googlesource.com/platform/system/extras"
+  },
+  "system/gatekeeper": {
+    "dateTime": 1613504471,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b8569c546ffa872bdba69bcfc49011c6ee70233a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wxbr2nrgv2w9zwy8vf7pi4vnjcs6jrhg7p0psp36iqqpj46ncpc",
+    "url": "https://android.googlesource.com/platform/system/gatekeeper"
+  },
+  "system/gsid": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09ecf955847fd6dff265121558eae3dc23785fbd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13xicpg8wk1y021a3lxlq49vr51v2nicfwn3zavvz0xgs065ygzs",
+    "url": "https://android.googlesource.com/platform/system/gsid"
+  },
+  "system/hardware/interfaces": {
+    "dateTime": 1629224552,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b32719e7dc910e464b1e5e8b6180b07391d588e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1wazlzks5irs3lx3glj150xx284gm8611x58vn1hyv0qbp2hzj85",
+    "url": "https://android.googlesource.com/platform/system/hardware/interfaces"
+  },
+  "system/hwservicemanager": {
+    "dateTime": 1622819569,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5a78106f7128d9a63dd6a75919db7e64ecaae09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03sg3s64q6iik4i0b8l57dz5m1xxk9dfyqirz72y61ycl4hnagmr",
+    "url": "https://android.googlesource.com/platform/system/hwservicemanager"
+  },
+  "system/incremental_delivery": {
+    "dateTime": 1631299265,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "924af62dc94b7c37bd653158b69ddc9f648beda7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qlkk5jyqyqs69h5pl0hi53qfh8f8z9f7vllrrd4vbckl1bp57gn",
+    "url": "https://android.googlesource.com/platform/system/incremental_delivery"
+  },
+  "system/iorap": {
+    "dateTime": 1626160706,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7fd8ba7d56dc6a860a273c722750e97e5076c84c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0q3ip59rm8b3x3ralfn414bc0q51p42hxk2n2mr9pdd7d3vhmbpb",
+    "url": "https://android.googlesource.com/platform/system/iorap"
+  },
+  "system/keymaster": {
+    "dateTime": 1628888009,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6304ff244cfd309446ed4006ca9b58a553adcb87",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0xfnh774f4s4rkyhpjm2y9lrzha5rp4scbym25jqnlzxamzcnv8l",
+    "url": "https://android.googlesource.com/platform/system/keymaster"
+  },
+  "system/libartpalette": {
+    "dateTime": 1623150906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25bbba2a96e48b74011446bea1be929048f3360f",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05l8n7nm3xzcxf8fi5mzbq62hxkgi3wk2sppi416jyfbznvs3h8p",
+    "url": "https://android.googlesource.com/platform/system/libartpalette"
+  },
+  "system/libbase": {
+    "dateTime": 1619677419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b82afe96f4e63bff98c9cfc4417b3996c1b23a51",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0h5aw1r81ikh1y5723m8nzdl3z6f3fq7krrzjfrv80x8zwvgyml2",
+    "url": "https://android.googlesource.com/platform/system/libbase"
+  },
+  "system/libfmq": {
+    "dateTime": 1621568409,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8726cca04217318c9155ba528822af6e2ddd75de",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gnrsz7k2ish726cdcysa2z0ai6npxnx9kpgpq65crakcnswkdgd",
+    "url": "https://android.googlesource.com/platform/system/libfmq"
+  },
+  "system/libhidl": {
+    "dateTime": 1624929280,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3e195932b70fb6a39118acd8d287f92535fdccd",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1y1sw5p7dlal4b74r00jp6p0y5mjpablpli42cdcq5byhayz08r8",
+    "url": "https://android.googlesource.com/platform/system/libhidl"
+  },
+  "system/libhwbinder": {
+    "dateTime": 1621981060,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a20d59706f59855a05843793f5142763da6e2d1d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "09nwism5hs2514pqccyh5nk558z2qrvrh2fhmqmfv3pm9sdd6bwj",
+    "url": "https://android.googlesource.com/platform/system/libhwbinder"
+  },
+  "system/libprocinfo": {
+    "dateTime": 1625122240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f38fcb840d63565e765d09103fda7b34e2590fa",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "015y2lxpg1w3ijvlfridfwnbjvqd6gcsgya6fri8xn651m5bhdlz",
+    "url": "https://android.googlesource.com/platform/system/libprocinfo"
+  },
+  "system/libsysprop": {
+    "dateTime": 1618498073,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26c042b8ef1888a0910a0c3709e69c490c9c9eab",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0m6nk4r3rp267mlc7pi9cq19a2npb836cf5kv8k1xza1iqiaq0bj",
+    "url": "https://android.googlesource.com/platform/system/libsysprop"
+  },
+  "system/libufdt": {
+    "dateTime": 1620239508,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca9b2960c365944ec6f6285800d3446ffee34d41",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0lx95r91jpfcqhp9d91yvn6z5rdym4s4z2l3v2sa84dqpb72frpp",
+    "url": "https://android.googlesource.com/platform/system/libufdt"
+  },
+  "system/libvintf": {
+    "dateTime": 1620777951,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9411ec2286194c946c94512b3deb70799ddbe48a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11rp914fxzapbdksjn6clmj40n9gmybgdqnngcppyqk4gs97bwz3",
+    "url": "https://android.googlesource.com/platform/system/libvintf"
+  },
+  "system/libziparchive": {
+    "dateTime": 1633961374,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c0a249d9b4db82b7a253b08057f78795cc56e99c",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0wb569wvkhdksgyqb9q5ahz4g3xr1lpi2xy0bb12crnnq29xr7r3",
+    "url": "https://github.com/LineageOS/android_system_libziparchive"
+  },
+  "system/linkerconfig": {
+    "dateTime": 1633072833,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "108dc596bf49188b7e61840a5fa243862de52b35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0vai4jakxwblgrh33siaz6zhf77mr2nwk4f880jk64fd5pw1rg13",
+    "url": "https://android.googlesource.com/platform/system/linkerconfig"
+  },
+  "system/logging": {
+    "dateTime": 1639650409,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "501af190cb13950924fa0e5e360c101472cf839f",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "18prwwlh489a3662mr0v0hgpnsj2q7qqmsd2f131crd9m57hi17r",
+    "url": "https://github.com/LineageOS/android_system_logging"
+  },
+  "system/media": {
+    "dateTime": 1639515225,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ae66fbad98d1130b2494cafc3aa1bcbe1f6a4ae9",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0l4b92pdrk8bvsdy1p83yzgjahnc3r3ir649jqcvdsmr9hy9sgj8",
+    "url": "https://github.com/LineageOS/android_system_media"
+  },
+  "system/memory/libdmabufheap": {
+    "dateTime": 1628890468,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a47eaf25d3e94c4151bf02636a057b1643c51d2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "03l8sr6dmi8rnf9psclm0sg0pwqfnp7vknc6vydxgbz1gjxgdr34",
+    "url": "https://android.googlesource.com/platform/system/memory/libdmabufheap"
+  },
+  "system/memory/libion": {
+    "dateTime": 1613829279,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c658a782051844a7743de960e0b6a2c7041c3631",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0jmb5lh6hgyzpsp711dd5igns56xls0crb2aqnzwqfyvn6dinbz3",
+    "url": "https://android.googlesource.com/platform/system/memory/libion"
+  },
+  "system/memory/libmeminfo": {
+    "dateTime": 1626297332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "804ee893ce53ba15af995dea4a68b5a04ec36b15",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hxknnvj22ap00v3nsh6867vi1bcb6dpsm90n223c7z0247kb5az",
+    "url": "https://android.googlesource.com/platform/system/memory/libmeminfo"
+  },
+  "system/memory/libmemtrack": {
+    "dateTime": 1617815252,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e0f980e3dac5fcc5688b3f36eeb0607ef73cbd3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1v1zrkh94ynxgsi30s5i1ivahdabv10clysam1v1c762rczsgr8v",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemtrack"
+  },
+  "system/memory/libmemunreachable": {
+    "dateTime": 1623285996,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b63b871b3059302e5a78766f58d1f4a5121c5a4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1hg82k95l8ph8phl9n982yxy016z68m4hbwjj5sdsnmi217v2cpy",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemunreachable"
+  },
+  "system/memory/lmkd": {
+    "dateTime": 1633144176,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03021f0e79176be311e64106eebf8c908343d1bb",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zs9110x7g59rjxrqjri4xm1s751p3yj0xq9dsbbhyg492l40wd9",
+    "url": "https://android.googlesource.com/platform/system/memory/lmkd"
+  },
+  "system/netd": {
+    "dateTime": 1634353751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b8ebcb1be89157ac56576e0369aea8dfa41c2cb2",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "16ra9lzaac6rp1f2a57i6knjnrbhl226wjaf42bkdnw0zcj9gp64",
+    "url": "https://android.googlesource.com/platform/system/netd"
+  },
+  "system/nfc": {
+    "dateTime": 1631046413,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68de2b7edacc8bb81b8123f7be7caaae73d10f91",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0dyhv0n0a58y0mw1rxkr806dayvq444h2bm1mva79phzmb92mjsg",
+    "url": "https://android.googlesource.com/platform/system/nfc"
+  },
+  "system/nvram": {
+    "dateTime": 1612561570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5cbfb622f4b2cb4e55a57e314f302862705bd09",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "05xspxnd1366hmv4sjq2fmhbgjq4camppfnqpmakkydd4pw4qnn0",
+    "url": "https://android.googlesource.com/platform/system/nvram"
+  },
+  "system/security": {
+    "dateTime": 1633569031,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21b26f2c4682b89c140c20c3d0670eeb45584c90",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mzimp7m7r2h5aa7dr90ba2lqg871cywqbwfx0z1ipam7pv7synq",
+    "url": "https://android.googlesource.com/platform/system/security"
+  },
+  "system/sepolicy": {
+    "dateTime": 1639515233,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "569c084ce9b99d0a0ee1dcd70882a8ed1cd86941",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "05saismwg89vkx39y7y0h9m24gh26knd5jxrga008jy2qy2vl1zc",
+    "url": "https://github.com/LineageOS/android_system_sepolicy"
+  },
+  "system/server_configurable_flags": {
+    "dateTime": 1613834532,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cab156c6102680ff471817ff48fde13431e5d2b1",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1ih665qh777kw9vyz8sgsbk3nm2bnhklir7v4df25j8wdr8kw4hv",
+    "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
+  },
+  "system/teeui": {
+    "dateTime": 1617044889,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "674fa5c63b51d6b5ed21f46f7159bb7657200dac",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bicz4kmz79mifxfmzc2rzrgvp95zmcxm7giw8lqsigv32m55avl",
+    "url": "https://android.googlesource.com/platform/system/teeui"
+  },
+  "system/testing/gtest_extras": {
+    "dateTime": 1613822497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9758e62d2ac64617fbf4cd4fa42dc7e9a4d5adde",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v5ifyrq7wxsm0mh9843fidj4jmr2x10xqdvdwsshb1p17hxjyyp",
+    "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
+  },
+  "system/timezone": {
+    "dateTime": 1633569033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e01f7f455f680f0533f85f55806b781b73c5746b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08sn293cpbizif7ac3g77dj3dj8wpbcqxasca2xzhj0jxw3khd1c",
+    "url": "https://android.googlesource.com/platform/system/timezone"
+  },
+  "system/tools/aidl": {
+    "dateTime": 1633072842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "89a5eb569ddc3aa755aee4d520f71b489f93dda4",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13ybc6k6blaw6linb0iwfybv1np2k95l35s6hfmrlbppyhlkkrfc",
+    "url": "https://android.googlesource.com/platform/system/tools/aidl"
+  },
+  "system/tools/hidl": {
+    "dateTime": 1627587690,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30fcc6376f5d5c4f638d211ed84bf4dbe69ad1c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "14klv5dx95fcihfck1r41bz9nxgcblf838sj62mad685pjmah7fb",
+    "url": "https://android.googlesource.com/platform/system/tools/hidl"
+  },
+  "system/tools/mkbootimg": {
+    "dateTime": 1638708049,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f7d329ffd8c325667ed310fc3f23ee7cf4668b9",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "08rw5mrq9dj6107s15ksswlgnwqa3hpfb7g3n7bwrximmlhm0wfr",
+    "url": "https://github.com/LineageOS/android_system_tools_mkbootimg"
+  },
+  "system/tools/sysprop": {
+    "dateTime": 1616580845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2bec02c1451bd950525c520d468f11a6f6d5245c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0hvq6n3kj0lyyx782wwy32q1m24qclkmas5jdb2wy5hxcrsqvwds",
+    "url": "https://android.googlesource.com/platform/system/tools/sysprop"
+  },
+  "system/tools/xsdc": {
+    "dateTime": 1623633975,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31b461e94d2339676173c6cebec9598079d8f992",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01kh80wg5r9b1csz23p7x0rqlpb26x5z4r4gi2y4ibisy5bva3w4",
+    "url": "https://android.googlesource.com/platform/system/tools/xsdc"
+  },
+  "system/unwinding": {
+    "dateTime": 1633144184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43b9ce9ca8f4a3f556efcb05405d43b9fab1c523",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0iw26p7rx6r9j11r0bvds8idpl7kw6gja4d81wyyfq2j8a2q74ys",
+    "url": "https://android.googlesource.com/platform/system/unwinding"
+  },
+  "system/update_engine": {
+    "dateTime": 1639515236,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80f33c6212ef6cd1a75accf3c90539d8dcc94ded",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0bw3sqq9r6i7ngpjlgvfnnhaj2n3a2as1x6r95103ad89b2d4vni",
+    "url": "https://github.com/LineageOS/android_system_update_engine"
+  },
+  "system/vold": {
+    "dateTime": 1630357499,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8598a9dc13fa7ce2f1778092951172f8c8ebd987",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0p78mczcs4sdrknpckvway3jhmjmcbsls10km62ix6vjv50h7c8x",
+    "url": "https://android.googlesource.com/platform/system/vold"
+  },
+  "test/app_compat/csuite": {
+    "dateTime": 1620253428,
+    "groups": [],
+    "rev": "f71ad3e931337de7a7b3ed5332a45dbefdf74962",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "11h6hldlwrcfk314wn77a218384yh4kz4xz3nzvy3yqm99ywhz8n",
+    "url": "https://android.googlesource.com/platform/test/app_compat/csuite"
+  },
+  "test/catbox": {
+    "dateTime": 1628926016,
+    "groups": [],
+    "rev": "e8d3429999d36fe080b5b105f7a59cbe92a8b37b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02lahsm3xbcr6rgjkwknwwi6sm5w79h0wpg4mm89y6vh2yrf60b6",
+    "url": "https://android.googlesource.com/platform/test/catbox"
+  },
+  "test/cts-root": {
+    "dateTime": 1624625659,
+    "groups": [],
+    "rev": "9c80ba0d0256b36c6a0b9d6ac3d91a9e358e68ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1garbzndz4qsxmv6cys2zf3gwlsay5yw5svfbz770hhim4i037b6",
+    "url": "https://android.googlesource.com/platform/test/cts-root"
+  },
+  "test/framework": {
+    "dateTime": 1613828438,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "3166ba1d3ce8b5c2bce35fcb98cdc3f4e52b4f7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1p4gak809gfak9r64pzrq708p53i7y7045x10q7ji16jycw123lv",
+    "url": "https://android.googlesource.com/platform/test/framework"
+  },
+  "test/mlts/benchmark": {
+    "dateTime": 1619453154,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "71313d62e0549c03545186dcb70f097753e8b896",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0n5yjswf4lnshqg8y0lb2wi65gqqqa0xjfgffkif6m8ma6642mh5",
+    "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
+  },
+  "test/mlts/models": {
+    "dateTime": 1594388199,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f7e2a0398d0214d4c0ac91a8ef60ede44799627",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "136fcq4lmc69yp1gzlynvrv7126z91aw2l1y1gns0d69xk9hfbjf",
+    "url": "https://android.googlesource.com/platform/test/mlts/models"
+  },
+  "test/mts": {
+    "dateTime": 1629762372,
+    "groups": [],
+    "rev": "b61182250b9e5b58121de6df31781a61ef78f2f8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1kl9kzfd319cyxj83qqgcdjvdh3fp7j5nmvnmv06zrw9krhdm5gg",
+    "url": "https://android.googlesource.com/platform/test/mts"
+  },
+  "test/vti/dashboard": {
+    "dateTime": 1551088143,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "55e96b37e798a8a3a26ee207a065706464201c2d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
+    "url": "https://android.googlesource.com/platform/test/vti/dashboard"
+  },
+  "test/vti/fuzz_test_serving": {
+    "dateTime": 1551002920,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "2de1bf485e3cbb298ad3d9828257dd77a73b4633",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
+    "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
+  },
+  "test/vti/test_serving": {
+    "dateTime": 1588777700,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "b5a35ff86a8956e60c39fb198f3d71ab42bc0dd9",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12y5bwvhbj1yscbi87irp0xgwmb018fck905zf678aii8qckhp9l",
+    "url": "https://android.googlesource.com/platform/test/vti/test_serving"
+  },
+  "test/vts": {
+    "dateTime": 1633655390,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "e58e5c30e8acc951b58f009ba76039accb689fb8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12lf6wx0r5q57jhkgsb34854h74dggls5jyb48wk2s4glbf5y9i8",
+    "url": "https://android.googlesource.com/platform/test/vts"
+  },
+  "test/vts-testcase/fuzz": {
+    "dateTime": 1613835246,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "3a4927081d472acb2b696b96eba0c4a9f9ff2322",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "106hmz81aaqpy3gq6apgz4a1j6nmvhzp8rbzpldqcl7ymn552h76",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
+  },
+  "test/vts-testcase/hal": {
+    "dateTime": 1631750128,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "2da137e7c80b15df7fe2c5c64daf43d4cbd53880",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "008b7xd5xpkqzzlk5rrpd3mx9vss363dzmmrmk3n5ra51vr8r7jl",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
+  },
+  "test/vts-testcase/hal-trace": {
+    "dateTime": 1551088166,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "334e9eb97ee6b15f6b2a49639c5525ac44c2122b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
+  },
+  "test/vts-testcase/kernel": {
+    "dateTime": 1633144192,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "fd0a1dad7f4518469c155cf9cfe5c4191e5e9a35",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "12m7drfr2z4rhamp1283rk96k9gskf9gqdhgbkyrnd6d3jasiqky",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
+  },
+  "test/vts-testcase/nbu": {
+    "dateTime": 1613834209,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "a1fd4c707d1eff6ef9c4f680f20ab2e6ad5013b7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1h3vd99wax8n5ygs6cg15f0p8kj07kas75n72j7b20n4qdy2bflz",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
+  },
+  "test/vts-testcase/performance": {
+    "dateTime": 1613828086,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0e1c597e4393809fbac50c80f662a8aeac18503d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dh5n3pprrdb607f3jriz2madgq3ri8fv4c4mcmqld5fbc56w05b",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
+  },
+  "test/vts-testcase/security": {
+    "dateTime": 1629477858,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "4d32e98674612bdb92942a6f222db0619f6ac1c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "08rnpidhp5h8yljvv6syb8sykqwqyyk996gc4sgml1kbx4h393q3",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
+  },
+  "test/vts-testcase/vndk": {
+    "dateTime": 1629748861,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d13b18af129aa01cb96bdb58ea545adeedc9e308",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1l8r1qczbzaqvlq8cd4x1wvi2y2lh14m4fqcqypxlmvi3nl62pqx",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
+  },
+  "toolchain/benchmark": {
+    "dateTime": 1613828208,
+    "groups": [],
+    "rev": "70c3a71142ecb106733cf791b1d3eb912156fa7b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "04c2hzbgqxcim23z4brvq0px4cifmz52434lxacq741kqy8a3yn8",
+    "url": "https://android.googlesource.com/toolchain/benchmark"
+  },
+  "toolchain/pgo-profiles": {
+    "dateTime": 1626386921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "623c608840f9ad092bf9c0fe490fd59413acd58e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "023wq00bzc3lafcy4l4dwyhx0dxlpxikqr7wixj8jvz39n0hlq9g",
+    "url": "https://android.googlesource.com/toolchain/pgo-profiles"
+  },
+  "tools/aadevtools": {
+    "dateTime": 1619980430,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0bcd62e44d72c66c381923162a8e454302d1337a",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1zb9yfwjj9f0hk75vi7qg9j3fllpk3n5mfhgky8z385bh2jmzk5v",
+    "url": "https://android.googlesource.com/platform/tools/aadevtools"
+  },
+  "tools/acloud": {
+    "dateTime": 1620888217,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "tools",
+      "tradefed",
+      "vts"
+    ],
+    "rev": "7efb620418c61c78eb4c49cd0fd65b9dec4bc733",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "02svjyi2vj85r6yi6k5i0xffkxkkxh6iyf7bpf99aiwq80aw3hfq",
+    "url": "https://android.googlesource.com/platform/tools/acloud"
+  },
+  "tools/apifinder": {
+    "dateTime": 1623117550,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "61a25ab6da46b348f520ac35de3b5263a3079996",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0bfac5abla83d56kz7hvwdb12h60h90lj9ahy7cgg75qfgjnj9ic",
+    "url": "https://android.googlesource.com/platform/tools/apifinder"
+  },
+  "tools/apksig": {
+    "dateTime": 1621911219,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "64ac786e76e582c47951569030429d3c64e29c70",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1dl6k7qnk9kl26sdr3a6hy2mg9939a20bk7qp11jb3c5vnmarcsy",
+    "url": "https://android.googlesource.com/platform/tools/apksig"
+  },
+  "tools/apkzlib": {
+    "dateTime": 1619441314,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "9115ad3611f5d841c807176c8cce3264bae2c99b",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qbj6g2jivxjlxgm1z27anqgb0hh50fm3mqfpb4bd55mqn73csi8",
+    "url": "https://android.googlesource.com/platform/tools/apkzlib"
+  },
+  "tools/asuite": {
+    "dateTime": 1627991749,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f0bf810da42361f63bdfc99cd8ed337cbf6c1df",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0lhpqxdbakqawxvkm8ad53m11yvcha5s75jzcqyni806wcspnc2w",
+    "url": "https://android.googlesource.com/platform/tools/asuite"
+  },
+  "tools/carrier_settings": {
+    "dateTime": 1619816368,
+    "groups": [
+      "tools"
+    ],
+    "rev": "faef458f6b7e434ea520bb7da3bf4607104253f3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1gcpddy94nmhqbmpr3y1s6b29w6zx3r5ixn53hd0s4y0rfw9ahj6",
+    "url": "https://android.googlesource.com/platform/tools/carrier_settings"
+  },
+  "tools/currysrc": {
+    "dateTime": 1611318709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88456cb9f75e1e49a5d0d19c0a463bd3f4f3214d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0h3smd8j3lrd8lnmzcpirn70k9q8l645sbgzfw6cxdrzbi7p2d1a",
+    "url": "https://android.googlesource.com/platform/tools/currysrc"
+  },
+  "tools/dexter": {
+    "dateTime": 1614949728,
+    "groups": [
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "e06b2804ae9db940ffe6577213e11eca764b89c3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1mmldb1h69bcxil78y708hfzr1v5s7y547j0v9cb2vgg48m109dg",
+    "url": "https://android.googlesource.com/platform/tools/dexter"
+  },
+  "tools/doc_generation": {
+    "dateTime": 1631737440,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "9c2e194c56864bd1970a9085718e320205528119",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0wrhriszbxc58k6sqmv1lsipac7bi67q15yjg2clb6k5irp8rzkh",
+    "url": "https://android.googlesource.com/platform/tools/doc_generation"
+  },
+  "tools/external/fat32lib": {
+    "dateTime": 1613437327,
+    "groups": [
+      "tools"
+    ],
+    "rev": "029944db36db3b1788a66c7cb6ccf19a13084db7",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0zx9wqm0l5w1ghcyj49bsfm39y8b97bckfmy9l5r62f6yx4hcgsh",
+    "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
+  },
+  "tools/external_updater": {
+    "dateTime": 1620858061,
+    "groups": [
+      "tools"
+    ],
+    "rev": "cb60767c57d26046d84c3ff0b6ff19e6dd6e658e",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0aa7dhk94wdc6qa45q2bhc8qc17x7f4n53gn8bqb06pdvwdiilmz",
+    "url": "https://android.googlesource.com/platform/tools/external_updater"
+  },
+  "tools/extract-utils": {
+    "dateTime": 1642362631,
+    "groups": [],
+    "rev": "9c6948b05800cb91bea6e3ba6f3866d5a3b8cd87",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1hg87j6vfkw8jr241fwngndiss7hk0q569f31wbyjh6i9m04j6js",
+    "url": "https://github.com/LineageOS/android_tools_extract-utils"
+  },
+  "tools/metalava": {
+    "dateTime": 1623243260,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "8be9b7926aaf036d2b1227e1f3573b2c6c275a43",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "01clliylngzky0lljv77vw9bf52ca4jqv8g62867wcw46vh7n5lj",
+    "url": "https://android.googlesource.com/platform/tools/metalava"
+  },
+  "tools/ndkports": {
+    "dateTime": 1599773449,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b58b2e1514f2fcb3655d16c99648f5e50d572ef",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "13f0scvw1gkwjx24l6hqgk9v7q919zilas7v0b6h8pg2akiyd45h",
+    "url": "https://android.googlesource.com/platform/tools/ndkports"
+  },
+  "tools/platform-compat": {
+    "dateTime": 1633396175,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4c4deac4067e71b554fde3a78a42d965cc812ce3",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "193lr1nxwghrz0ch9a2r744w108npnvr7rpzziy1h3wxgg8474qk",
+    "url": "https://android.googlesource.com/tools/platform-compat"
+  },
+  "tools/repohooks": {
+    "dateTime": 1633560917,
+    "groups": [
+      "adt-infra",
+      "cts",
+      "developers",
+      "motodev",
+      "pdk",
+      "tools",
+      "tradefed"
+    ],
+    "rev": "0f54b3300ea7902266ae501b604e0d916a6d8f0c",
+    "revisionExpr": "master",
+    "sha256": "1yx3bwnpw5crc22v4sssy6vr55z2j1m9x4wa1gphix0lqy6n163j",
+    "url": "https://android.googlesource.com/platform/tools/repohooks"
+  },
+  "tools/security": {
+    "dateTime": 1620063693,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "02eea8c0f4724a1b315ffc6b0785340ce0d343a8",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1pd6isfz0nab12mqmczmyvvp1dhsz1q18m7wzbh0mz3s4584dip4",
+    "url": "https://android.googlesource.com/platform/tools/security"
+  },
+  "tools/test/connectivity": {
+    "dateTime": 1633655409,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7bab7bc56b84f589d621b9f992362ee3424a028d",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "17bdqp7l3h60c8kh3r78m6g0p6la1zqsjq7fzwn7jxhl06sryzkf",
+    "url": "https://android.googlesource.com/platform/tools/test/connectivity"
+  },
+  "tools/test/graphicsbenchmark": {
+    "dateTime": 1619035270,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "faabdd57fc66b6920b581a90678bc1d4d5bca4a5",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "0v5b8p7lwcwrmd1sxc6axf7qkdqyq9p5dqcyazngr0amhdf2xg0j",
+    "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
+  },
+  "tools/test/openhst": {
+    "dateTime": 1613834515,
+    "groups": [
+      "tools"
+    ],
+    "rev": "14c955abfde3ce4110da3cb9856f21d8785dc622",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1qlnvcpsy11nd9cjjh6yy1bhcsikx3xg5rzkqbfhli0q0a5jwrpp",
+    "url": "https://android.googlesource.com/platform/tools/test/openhst"
+  },
+  "tools/tradefederation/prebuilts": {
+    "dateTime": 1634353785,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "91d3ac2869c3f12c070569111733718937af4c71",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1bcwf7sblx43fl2pxijr66f7h2y5mly5hvrvkd94zxa2svn694i2",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation/prebuilts"
+  },
+  "tools/treble": {
+    "dateTime": 1619655332,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "d77bc2ad9eec7c8eae1f827ea5de4d7c1d7e410c",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1cm4prh06srq421ibkac8s9kdjxvq6s0gy336sa92wc886hg8k2d",
+    "url": "https://android.googlesource.com/platform/tools/treble"
+  },
+  "tools/trebuchet": {
+    "dateTime": 1620860981,
+    "groups": [
+      "cts",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "91e9260be9641b0691feb763bca2294d543477ce",
+    "revisionExpr": "refs/tags/android-12.0.0_r27",
+    "sha256": "1i3iz9fyd0jbvmjawxy3w0qvf6ycnv6jvmxk6c7xm272ad43gxag",
+    "url": "https://android.googlesource.com/platform/tools/trebuchet"
+  },
+  "vendor/codeaurora/telephony": {
+    "dateTime": 1639493173,
+    "groups": [],
+    "rev": "46dd0ea62a01ba2e6275390b4707c846987e87fb",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0439l5hnw5if5g450mdzb6jifxdv3sbrbqm0ciz1pwsxahlv9cb9",
+    "url": "https://github.com/LineageOS/android_vendor_codeaurora_telephony"
+  },
+  "vendor/lineage": {
+    "dateTime": 1642081231,
+    "groups": [],
+    "rev": "d91d695664f4f6e4dec491c322b963b17bab5245",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1cb4ygwh45ag2fsidzz386v2ymarldi7dppadn862sibsm2a9d7v",
+    "url": "https://github.com/LineageOS/android_vendor_lineage"
+  },
+  "vendor/qcom/opensource/commonsys-intf/display": {
+    "dateTime": 1637099459,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "3563ec7c723668c24ac04aacf45f8017ee4f0799",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0yz9a5gh1idg1i1qmhrv95w09ycx74vyaxs3ym01j69srwr27ykp",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_display-commonsys-intf"
+  },
+  "vendor/qcom/opensource/commonsys/display": {
+    "dateTime": 1636993411,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "1d8cacd405355e5805b2991c003b756e46590f78",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1amca4h8liv67m3rhwkj4dfhby8w8qz7wc23ms2jh24xcwj64iyq",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_display-commonsys"
+  },
+  "vendor/qcom/opensource/data-ipa-cfg-mgr": {
+    "dateTime": 1642258232,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "39c0a8133ca910d47289d944d363b5d67f93fa02",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1azwxghpswi7b7qwjqb8jwi1b75247aj8f47n0c1mfqb6hm4q595",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_data-ipa-cfg-mgr"
+  },
+  "vendor/qcom/opensource/dataservices": {
+    "dateTime": 1639355700,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "0337efb516d65f511c6bb5ff9a61ac5a7ab2fd1a",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "03xvygvj06fzdhw2xw5z0a63nkra5j0wxn07fvysfpqxsf5jna24",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_dataservices"
+  },
+  "vendor/qcom/opensource/display": {
+    "dateTime": 1639175227,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "69f7b0550973a0f6bfb3ff9a244b75dfe008c781",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "14nf4rgnsg7dzb6z3w2b047685wf1gf7d3imfdvnv2hxf7faiqhc",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_display"
+  },
+  "vendor/qcom/opensource/interfaces": {
+    "dateTime": 1636071220,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "488918a6b6939835e48efcb2ad5a2e9f280b002b",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "0ngpknlmf6qlvc3j3l5g85pyd9yqh5sbm5nyf320ndn9vgcbmdpz",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_interfaces"
+  },
+  "vendor/qcom/opensource/thermal-engine": {
+    "dateTime": 1602160411,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "14ffb4dace7ba35fe48124ca56585e1de96c1458",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "198gvmsd2n9iki424kxv5hp5q3v07yv07v5qd3wrrxv4d24xrqn6",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_thermal-engine"
+  },
+  "vendor/qcom/opensource/vibrator": {
+    "dateTime": 1639183153,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "47c5f2c90f64cf901155c6c5b4a6febfd788adc1",
+    "revisionExpr": "refs/heads/lineage-19.0",
+    "sha256": "1zj4414z2bkyjikjl6xsvixy7m9l4c5v7xy6hz6f5x2qm8j7fm3d",
+    "url": "https://github.com/LineageOS/android_vendor_qcom_opensource_vibrator"
+  }
+}

--- a/flavors/lineageos/lineage-19.0/vendor-dirs.json
+++ b/flavors/lineageos/lineage-19.0/vendor-dirs.json
@@ -1,0 +1,35 @@
+{
+  "vendor/google": {
+    "date": "2022-01-13T21:43:57+02:00",
+    "deepClone": false,
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/aiya7l0i89dbccgfzd1ywdmsgi6a95x7-proprietary_vendor_google",
+    "rev": "957c1645c548d3abe38809f33d690b73db3d0f8d",
+    "sha256": "19rjlj8877b9958l047qh1jihi69y2jznk7kfprwrp9w17wlf7n9",
+    "url": "https://github.com/TheMuppets/proprietary_vendor_google"
+  },
+  "vendor/nubia": {
+    "date": "2021-11-22T12:21:50-07:00",
+    "deepClone": false,
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/31mgp42lznsjkp74r0bz4hgdbwxxdqaj-proprietary_vendor_nubia",
+    "rev": "41959bc2992689b9019a875ed3df51f76511fd4a",
+    "sha256": "1685ggc85gg3r0w9sazkkd1szw044z161bws3nhqnn590gbvvvf0",
+    "url": "https://github.com/TheMuppets/proprietary_vendor_nubia"
+  },
+  "vendor/samsung": {
+    "date": "2022-01-13T12:39:17+00:00",
+    "deepClone": false,
+    "fetchLFS": false,
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/pdy0qmsf5ysj2lqbg0q43n29y893zbk5-proprietary_vendor_samsung",
+    "rev": "1fdc66fe1fd8e3a2434da6cce74f2142701c6704",
+    "sha256": "0aa50njkj7r5g70h54vxs9x4r6br7axwx3wl7wnk3mfq750lshk6",
+    "url": "https://github.com/TheMuppets/proprietary_vendor_samsung"
+  }
+}


### PR DESCRIPTION
Initial support for building LineageOS 19.0.
Has been tested to boot correctly according to @danielfullmer.