### PR TITLE
vanilla: Update to 12.1 (March 2022)

### DIFF
--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -15,11 +15,11 @@ in
   buildDateTime = mkDefault 1645396670;
 
   source.manifest.rev = mkDefault (
-    if (config.deviceFamily == "raviole") then "android-12.0.0_r32"
+    if (config.deviceFamily == "raviole") then "android-12.1.0_r2"
     else "android-12.0.0_r28"
   );
   apv.buildID = mkDefault (
-    if (config.deviceFamily == "raviole") then "SQ1D.220205.004"
+    if (config.deviceFamily == "raviole") then "SP2A.220305.013.A3"
     else "SQ1A.220205.002"
   );
 

--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -16,11 +16,11 @@ in
 
   source.manifest.rev = mkDefault (
     if (config.deviceFamily == "raviole") then "android-12.1.0_r2"
-    else "android-12.0.0_r28"
+    else "android-12.1.0_r1"
   );
   apv.buildID = mkDefault (
     if (config.deviceFamily == "raviole") then "SP2A.220305.013.A3"
-    else "SQ1A.220205.002"
+    else "SP2A.220305.012"
   );
 
 #  # Disable for now until we have it tested working

--- a/flavors/vanilla/12/repo-android-12.1.0_r1.json
+++ b/flavors/vanilla/12/repo-android-12.1.0_r1.json
@@ -1,0 +1,10897 @@
+{
+  "art": {
+    "dateTime": 1635375679,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccc0f78b5e7a0cd901fa713694faa5138589969b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q5l3x7qdyz6a11pgqbfsjf7frfnhxrz5nms5rcijfg9swahrh2b",
+    "url": "https://android.googlesource.com/platform/art"
+  },
+  "bionic": {
+    "dateTime": 1637280060,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb0787fa735ecd46f9985b03b3fcaa237737038a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rw2r4b9073hs773zn096fcjjyc87nr6hm6kyz22zvgqxr0viszz",
+    "url": "https://android.googlesource.com/platform/bionic"
+  },
+  "bootable/libbootloader": {
+    "dateTime": 1616547664,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "3840a71317a453cc9b054695be45498e6acc53f6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1g10xsdj43z21cw7yl1mg70jdmgf27xqm713al4bvpqy7g3l177j",
+    "url": "https://android.googlesource.com/platform/bootable/libbootloader"
+  },
+  "bootable/recovery": {
+    "dateTime": 1639612859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa0b04e78152df89d8fc401ed6d49081d2d5fd1c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fiwgp9zxnag49zjifili6nrcvbz3x10q64hwbyzgk76mdn6v54f",
+    "url": "https://android.googlesource.com/platform/bootable/recovery"
+  },
+  "build/bazel": {
+    "dateTime": 1621047725,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "WORKSPACE",
+        "src": "bazel.WORKSPACE"
+      },
+      {
+        "dest": "tools/bazel",
+        "src": "bazel.sh"
+      },
+      {
+        "dest": "BUILD",
+        "src": "bazel.BUILD"
+      }
+    ],
+    "rev": "566de85b3288b763459b9c5297d1cf6f72395461",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jsyl5fjbqna5vw2w3qqn6p9gr9rln6mkzisd0dqz1i8wh7nw1rf",
+    "url": "https://android.googlesource.com/platform/build/bazel"
+  },
+  "build/blueprint": {
+    "dateTime": 1621904550,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "bb5cb8997fb09dbd01a06d12684965df9012b884",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yi42fwvv679pfpr4vxy7vfrqr4la043a7s57rpbw2k5v7h6vm2y",
+    "url": "https://android.googlesource.com/platform/build/blueprint"
+  },
+  "build/make": {
+    "copyfiles": [
+      {
+        "dest": "Makefile",
+        "src": "core/root.mk"
+      }
+    ],
+    "dateTime": 1644645761,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "build/CleanSpec.mk",
+        "src": "CleanSpec.mk"
+      },
+      {
+        "dest": "build/buildspec.mk.default",
+        "src": "buildspec.mk.default"
+      },
+      {
+        "dest": "build/core",
+        "src": "core"
+      },
+      {
+        "dest": "build/envsetup.sh",
+        "src": "envsetup.sh"
+      },
+      {
+        "dest": "build/target",
+        "src": "target"
+      },
+      {
+        "dest": "build/tools",
+        "src": "tools"
+      }
+    ],
+    "rev": "20cc2a32a56496db7b3da31c6c7b25374085a91e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0smy8kd9bqpwrqfns21hm04xcr0dynvzzknx7rn8mm0l0xnvdb1k",
+    "url": "https://android.googlesource.com/platform/build"
+  },
+  "build/pesto": {
+    "dateTime": 1621047726,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c010b1de651ba510fb0d5c9ceb86be74b15f4a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cgw3nmazi87f7qam00szqzy37laz7lv5w9l5zagniv5z0kjl10j",
+    "url": "https://android.googlesource.com/platform/build/pesto"
+  },
+  "build/soong": {
+    "dateTime": 1642032097,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "linkfiles": [
+      {
+        "dest": "Android.bp",
+        "src": "root.bp"
+      },
+      {
+        "dest": "bootstrap.bash",
+        "src": "bootstrap.bash"
+      }
+    ],
+    "rev": "33bf5fe7eace38d6e6316992e698ce80f6d4a6e6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pvywv5bhp2mmrfrai1w5nnj75dbyr81s3aa772r9z76x2ydgcqy",
+    "url": "https://android.googlesource.com/platform/build/soong"
+  },
+  "compatibility/cdd": {
+    "dateTime": 1621047729,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1df8d40b33c92907040d4a8acf6a59bf968af81f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04l9jdf0i7pf4lq3dxrik4gg3k00v2r3dr9mp6bznf6mm37cvzh9",
+    "url": "https://android.googlesource.com/platform/compatibility/cdd"
+  },
+  "cts": {
+    "dateTime": 1644645748,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6dd44fcad0735c69555bcd8e71397d2c74dd7123",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06b1aii0zab93ynrs53vvw4amqa2jlv4g3mckq1imqr3rpj3zpwl",
+    "url": "https://android.googlesource.com/platform/cts"
+  },
+  "dalvik": {
+    "dateTime": 1617930097,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1ac2940f249ed48f9c6c8b821646dfbf2b51d2d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18iw5p98mm7wnfjd0yhnb1fcrnjwrigp1apbz2lyizlm95hkgz2v",
+    "url": "https://android.googlesource.com/platform/dalvik"
+  },
+  "developers/build": {
+    "dateTime": 1613865703,
+    "groups": [
+      "developers",
+      "pdk"
+    ],
+    "rev": "a680cfebe5130817e0996eee3337efb2376716ad",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pvgglif7iy8n6sx8xkxw7xf6gcv60lgfh4kbd4k1ry75rb1hfy3",
+    "url": "https://android.googlesource.com/platform/developers/build"
+  },
+  "developers/demos": {
+    "dateTime": 1496909782,
+    "groups": [
+      "developers"
+    ],
+    "rev": "7828835c9c4d14f1d2c08a88543ddeb2cba7038a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ciqaaj6jkykb6lkksqfka0077fhz1md6qiw5m337llyyiz29ywc",
+    "url": "https://android.googlesource.com/platform/developers/demos"
+  },
+  "developers/samples/android": {
+    "dateTime": 1621047731,
+    "groups": [
+      "developers"
+    ],
+    "rev": "22b9dbbd818ecf6eb4373a9d00e523df672b6e8a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1npnk3yyvchp4lh38aa7b31kly968h4j9af3x0ad894qigdmbk2g",
+    "url": "https://android.googlesource.com/platform/developers/samples/android"
+  },
+  "development": {
+    "dateTime": 1641945656,
+    "groups": [
+      "developers",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "180c0b76786069ad7676b109177def40dd0cac12",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z6wkslcpw23g4dlm8glwwdpg6all0pr4wzdyr688gwsn8cy1592",
+    "url": "https://android.googlesource.com/platform/development"
+  },
+  "device/amlogic/yukawa": {
+    "dateTime": 1636322442,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "da8be997b89f2e6da330168391af8868ee3a219e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qk861pyigxp903dckyzls5lw8cz5vp4pzx0l0y1g5bvag84i65l",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa"
+  },
+  "device/amlogic/yukawa-kernel": {
+    "dateTime": 1617152484,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "54783b3ee77107c3dac92054292cee7acde12bbb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hfm6i7s4jrhfkxggkdvi58bwkl0gs0zyhn0p2p4gkg4vn1xhzyi",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa-kernel"
+  },
+  "device/common": {
+    "dateTime": 1630450866,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs"
+    ],
+    "rev": "7c7c7a5733afa1c1b3c1405a36d17f499ddc4efb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l39hk80ai2nsxjcbqg9kgf4xyb5s05kjijvswg2w055j0cmxsi9",
+    "url": "https://android.googlesource.com/device/common"
+  },
+  "device/generic/arm64": {
+    "dateTime": 1588703768,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb7b2db347d883cb3b2a87e41ee20d997d1ff364",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l66va61ybzf224l9q2gq60i132ikb75k58h1za1faq18m8hwvyx",
+    "url": "https://android.googlesource.com/device/generic/arm64"
+  },
+  "device/generic/armv7-a-neon": {
+    "dateTime": 1615075279,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2bf23daaead97c68575c2855730f04d2e9d5d6a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1986xyq0p2cqf4bgw3xf21qjszbidll8iwz2snzvffapybhr1213",
+    "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
+  },
+  "device/generic/art": {
+    "dateTime": 1613865708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43e28e47303d461909b3a813e6aed1f35f93b8e3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ijzwbsqb7xhzlj1bc84mp6hx782q30cvdsk4z6m36yibwlmkd97",
+    "url": "https://android.googlesource.com/device/generic/art"
+  },
+  "device/generic/car": {
+    "dateTime": 1639188046,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f9c2b65dd33e1474280d9e6269dd0c99e420195",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11k274qmdw1n585z0ras57zwavzk2mdw19sg1q1xsj5plhn01psn",
+    "url": "https://android.googlesource.com/device/generic/car"
+  },
+  "device/generic/common": {
+    "dateTime": 1639188047,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42a9e8892919b9cb415c930d0c91ed320b834698",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1kv3h6c7bpxvlvjmxz19av9zsign6h690ab8h7sprwpwh8ra70zi",
+    "url": "https://android.googlesource.com/device/generic/common"
+  },
+  "device/generic/goldfish": {
+    "dateTime": 1637884862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c11b074bde47a8641ac7e4e66745a558e8d39b68",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "163rys1cm6rv390ix5qda0yj0n75gzzs4yiasfrbms27fsk4pamh",
+    "url": "https://android.googlesource.com/device/generic/goldfish"
+  },
+  "device/generic/goldfish-opengl": {
+    "dateTime": 1634252492,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fcdbb272516b10a6ae45d33bd85d01dde835184",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fb0p8cwr6zlz6vwvvd59hvawqsaqq9niy3c9l3rr0ff351djdxf",
+    "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
+  },
+  "device/generic/mini-emulator-arm64": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3bbc90e86012ef8729cf71e0521fe43e6d9ce236",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
+  },
+  "device/generic/mini-emulator-armv7-a-neon": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fad6b21e974262c194db02bcde1568689aa20007",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
+  },
+  "device/generic/mini-emulator-x86": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "18a64b630385eb5bd18b964f86bc70a0467e5a47",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
+  },
+  "device/generic/mini-emulator-x86_64": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e7f4d2f97dd8586c94b1993ce85ec1a926baa348",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
+  },
+  "device/generic/opengl-transport": {
+    "dateTime": 1613440905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f44a15d881d49bd33fe46f7dcc5fbe9475220c6e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j6amjg99zbjsdg3xzgls29i0awz5rxdq8wklvkvrymhczk9ibr8",
+    "url": "https://android.googlesource.com/device/generic/opengl-transport"
+  },
+  "device/generic/qemu": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "597981e176adae2e849287248e7e660e87d7c4f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/generic/qemu"
+  },
+  "device/generic/trusty": {
+    "dateTime": 1621047742,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c5a83fce9d4d719831e4c7783ee78e5296035f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hj6w5lsdahw94dh8zgj2a6zs1vidcxdyi0wsxm7zwsvl1pwmrmr",
+    "url": "https://android.googlesource.com/device/generic/trusty"
+  },
+  "device/generic/uml": {
+    "dateTime": 1613865715,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "1cb4f0a25c771996d5cb033a4244525e2a47fbdc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18ninwq7gwgxxkrf5pgqfd05n8wjfnl9wc2wmwrs9r4kzgawmhgs",
+    "url": "https://android.googlesource.com/device/generic/uml"
+  },
+  "device/generic/vulkan-cereal": {
+    "dateTime": 1639008078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "204b2f880d435439f49fc73d137bffa3ce02f07c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lx8pz8pcm26j2smb4ydg58wgfknjia9swz31p3dmak6h1q3j922",
+    "url": "https://android.googlesource.com/device/generic/vulkan-cereal"
+  },
+  "device/generic/x86": {
+    "dateTime": 1588705083,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2764ff3bf47cc0b8fd57dcdd626c1d08eb911e8b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1msvricg8asj7vhkpfx4vd3jykdg3xqs0yhrvhj7m48lhsandfdz",
+    "url": "https://android.googlesource.com/device/generic/x86"
+  },
+  "device/generic/x86_64": {
+    "dateTime": 1588704382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b112f67820f5ba606f79a45e491557168788fbae",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1w7b33sap7ym1y23435n3cjsbvl8ws49m46lk8h1kgy8apg08mkw",
+    "url": "https://android.googlesource.com/device/generic/x86_64"
+  },
+  "device/google/atv": {
+    "dateTime": 1641765684,
+    "groups": [
+      "broadcom_pdk",
+      "device",
+      "generic_fs",
+      "pdk"
+    ],
+    "rev": "bf447db8b9866120d31c3e4cd97d2cde625663cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1glsmdxc5a6hr1dl1x46dkxblrnsy1dzx9gwjd01sjiiikl9zi1m",
+    "url": "https://android.googlesource.com/device/google/atv"
+  },
+  "device/google/barbet": {
+    "dateTime": 1641945670,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "9a979adc6c5ef2495863a4f31f45b839c05aa7dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19qrx0il7yk9mdcxpqd2h8s570dwq3ssw4vmrglgd7207mfxmkbd",
+    "url": "https://android.googlesource.com/device/google/barbet"
+  },
+  "device/google/barbet-kernel": {
+    "dateTime": 1642552796,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "bfd3653af50f2e0eca1cca7f8f6bcf20bb03f125",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05zrgqwadms899hm9rsq2mj5xa6736v0016mkxlfjnxdp3bj9pqv",
+    "url": "https://android.googlesource.com/device/google/barbet-kernel"
+  },
+  "device/google/barbet-sepolicy": {
+    "dateTime": 1626311159,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "c4d33b46a32ef5cc68f45e9e9d7274869c8f8f08",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lwjsrfcvdzj8lqkjy55y58bqmzirfg25zb19nhrp0bfnph3wlln",
+    "url": "https://android.googlesource.com/device/google/barbet-sepolicy"
+  },
+  "device/google/bonito": {
+    "dateTime": 1641945674,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "ed91d823a01435e1a77ccfdf531f074fdd0649fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "007dskcls76icdflzpvvj995p6bhmjfzw5cw81j4rqcn13ap52dq",
+    "url": "https://android.googlesource.com/device/google/bonito"
+  },
+  "device/google/bonito-kernel": {
+    "dateTime": 1642212074,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "a7a0796c79ad0b47c3c340758a508baf5ee28d15",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03rw9md6zwz5n315gyp2yb5a39hw7ycl1yf35pd1m2xps0ngylfv",
+    "url": "https://android.googlesource.com/device/google/bonito-kernel"
+  },
+  "device/google/bonito-sepolicy": {
+    "dateTime": 1637280083,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "86c7a8946075382568b933eb6884523c9471ef5b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16m9crk2f4gazqjg4dwjn8ys99s3mcsp92ikfx5hyxd4zfcmb1r2",
+    "url": "https://android.googlesource.com/device/google/bonito-sepolicy"
+  },
+  "device/google/bramble": {
+    "dateTime": 1639612895,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "053f73295155eeada2b8dca9b613d3d7d31a18e7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0dq4cy51r5my7j6zn6pj844rysc9psigflx8qwgnhwwvlp1gv9gg",
+    "url": "https://android.googlesource.com/device/google/bramble"
+  },
+  "device/google/bramble-sepolicy": {
+    "dateTime": 1621047749,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "f5da60fa0cb4406e7dea92604deaaa5e7481d439",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05f5cn22jkv4vjcdghy8j6g8g33yayrp4qk0bh289xri41l56yy2",
+    "url": "https://android.googlesource.com/device/google/bramble-sepolicy"
+  },
+  "device/google/contexthub": {
+    "dateTime": 1631998880,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "090bade7a270c15b539bde67ae491bb071906cfd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0b8a5fr7kdk156pwxahv7djm2m4l0bqhvsibf1ymlsan2h7z2kc8",
+    "url": "https://android.googlesource.com/device/google/contexthub"
+  },
+  "device/google/coral": {
+    "dateTime": 1641945677,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "e59f469e459a4a8070b009d4fc2ef66ac1444bfd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10jbh8ad2ich65b2bp72v1n95awc71kmrhbf5j9i30aja6zlzyc5",
+    "url": "https://android.googlesource.com/device/google/coral"
+  },
+  "device/google/coral-kernel": {
+    "dateTime": 1643332816,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "adf51a276982d3720781531da9173dcd0d01a62a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10kb2fq5452wh40zjmxgd1bd0s96qrpd0cc8dimx4ra6rhy0n6vc",
+    "url": "https://android.googlesource.com/device/google/coral-kernel"
+  },
+  "device/google/coral-sepolicy": {
+    "dateTime": 1637280086,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "de67cf6d293b1166b2504725c889a5d71550d61a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fllk0x7y2p97ka3ppvs1l9dkyc9y67qpb2rc2dy98mdn8md2ad2",
+    "url": "https://android.googlesource.com/device/google/coral-sepolicy"
+  },
+  "device/google/crosshatch": {
+    "dateTime": 1640304077,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "b26b028ae7ee858233d6db183327e7f303ca1272",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0awadvz8zw7354capnc6psrbrc79xhyfvpi45wzy7zkrz8fmgq19",
+    "url": "https://android.googlesource.com/device/google/crosshatch"
+  },
+  "device/google/crosshatch-kernel": {
+    "dateTime": 1628305341,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "5cb53708bca74e706e417127984958e167a6811c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0y2984wgi8277hkalin5spnhkljdx9qx2s6pppxm0aalcxk34shj",
+    "url": "https://android.googlesource.com/device/google/crosshatch-kernel"
+  },
+  "device/google/crosshatch-sepolicy": {
+    "dateTime": 1637280095,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "584bb866312e6bdf5d58f12d189c5fdc97b80ddb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09laq8ckzgw28gv2hmy7f695z1zb5n8dfxigyqz6z3jmi75zyyji",
+    "url": "https://android.googlesource.com/device/google/crosshatch-sepolicy"
+  },
+  "device/google/cuttlefish": {
+    "dateTime": 1641945687,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "b1df1b439f657a2367aa57c982d27a8ee66fe6e6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0897jxvfbpb7kc7yqdp6nszrfbv1aqbv1nncavvipf610qk7kkxw",
+    "url": "https://android.googlesource.com/device/google/cuttlefish"
+  },
+  "device/google/cuttlefish_prebuilts": {
+    "dateTime": 1640131302,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "a391da4dfe03bf35b9266e55b4d5bce52253cfed",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sa42f1n396h12qk7sbppcay6k17rvr7wbyha7cflb3b21z25w8y",
+    "url": "https://android.googlesource.com/device/google/cuttlefish_prebuilts"
+  },
+  "device/google/fuchsia": {
+    "dateTime": 1613865735,
+    "groups": [
+      "device"
+    ],
+    "rev": "d6f57981e9dd18e5d6d1fab3637f8f5fcb0e6ea8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "131k68cyq4yl559hjy9qxll6smzavph9c2l39q5wwqxlb8w96gzp",
+    "url": "https://android.googlesource.com/device/google/fuchsia"
+  },
+  "device/google/gs-common": {
+    "dateTime": 1621363244,
+    "groups": [
+      "device",
+      "pdk-gs-arm",
+      "slider"
+    ],
+    "rev": "65aa97f0e51ee9924fc7abdd64c328e166aefbe3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/google/gs-common"
+  },
+  "device/google/gs101": {
+    "dateTime": 1642728541,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "1a3aed9ce13ce4899b64ca072f469755cb2c4ae1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pgmhkp9si7823pxq75hpb6jc75jirry7b0ngvrasqj72sbc6ljy",
+    "url": "https://android.googlesource.com/device/google/gs101"
+  },
+  "device/google/gs101-sepolicy": {
+    "dateTime": 1642118528,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "cf28dc16a810932db756b37d7127a81d9589a28a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ck5spfrwdx4jv9dac9xn6xsfvb92hxw74rhxblwh3436rvq7qbs",
+    "url": "https://android.googlesource.com/device/google/gs101-sepolicy"
+  },
+  "device/google/raviole": {
+    "dateTime": 1644453733,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "59dfe05fec9561346e6e968c4a08a07d8a1cb0b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18s94x6v6xsmxq44annl3ly74yzfy7hgy4za1vr1895r79hm4gq2",
+    "url": "https://android.googlesource.com/device/google/raviole"
+  },
+  "device/google/raviole-kernel": {
+    "dateTime": 1643332817,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "d692a5f0d6bc76c2c3591b3079fc7b375f9bc541",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j5jz7bwszspwdrhpa9d7m27v8a6l84l272mzcdy9lnamfki03zx",
+    "url": "https://android.googlesource.com/device/google/raviole-kernel"
+  },
+  "device/google/redbull": {
+    "dateTime": 1642212081,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "590540ab4111a509b6986d7bb34428f5e2cba90f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hpa4l3m5lns2dqmv1844sz9linwfgqd2q1l38qv3p8nwbj8g52h",
+    "url": "https://android.googlesource.com/device/google/redbull"
+  },
+  "device/google/redbull-kernel": {
+    "dateTime": 1642552796,
+    "groups": [
+      "bramble",
+      "device",
+      "redfin"
+    ],
+    "rev": "427e640527c6fe743a87a9c39b0ce7adc9de9afb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04nnh5qrdwpx2alvsf438ihqbppwa7155zffwq16vvbqza7yh9f6",
+    "url": "https://android.googlesource.com/device/google/redbull-kernel"
+  },
+  "device/google/redbull-sepolicy": {
+    "dateTime": 1637280091,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "7e9844308272d07b57fb98bded793dd6f28161d0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h75hq2nxy5g7sk2fgli04zkhhy0w6s297x6m0c5rr55ah8z9s8d",
+    "url": "https://android.googlesource.com/device/google/redbull-sepolicy"
+  },
+  "device/google/redfin": {
+    "dateTime": 1639612908,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "21b40cf4f737732291117b20fc0348384eb86dda",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1740czypmzqiv20n1x0capch8f8k2n8q8bkqd4m4zhx2g13xzhcc",
+    "url": "https://android.googlesource.com/device/google/redfin"
+  },
+  "device/google/redfin-sepolicy": {
+    "dateTime": 1621047757,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "0574a33048d8e9f1728c14971513abe9a5493264",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18ng4p4hgm1mcr9j7py85420hsdasv34hqbi3whg3kiynsbflj10",
+    "url": "https://android.googlesource.com/device/google/redfin-sepolicy"
+  },
+  "device/google/sunfish": {
+    "dateTime": 1642212084,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "524ba5e10e57322fb8e0579b156e28ef6c49d92e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fcb2wgwmj50kd5mb04b2n9gy14492gxhd0sk7z6drr5dzr5pg1f",
+    "url": "https://android.googlesource.com/device/google/sunfish"
+  },
+  "device/google/sunfish-kernel": {
+    "dateTime": 1642212085,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "123d224b3a7520764c25818c04ab69b26adb714f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02f45bzzk6qhds7zqwnwrw08mjaqiiydk1ci0xdmwgbgdplq0v65",
+    "url": "https://android.googlesource.com/device/google/sunfish-kernel"
+  },
+  "device/google/sunfish-sepolicy": {
+    "dateTime": 1633388500,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "02c0e1bf9bf9327ce6b19f7be487aee3fd7626d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zq45s6952q85g5s9dvs91y7f6h0s5hpma2g6fqfa0m5hydj8bzb",
+    "url": "https://android.googlesource.com/device/google/sunfish-sepolicy"
+  },
+  "device/google/trout": {
+    "dateTime": 1642212091,
+    "groups": [
+      "device",
+      "gull",
+      "pdk",
+      "trout"
+    ],
+    "rev": "fb61582a751ae5d7a76ecc09fa61b94132c4de6d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mda6q9fvfmgzq4mksxj75lg7733zjbnwkhqpq9mm6ca6qpk7fiz",
+    "url": "https://android.googlesource.com/device/google/trout"
+  },
+  "device/google/vrservices": {
+    "dateTime": 1613865737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c66d8af31885c6e4f2bb372fabdd60f20b047f06",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bqfiyv18g1il413rkmyhz4prkmq85ww4sh2d5i0rzpddc9rldjy",
+    "url": "https://android.googlesource.com/device/google/vrservices"
+  },
+  "device/google_car": {
+    "dateTime": 1636232492,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db7d0b246b79ca44ed766902fb26851d9e7e0616",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "170jwa4p72l2vrxfyydv45ppwshs9480f4skaw5m4cb4dhzidwpr",
+    "url": "https://android.googlesource.com/device/google_car"
+  },
+  "device/linaro/dragonboard": {
+    "dateTime": 1624496815,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "771fc8de11eb8adeed948a2badcb38f3233d1160",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pb3mqvj4r549lgvqv53cd8x3qyx0byj9a87v5gl5q99lsrbjar9",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard"
+  },
+  "device/linaro/dragonboard-kernel": {
+    "dateTime": 1613865740,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "e7906e0ee8b7c7ca587f21e8e5314d88800f0daa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0prblxspjvp5nsz9ff236ia761539rbnn9wmna8za4k2qg4j26xk",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard-kernel"
+  },
+  "device/linaro/hikey": {
+    "dateTime": 1621047770,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "cf809ee7c26373dce5237f8623308928128423fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l5bkan588ig1g44bf1c5pwcd27i6wysh3i7sdfvlabkv6h0g86z",
+    "url": "https://android.googlesource.com/device/linaro/hikey"
+  },
+  "device/linaro/hikey-kernel": {
+    "dateTime": 1613865741,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "36442d54ae95b6b621d198236ea76b5dc952c7c9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r994z41qd5fq9vsg0360glrljrivkwa4wsms1amaw503vdxx2nn",
+    "url": "https://android.googlesource.com/device/linaro/hikey-kernel"
+  },
+  "device/linaro/poplar": {
+    "dateTime": 1621047771,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "59724cb6d3bddb7a7354227a5e25b534bc42cfa0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j921jkjwi0v7mhf6lybdlv2axyzlrhmyfkpdghmfyny9y1za7bz",
+    "url": "https://android.googlesource.com/device/linaro/poplar"
+  },
+  "device/linaro/poplar-kernel": {
+    "dateTime": 1558122724,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "4c1931e4fc1b7a27bee6cdb673b9f540006dbc15",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0danmswzl4r3skm19gg0868p36fxlhd5vj793v4i5allqkqgnxin",
+    "url": "https://android.googlesource.com/device/linaro/poplar-kernel"
+  },
+  "device/mediatek/wembley-sepolicy": {
+    "dateTime": 1624639763,
+    "groups": [
+      "device"
+    ],
+    "rev": "5a3026f515d22face23191e80995720903b61abf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "184isr5327zlh5fjaqzcyanldbjxr7lp934141r80c2pydgfx765",
+    "url": "https://android.googlesource.com/device/mediatek/wembley-sepolicy"
+  },
+  "device/sample": {
+    "dateTime": 1621047780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1dfcf87a82fa64f35e2b8f26ffa52aa37717ce52",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "14iyki70hlnb95i416izsw29hiyfpj1dnfb2pxnrr82qy3xk6dr7",
+    "url": "https://android.googlesource.com/device/sample"
+  },
+  "device/ti/beagle_x15": {
+    "dateTime": 1617152532,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "abe73a5d22c1a4d9b8f68ac900239f63dac18bd2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vbknk4k3dx9gbmhnhgvaiinfmhk8s0f3j5hzihbbdljqp0j65mj",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15"
+  },
+  "device/ti/beagle_x15-kernel": {
+    "dateTime": 1554368860,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "47f021405f7d936087710d58ecaeb3995ce3f232",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ahsr4x06x982y975jizgy0k3jix70rd1ypzgg3v3k24wpifrnn3",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
+  },
+  "external/ComputeLibrary": {
+    "dateTime": 1614823343,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "035979c5c7d329734ba817c4622c2cc633454e88",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k1ian6l5wkr2lgbn061rqggrv2k37z8x56jw2k005ga020qb71k",
+    "url": "https://android.googlesource.com/platform/external/ComputeLibrary"
+  },
+  "external/FP16": {
+    "dateTime": 1613786607,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab2eb34a983395d2ab799aa0d8fabd624895d795",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13lwr9v1rhr35mlvhzvwhwx9zcsry9nmin57w8wy8f3jm3m65lsd",
+    "url": "https://android.googlesource.com/platform/external/FP16"
+  },
+  "external/FXdiv": {
+    "dateTime": 1613865798,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f36b8c73fa750057a82b095186f51a7c096f0cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1804qzjg3vn7crqfzb8qv4f8sz5gl09b6h1lsgdr2plz2iga6b6m",
+    "url": "https://android.googlesource.com/platform/external/FXdiv"
+  },
+  "external/ImageMagick": {
+    "dateTime": 1621047850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2455ece07ff7eb841d561d8de97660c2c0aa116b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06ngnvlj2yd1n5r9d5jg914br23ynp0hjwqlvcp9kyb9wnz8n7ll",
+    "url": "https://android.googlesource.com/platform/external/ImageMagick"
+  },
+  "external/OpenCL-CTS": {
+    "dateTime": 1622077509,
+    "groups": [],
+    "rev": "b0294aff16cdb5a768b3b9342c8644074a011fca",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vs5jdpd0mxglmpcs0yjf778ink7mhkliahd7py6smw8mlram7kx",
+    "url": "https://android.googlesource.com/platform/external/OpenCL-CTS"
+  },
+  "external/OpenCSD": {
+    "dateTime": 1613865885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "923c7bc07b90f0ee888bf2a2ae81e89ed4addb68",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b3sn1yxyjl7ghzvgq2fk50q1q52s5wbwg7lgdd37kn0dfj8f7pw",
+    "url": "https://android.googlesource.com/platform/external/OpenCSD"
+  },
+  "external/Reactive-Extensions/RxCpp": {
+    "dateTime": 1613613913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad143d2c7d016d02735d813f37b681c155844330",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ydkh937q0vss0y5zid0zfrhlvk0rib57g2cnylzl2f667svabr0",
+    "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
+  },
+  "external/TestParameterInjector": {
+    "dateTime": 1630969648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30761803757a072be79fe65ade94877a4e461d3f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d1y4rr7xl4r9bb5v20jpskkgkgidb26vnkg4s1dq8fmsk2maliq",
+    "url": "https://android.googlesource.com/platform/external/TestParameterInjector"
+  },
+  "external/XNNPACK": {
+    "dateTime": 1616634395,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd9cf24082fbce775f1f75881252fcb72c6132af",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ps0gzf10n84ppcv23m03knwbllqd6x1skvn69sn6ssfiw12slwh",
+    "url": "https://android.googlesource.com/platform/external/XNNPACK"
+  },
+  "external/aac": {
+    "dateTime": 1621047782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fd9617df0e8e80ffa6d15420cae85e029a9caf3e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bg8wabf6snkr7fy3izis441jhqhag1gngi53dlzfk7g7ljiz3if",
+    "url": "https://android.googlesource.com/platform/external/aac"
+  },
+  "external/abseil-cpp": {
+    "dateTime": 1613531642,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e019102001e4386e4e862f228667cb3adb47df6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "090a9pkyc3pxqz1pa42kmgqzqn3cs80f4arabm9sffnkxgds1254",
+    "url": "https://android.googlesource.com/platform/external/abseil-cpp"
+  },
+  "external/android-clat": {
+    "dateTime": 1622768575,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73bb3c42eaf033b4ca6647a26c3748438b0ed5f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08bddsbl7za78ac6drf63pmpimyqcjkqp3xkjacqqppa16gk15f0",
+    "url": "https://android.googlesource.com/platform/external/android-clat"
+  },
+  "external/android-nn-driver": {
+    "dateTime": 1621652558,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "2c83705b236b369130b8c9a9156b863ad6c0c4b0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "060pv319qq0wdmy6xjbllc83mx5xkkz0jaanzbmgwiv2cq2xsc1h",
+    "url": "https://android.googlesource.com/platform/external/android-nn-driver"
+  },
+  "external/androidplot": {
+    "dateTime": 1621047784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ce568d0726de1b7d88b13b38453830a858206b1b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dxx539y2fbys0v3108mvk6ac875rjz6sw552xa2mhdhj5hywx32",
+    "url": "https://android.googlesource.com/platform/external/androidplot"
+  },
+  "external/angle": {
+    "dateTime": 1631746982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed63f27f2bff2e852635b6360a621ae59b04c538",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sgr6i1qw61gi1brgqpxrcnnlp8ibq9ar8lzm577xxrjrivp3j21",
+    "url": "https://android.googlesource.com/platform/external/angle"
+  },
+  "external/ant-glob": {
+    "dateTime": 1613613773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df2c84ff5eb19be038fb9342c656c355b5fa6e19",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1kv13x3rrjv04fyipfjgdmvbj9c22wb4ws8xikp2byvqss5qfyfj",
+    "url": "https://android.googlesource.com/platform/external/ant-glob"
+  },
+  "external/antlr": {
+    "dateTime": 1613531645,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "622c026bb9a7ce1c0b388df859009d5aaf45dce0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09m5na2mm1qbbffzvmyvkvvp48wcfyd2m90asg07adaf94pw7xkb",
+    "url": "https://android.googlesource.com/platform/external/antlr"
+  },
+  "external/apache-commons-bcel": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9dc10b4cd273f5dbf068f3bc0b9733cedeefea3d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wg1k32wz232b3d0iz8n0krpclz21l8jmmpd08ybgx410ga0nlwb",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
+  },
+  "external/apache-commons-compress": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d375fdf25d16bc86ea61ee7138d4df91916ce329",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mrr0ypp23pljll9i0xawar6h4snw52k10xnggmsrj638xi5bmms",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
+  },
+  "external/apache-commons-math": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75baa072e18b4a1c0230e269280d5dfa8eefd95f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17f2wbjgrpyjbcxxmwyfyxfbr7ci4z14ry1vp7dac0hlzn57rpln",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-math"
+  },
+  "external/apache-harmony": {
+    "dateTime": 1622077381,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b64d7f833f7074acd1a92523238878f19c9d9ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13j3zz0wjvyyy8i4n56039n96yrla6iqzng13fi02fia2wwv5vjb",
+    "url": "https://android.googlesource.com/platform/external/apache-harmony"
+  },
+  "external/apache-http": {
+    "dateTime": 1622934146,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "472d3cc039474b1fe4b45262033dd6648bb015e9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "180wkbj8pj021w6wizcjlnjl8giw3bs998jrxxpyrkpnjbf7nw2a",
+    "url": "https://android.googlesource.com/platform/external/apache-http"
+  },
+  "external/apache-xml": {
+    "dateTime": 1614909723,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d70c64f4525ce17a9389cacd39a13eaaf97ede6e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07p95202kf49p5wpg5fq9nc99hcjcphac903sbm8wlsvcvppw6hx",
+    "url": "https://android.googlesource.com/platform/external/apache-xml"
+  },
+  "external/arm-neon-tests": {
+    "dateTime": 1613531647,
+    "groups": [
+      "vendor"
+    ],
+    "rev": "5ff08159f44d70ca08e1e5a1c086794b29557bcb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05q3rb390d3zdmva3br4r2njy8hwvnn3ny796dbbsy8fwyq6ijzg",
+    "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
+  },
+  "external/arm-optimized-routines": {
+    "dateTime": 1621047790,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e4d81a9510564caa99aaf6d293a37022027ee686",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ag1zvd22685wxp2yk82vkwc246y2n1csqqjspx6zsbixgjrap5x",
+    "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
+  },
+  "external/arm-trusted-firmware": {
+    "dateTime": 1613531648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d1eaa389ffc7cf62e221a6404b71b7750dc0b60",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rdw9ffppv0lqb2gy6pljp9irrckg389afkb9m90nlx84cw4kg4j",
+    "url": "https://android.googlesource.com/platform/external/arm-trusted-firmware"
+  },
+  "external/armnn": {
+    "dateTime": 1616972522,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "21722192ae77712fae3e797f5812c75c8f6f5e38",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s30csg50az4hgmc0idc8ifnckw4rrjmhxlc3pl19kqywv1ng9m1",
+    "url": "https://android.googlesource.com/platform/external/armnn"
+  },
+  "external/auto": {
+    "dateTime": 1613865762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dbfa08ce30589cc6e1d4d87ca4a1097a9dfd9399",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02zs1cf9553f3wamv53sfxpphh2ss7l6lvww39f970zdpkkr1k85",
+    "url": "https://android.googlesource.com/platform/external/auto"
+  },
+  "external/autotest": {
+    "dateTime": 1613865762,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bcc40eb9f8c26462986aa874660cdd846e16bf3c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wnd234ci6hwfflsdf248jvmwp8dd08hcka8nll3gh0wqmy9bizf",
+    "url": "https://android.googlesource.com/platform/external/autotest"
+  },
+  "external/avb": {
+    "dateTime": 1625706308,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a878b6cd196e69e1943328dfca726102b52f3ef9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s35d3zns4w00k7x2x2pvc4b2y4c8kd46rmi7x860kszkl02kvwx",
+    "url": "https://android.googlesource.com/platform/external/avb"
+  },
+  "external/bazelbuild-rules_android": {
+    "dateTime": 1616461328,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5bdbfa8d412beb4382f04b7669ce104a283d86c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mg4iyzaq22b9n07146vmq273vrk2f0hlyj7jm71s6vhmlqzvl3z",
+    "url": "https://android.googlesource.com/platform/external/bazelbuild-rules_android"
+  },
+  "external/bc": {
+    "dateTime": 1621047794,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f7697492bd97e741789dced2ed084ae9bc068525",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ijih5ka54195h55c019z9nq5hmb71f3smgkssnh0rmjry6h5dld",
+    "url": "https://android.googlesource.com/platform/external/bc"
+  },
+  "external/bcc": {
+    "dateTime": 1613865764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba4f3f62cf3f80c9a24e461bc54cb3b52ae85b5c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04kphwmxxnpv72ycsn8skhlc8hkmm01rb8w8x0jl0gcbcw28dbng",
+    "url": "https://android.googlesource.com/platform/external/bcc"
+  },
+  "external/blktrace": {
+    "dateTime": 1613952161,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a0e6f830239c90afb22e1e69ef1eb479af8b85d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v4znxs40lqzd9k5qw5my887x3ybybdfhhcf7qi3y4v9p8wqk9mw",
+    "url": "https://android.googlesource.com/platform/external/blktrace"
+  },
+  "external/boringssl": {
+    "dateTime": 1621047796,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "927f97ad769770065507e7f22d261e800fcdfba9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zdzw01rab9qnsj9vn4ygk0x2i3bm2zjidl7fxwxf8z42h027bpx",
+    "url": "https://android.googlesource.com/platform/external/boringssl"
+  },
+  "external/bouncycastle": {
+    "dateTime": 1621047796,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f9deaa915cd8d3d6ad94259682c5668077617b44",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0x4sy9406gffkglnkyg1pwpi66p1mhkrhh0p1245f2mbap6zbhx4",
+    "url": "https://android.googlesource.com/platform/external/bouncycastle"
+  },
+  "external/brotli": {
+    "dateTime": 1613865766,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ebaf67e5fb281d4be42876a09e0304f92f83ed99",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jjahi9515i5fchmym5rc9fk63hh8dmmbacpvf5q8bfb96vc52bg",
+    "url": "https://android.googlesource.com/platform/external/brotli"
+  },
+  "external/bsdiff": {
+    "dateTime": 1621047797,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0bbd0e5fc71a26cc78aa118c78db009ac660cc7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bvvbndadhzqsl8avqwzxag02i90zmplbzw5xfiprdrbzr3l07im",
+    "url": "https://android.googlesource.com/platform/external/bsdiff"
+  },
+  "external/bzip2": {
+    "dateTime": 1613865767,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c175a5432408f8cd1d243776c3c488b08c5ffd10",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vc2m1fz3dhypn771zbhfdf1my1lgm1naz08zyfcm62j6p0263sw",
+    "url": "https://android.googlesource.com/platform/external/bzip2"
+  },
+  "external/caliper": {
+    "dateTime": 1614308718,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94fa11a936e00df2e986a2e9538e38a0a5782847",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hg2c1b1vqrx3ky9s1s9bdalvpf47sgm2w2m3cwwc66p92x9sk8y",
+    "url": "https://android.googlesource.com/platform/external/caliper"
+  },
+  "external/capstone": {
+    "dateTime": 1613865769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f467da98a75b4bdeb1a154623a768ea82a418062",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "181svy2yh8400xdjbz09rfmkzbzic8i8zjpj3mmicpq3lrbp37lz",
+    "url": "https://android.googlesource.com/platform/external/capstone"
+  },
+  "external/catch2": {
+    "dateTime": 1613531655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "55e23424b866617bcff433da222903661720af71",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "121f7mvnhl9ss3ckwliiqfdkpi0c1siq7vy2ghd46lk17yc7lc7l",
+    "url": "https://android.googlesource.com/platform/external/catch2"
+  },
+  "external/cblas": {
+    "dateTime": 1613613786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bfad236f40eb4b811f3dd089e21cb54510828c0e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vs0bvv7jxg9v853ys0262523qw6f83vlyzkq8dfrsvnsycakzzf",
+    "url": "https://android.googlesource.com/platform/external/cblas"
+  },
+  "external/cbor-java": {
+    "dateTime": 1613531656,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ea9306a7a6b310125858afe59e490870e30e988f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18ycp109z76isyfi7pac2nd9idi23wpywkbndp9ki1h69mwr2zmm",
+    "url": "https://android.googlesource.com/platform/external/cbor-java"
+  },
+  "external/chromium-trace": {
+    "dateTime": 1621047801,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87ac1eedf31fed50a4d1537b8c502b96401e18b4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0alb6ykda1vi6n2g1cw3b3p871c9bpz4xgi163p7kz39hpwv4h5p",
+    "url": "https://android.googlesource.com/platform/external/chromium-trace"
+  },
+  "external/chromium-webview": {
+    "dateTime": 1642212129,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "55c6a63eefb916266d6ed501b24756b248e5e3e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0dficsikbljkjnbfyq6p2hl52mb79wjzw01v8kyl7kldqjff7k5g",
+    "url": "https://android.googlesource.com/platform/external/chromium-webview"
+  },
+  "external/clang": {
+    "dateTime": 1613865771,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e4305f3d519548752fe299476f92fb03540fcb50",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06jjzh7xg63a852m61x1dy5mk32g505srm9qax981y1fiqy4pr9b",
+    "url": "https://android.googlesource.com/platform/external/clang"
+  },
+  "external/cldr": {
+    "dateTime": 1636768923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "092fe9b7c1a5726ac00b3471ffa26d4a1cdf9ede",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qgy41wyv39yx3ia6ysnwnc919xkxk0dh3wpzmzq962sm6k3b04g",
+    "url": "https://android.googlesource.com/platform/external/cldr"
+  },
+  "external/cn-cbor": {
+    "dateTime": 1613613788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f40fa5ab265e48637c3abaa7884c1267d9c1547",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gh910wa3zrdk8jaghbbrwhr5cwxj2jiji98b00i79vdndi9fkp4",
+    "url": "https://android.googlesource.com/platform/external/cn-cbor"
+  },
+  "external/compiler-rt": {
+    "dateTime": 1613865773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25403535052ff6146b89ce9f8c8989283698d3a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sxxwngwcb9z6x3f9i7fw8j08h27wvzhdnmwxbrx2kz2zphm4gwn",
+    "url": "https://android.googlesource.com/platform/external/compiler-rt"
+  },
+  "external/connectedappssdk": {
+    "dateTime": 1634346131,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c037d310bf7e3a07abf8bc2732d16519d510671",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11qr5prfh22has9ay82flxs6wbhi7dviq4ac3hdvv1bbc64qimxc",
+    "url": "https://android.googlesource.com/platform/external/connectedappssdk"
+  },
+  "external/conscrypt": {
+    "dateTime": 1639440141,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e1d631496d4f47365b4c70d82717c5bfb4493ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0yzfqjv9kir19p3bkcq9gdwcplj028n7spxaippxhlrqzd7xba63",
+    "url": "https://android.googlesource.com/platform/external/conscrypt"
+  },
+  "external/cpu_features": {
+    "dateTime": 1614996141,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4290cc4ea0012cc4ee93d68d2b5eb9a9cdece7bc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "078fa0lqhy0v8nhb81yr4r80lr6d24r0xayxwzvyz9f78phvypi5",
+    "url": "https://android.googlesource.com/platform/external/cpu_features"
+  },
+  "external/cpuinfo": {
+    "dateTime": 1613865775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3f36e9757ca4d74bc0bc9a611523e987602e71d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0y7api7gknnfphvwz8fc751yzwj5vzzgm7zqdbrcf0r3m09my4yg",
+    "url": "https://android.googlesource.com/platform/external/cpuinfo"
+  },
+  "external/crcalc": {
+    "dateTime": 1613531661,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98100c0c947b614e4f4ccb52a92930b5d179cffc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nldnvwr197rpzigkxrdb1342vcnwh1mdazr831ynscqga55f7sc",
+    "url": "https://android.googlesource.com/platform/external/crcalc"
+  },
+  "external/cros/system_api": {
+    "dateTime": 1588165008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d99893b3499079ba5b2dfbf52b84df18ac417e42",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jr6jiz7qjgwfm8p15lq6qh18iy25qbyr1accj1mxy2xcp3lcvnl",
+    "url": "https://android.googlesource.com/platform/external/cros/system_api"
+  },
+  "external/crosvm": {
+    "dateTime": 1636160545,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e17db4739686c74d1d054403f0c05be0a3e0fe1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19ilymnxcjfrgq5bgnlkcl4hn4wdky5rq0r377q344wd431i6ml9",
+    "url": "https://android.googlesource.com/platform/external/crosvm"
+  },
+  "external/curl": {
+    "dateTime": 1613865777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "084e33872ba9bc9be7481a1c2277f7fe55017711",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wfyfdkw212wlqdmxwwm985hdm6wwcgx3lagbl373h9f9d6j7y28",
+    "url": "https://android.googlesource.com/platform/external/curl"
+  },
+  "external/dagger2": {
+    "dateTime": 1621047808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a881f6f758f950ca30b56070630ebd4191bcfe4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0aa3q04an07rmyf3fjjs797fpm49mq4fi1y0arqdk3jcn44ha8al",
+    "url": "https://android.googlesource.com/platform/external/dagger2"
+  },
+  "external/deqp": {
+    "dateTime": 1635375761,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f75c67fb1a7db5fbe49de1ee9f249a9d827dade5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16wwzkh068n4n6335r65cx3l24aapq05j9pbj3svpndgkzd28n6q",
+    "url": "https://android.googlesource.com/platform/external/deqp"
+  },
+  "external/deqp-deps/SPIRV-Headers": {
+    "dateTime": 1632870142,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "38d7bf234119f9e1e655cda3709d3fc61b8a96de",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "197mx23883n4i2grsaaf7d09cbp70yajzd4ylwr186lg1q94j649",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
+  },
+  "external/deqp-deps/SPIRV-Tools": {
+    "dateTime": 1632870142,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8fb9e3ae6eddd3ef3aa54b19328de110d65d3a48",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n9i57smxsy1hrqa7i0as6ky0ggcyp3y104hgmxmgzmxsch6a4n4",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
+  },
+  "external/deqp-deps/amber": {
+    "dateTime": 1616029365,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "cfc77eb015429a38db3ad1c1e026386a8922a4c9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "012vrgcf5afz99avy1107z40ly4dbnvaldzmm60zm074ys2gpczv",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/amber"
+  },
+  "external/deqp-deps/glslang": {
+    "dateTime": 1616029365,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b52f929e34429f6ea27ce147395062b43d6a80e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0m4pvypx9l7d16pslkf8imqm3k21jap1vcb05pm6213rwrgl11im",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
+  },
+  "external/desugar": {
+    "dateTime": 1613531665,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "946d37fa83e240cd44df667ef38e5c247e8ab562",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l24kgg5lm93aawfknf9igbhcag5jlacs0v1h0b2cwk7ffq6igyv",
+    "url": "https://android.googlesource.com/platform/external/desugar"
+  },
+  "external/dexmaker": {
+    "dateTime": 1613865781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b640deabdcbcb7cd4c7a651ba5bad919ca957047",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c47k9acimibwfm46zkhnwxr9ijjhz300w14dwzkirwk6hacsmy4",
+    "url": "https://android.googlesource.com/platform/external/dexmaker"
+  },
+  "external/dlmalloc": {
+    "dateTime": 1588119024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49e3a0d55e581bd40287e0b031af822404f4cb66",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yz7c4y6jppq2gxgc7bnrhis4na6r96w3i9y7rqb32hyh971ym8h",
+    "url": "https://android.googlesource.com/platform/external/dlmalloc"
+  },
+  "external/dng_sdk": {
+    "dateTime": 1613865782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7b90e37455ddcf1be1eb6efd69fdc0fcb091f5a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n0kz9ffs327mwd06qj7msmfwrhyiabcvapxsr172az0skr9980p",
+    "url": "https://android.googlesource.com/platform/external/dng_sdk"
+  },
+  "external/dnsmasq": {
+    "dateTime": 1614909745,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8c86070da70a8d549f706cd7cddb33ccd387bcb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06lwhhpprrsv7bz2jysf1wjx50zmck3q7wpmnci28lc2r2b39xv1",
+    "url": "https://android.googlesource.com/platform/external/dnsmasq"
+  },
+  "external/doclava": {
+    "dateTime": 1621047814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "071b0e2adfaa5dfd480c491583b3447af0c8e2d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1aa1aycv47aavy6j29wkivspdg6fxhrpzkb9fd7mpv7im2z134zi",
+    "url": "https://android.googlesource.com/platform/external/doclava"
+  },
+  "external/dokka": {
+    "dateTime": 1621047814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "693f46f61f5e5c5aa1ef9de11dcacfacbe016426",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n9lbm134yr4gd9lddlc6kykh0f18q4s3jvp3y09xy6r8hbilxx8",
+    "url": "https://android.googlesource.com/platform/external/dokka"
+  },
+  "external/downloader": {
+    "dateTime": 1614650588,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "74e84996d0d81e3c55bebe924b0c07f4472fae6f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1prbsya7mwnk2f6z7zmg4a62873kk5yfhjrki7dwb8rzwzq9mm5n",
+    "url": "https://android.googlesource.com/platform/external/downloader"
+  },
+  "external/drm_hwcomposer": {
+    "dateTime": 1634166161,
+    "groups": [
+      "drm_hwcomposer",
+      "pdk-fs"
+    ],
+    "rev": "d41907c464b0eeafaa3769597b7b51b5b151b733",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18ma7x3pw5nq6l85whkr3m1nwd6hnjqxiqr3q0mbafi9hp8sfraq",
+    "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
+  },
+  "external/drrickorang": {
+    "dateTime": 1613865785,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35e55f09b86d21217254e7d569c81562dd069892",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c705icrhgcdkxlbz125yn61hglzbnyvmwj6prafs74l3jb9h2sf",
+    "url": "https://android.googlesource.com/platform/external/drrickorang"
+  },
+  "external/dtc": {
+    "dateTime": 1613865785,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c4267d983c594b016134870000a0d84a172dcde",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x6qsq1d8ay15is649cy900b6n4syl37m8705fk1x5972gm3s833",
+    "url": "https://android.googlesource.com/platform/external/dtc"
+  },
+  "external/dynamic_depth": {
+    "dateTime": 1617238941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5026600b59cb598158f4112fba351f4700b188f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11mw0dwirrrirgrap33k8dvngpilf6qdzwsz0phzbpr05900915j",
+    "url": "https://android.googlesource.com/platform/external/dynamic_depth"
+  },
+  "external/e2fsprogs": {
+    "dateTime": 1613865786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87c313e2da50c9da1eb0d492265ab5b5b86a91e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00y5a8kkqiqwg8q3mgns7vph072s3jiv7ih6b43qbgha622d9xq5",
+    "url": "https://android.googlesource.com/platform/external/e2fsprogs"
+  },
+  "external/easymock": {
+    "dateTime": 1613952184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88dd75eaf69a80bbbf7f5efdc5deff078548e655",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13x8mwwilrqva7wknhcab80lhmh0j55mgdiha3w5v1crlk7nbgrz",
+    "url": "https://android.googlesource.com/platform/external/easymock"
+  },
+  "external/eigen": {
+    "dateTime": 1617238942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80c4fe9883ad7886cec355cee61d3a7d62e990be",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mja982a49hx7mzplq5vb3igzkyv659032hfha4qhg83qc5svpm3",
+    "url": "https://android.googlesource.com/platform/external/eigen"
+  },
+  "external/elfutils": {
+    "dateTime": 1613865788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8cd900c21f356504ad76787da4a4ed04269c814c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1znxr9qbz5mgdl35g263c0n2k33siq2qhgdx0kilf566l9c7cjpp",
+    "url": "https://android.googlesource.com/platform/external/elfutils"
+  },
+  "external/emma": {
+    "dateTime": 1613613802,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "930ab2a3bc7dcba729d645ab2c4c69efeff1aa0b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q783p5xwhrw2hgq2lihxdz80n7gyw6pri9l8ryrzgdklxqgpdhy",
+    "url": "https://android.googlesource.com/platform/external/emma"
+  },
+  "external/erofs-utils": {
+    "dateTime": 1621047819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dfecfbb2d1dc6a35deaa4625940108280791c7d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jj89j02d66jzcf53yjvrv7rgbwcmfpbi8839ygab0m5zxjdlshv",
+    "url": "https://android.googlesource.com/platform/external/erofs-utils"
+  },
+  "external/error_prone": {
+    "dateTime": 1613865789,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e572051c193366d1da4189deaa6eaf207e7cf285",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x5ikif1igni9sh9fcl9ma0k670a8gykvjv8bxl745mhzfnyfwqb",
+    "url": "https://android.googlesource.com/platform/external/error_prone"
+  },
+  "external/escapevelocity": {
+    "dateTime": 1613952187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3955e3693a43dfc6529fc908a206e66e91060b16",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12g3s6l40sncayrl9hvwkixb0diq5gkdf0i3j3llz8yi5i9bh1pp",
+    "url": "https://android.googlesource.com/platform/external/escapevelocity"
+  },
+  "external/ethtool": {
+    "dateTime": 1613613804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24021296b20eaad69af0fa24f378c0c60b8ef137",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17i4hhqfprqilra51s34l07rin3k32pzw36sb5xazmgr3g926giy",
+    "url": "https://android.googlesource.com/platform/external/ethtool"
+  },
+  "external/exoplayer": {
+    "dateTime": 1631228836,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec5a25801579a665f1689b254b77b9a454cc1bd9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r3zdplwd1h8x1phqmkws4ismz92vnmvvw11s3jyjpay80maqgh4",
+    "url": "https://android.googlesource.com/platform/external/exoplayer"
+  },
+  "external/expat": {
+    "dateTime": 1617490956,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "79a383a16b87261aa15e1103cfb1e303effa9191",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1p1ckravpadk36lb04ahd40f2ivc921wrd21swq7n69c16g4a920",
+    "url": "https://android.googlesource.com/platform/external/expat"
+  },
+  "external/f2fs-tools": {
+    "dateTime": 1633043395,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a49677550a6b845e9867e1eb77312906430de18d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "062r7sgrg626wgg8wvzjimm5gd8pixd3ssm921zmw7ahfzfi9720",
+    "url": "https://android.googlesource.com/platform/external/f2fs-tools"
+  },
+  "external/fastrpc": {
+    "dateTime": 1587748082,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c87c4073f561a5d9b735b3495e331e4caa9e7a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mfid59pw4qkv4zdj86g8mm0gsrdqkpc8kcwx6xbq8l42k9br4jl",
+    "url": "https://android.googlesource.com/platform/external/fastrpc"
+  },
+  "external/fdlibm": {
+    "dateTime": 1614909756,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b55d4c61154de3b94924257f624331a65286d9aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cxx79d3l3w7p3b1pzlmnargzw8svaqx3jpl69a816ipq274y5kg",
+    "url": "https://android.googlesource.com/platform/external/fdlibm"
+  },
+  "external/fec": {
+    "dateTime": 1625706396,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8627a3bbd38bca22e598c2f06b70604d099cfc9d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j0s8xhs6hgzjlybzks1brkjq7xlwlr17xkvay6lkjqb57cdsqxv",
+    "url": "https://android.googlesource.com/platform/external/fec"
+  },
+  "external/fft2d": {
+    "dateTime": 1616972553,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5af05ae4c6623b6b922364388aa7805b32c4e50e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "061p07mzli7srnhzvnz726j849446yyprlgxc300f5zwjla3cz3j",
+    "url": "https://android.googlesource.com/platform/external/fft2d"
+  },
+  "external/firebase-messaging": {
+    "dateTime": 1624928655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73733c69195f322c2d92557da9b76def82572313",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18c68j3cfc906x8glmlmcsxrbxfqy67dlim116grjmihv491zlsi",
+    "url": "https://android.googlesource.com/platform/external/firebase-messaging"
+  },
+  "external/flac": {
+    "dateTime": 1616814204,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd9117111155b10241588708beda20c18612b5fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bxl0m0kxfzwjk10nbm8i2fnsvn92d7793yv8bpwzqj4k7kcrg5m",
+    "url": "https://android.googlesource.com/platform/external/flac"
+  },
+  "external/flatbuffers": {
+    "dateTime": 1613865794,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb010ab199685aa2fcc09c5a500de10555efa842",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0aqwlh168j42532l0klgx6gsbqw7lhj92l25b8b1380j2qgz23hs",
+    "url": "https://android.googlesource.com/platform/external/flatbuffers"
+  },
+  "external/fmtlib": {
+    "dateTime": 1613865795,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f347f2f48d0b05f6468afb2e83d02e539fdf1380",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16x73827rr1sfvxpd4gg4rpx30vqfdp2r2md9ynmbl6lf2qwgqfg",
+    "url": "https://android.googlesource.com/platform/external/fmtlib"
+  },
+  "external/fonttools": {
+    "dateTime": 1617418946,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08089f06954f63bf457022920ddd47c5079df465",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "082gbxzxji2hssl0h25yxvs0caf8cyaisjd6k09s2wcgvnvvc7n7",
+    "url": "https://android.googlesource.com/platform/external/fonttools"
+  },
+  "external/freetype": {
+    "dateTime": 1621047828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80db3252629f08822ebd1ea94d26c73a444a9600",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1higwvkpvh6wz0ryjbq31v00fqxq14q9xrr3p7ww32q2nvkych80",
+    "url": "https://android.googlesource.com/platform/external/freetype"
+  },
+  "external/fsck_msdos": {
+    "dateTime": 1621047828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bdcb89526ab11c23b40e07e4283fc34f12157994",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08js9q4kzic0i6sj67cdppga0q818277a3wivp7dpaxvz4anc40s",
+    "url": "https://android.googlesource.com/platform/external/fsck_msdos"
+  },
+  "external/fsverity-utils": {
+    "dateTime": 1613865797,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "96a7a1ef1afe1b0440afd94ec0091b1b760879e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v541yjbvlkkddynwnwakrhj77jmawm1niz1nwbr2ish612v07p5",
+    "url": "https://android.googlesource.com/platform/external/fsverity-utils"
+  },
+  "external/gemmlowp": {
+    "dateTime": 1615600981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46450c4c1ccc045154e48ce2cf514843ce384a34",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dff6jrd314xnib7jhqwpfc4hyv6ycjgrmb92wwany30drmlnw9l",
+    "url": "https://android.googlesource.com/platform/external/gemmlowp"
+  },
+  "external/geojson-jackson": {
+    "dateTime": 1614736983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8acca14b9cbee56e9bd125c7b5b798b340e0ea26",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qrp98sn4q997q5szpz37414hlm3yl6183r504sv14azfwm7ymyf",
+    "url": "https://android.googlesource.com/platform/external/geojson-jackson"
+  },
+  "external/geonames": {
+    "dateTime": 1605020923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9c53a8ff2e3a1ba6a8e594a536384b9b25fba2cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xcdyb82cs40am7x477cavyczh1ijm5zx785fw2in1wkqah4zp0a",
+    "url": "https://android.googlesource.com/platform/external/geonames"
+  },
+  "external/gflags": {
+    "dateTime": 1613865800,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb22b884a72891e2e768ea62c3fc98b1aa67f602",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wyiic485x863sdm6834dsl3b4c40fqpagz529v091kribmmm8gz",
+    "url": "https://android.googlesource.com/platform/external/gflags"
+  },
+  "external/giflib": {
+    "dateTime": 1613613812,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "0c85d92a59fb568c77e540f383e97878493c3823",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sibmcf4ld5cda63fyklr7bd0naydy5c39rszg0fp7iiivx3n8il",
+    "url": "https://android.googlesource.com/platform/external/giflib"
+  },
+  "external/glide": {
+    "dateTime": 1613531683,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d7db3a4e2d9510d6ea629abe3a0150a9c2fe897",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b38i7kvsivigic627hxi04k9sf5iq6ry176drcx9mr6wkbysbvf",
+    "url": "https://android.googlesource.com/platform/external/glide"
+  },
+  "external/golang-protobuf": {
+    "dateTime": 1613952198,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4f382226fa9310bc99af68e92ff06b1001e8c93a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1za35lgd4h3vfqhv0a9kjbi0arrq9k0phpks113mddzlfg7dxnbw",
+    "url": "https://android.googlesource.com/platform/external/golang-protobuf"
+  },
+  "external/google-benchmark": {
+    "dateTime": 1613865802,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8856a8e506b90ccfd763933691b0f2f9042c7e87",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jnb9fbib4gp3w9smw5s1nvz2snbz414yxxa1xb58p5wjp7fqx4w",
+    "url": "https://android.googlesource.com/platform/external/google-benchmark"
+  },
+  "external/google-breakpad": {
+    "dateTime": 1614823373,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b416bd680aba22ac6ee76cbb2da4826d29b7e5e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13l54qb6a8ba4g80h59mk1xxbdiqa0219h4p78rxzx1j75cx7m6h",
+    "url": "https://android.googlesource.com/platform/external/google-breakpad"
+  },
+  "external/google-fonts/arbutus-slab": {
+    "dateTime": 1613865803,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61ebe4245bc344ce3696db2b9cbe843dc4520dfc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18g7n073qp1ii4gx11n6fpsv8si0ima4ldrx7mraca9mdq72w71m",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
+  },
+  "external/google-fonts/arvo": {
+    "dateTime": 1613865806,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a56ef2fd8d80fe33651cb55770a4b561ef6578e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "144j3kjdp9gm5qi9x0j571m88vnqs1lwm8672qh9l3m7lxxsy0jl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
+  },
+  "external/google-fonts/barlow": {
+    "dateTime": 1613865803,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d24de778f0759096da3346ed1e0226e5d7cbe33b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "029n04xijjbwwxmz8lbihwcl9a30bgy9czdzg82ybwylnwq9pfwm",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/barlow"
+  },
+  "external/google-fonts/big-shoulders-text": {
+    "dateTime": 1613865805,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cd284294031a74cae007e91f9c0617dc3a7c3bf3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jpm0ld79d3g66iwiwmx4dn2gxdlrgwsblynf4zwcgcq7ydi4zb0",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/big-shoulders-text"
+  },
+  "external/google-fonts/carrois-gothic-sc": {
+    "dateTime": 1613613817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f79b6a1c298980a2f9d31724dee47a262a2cc138",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "067xqhgd67ngvkr7frxdy1y774pfpzzkih3jjk7fj24wqnkc6d5j",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
+  },
+  "external/google-fonts/coming-soon": {
+    "dateTime": 1613613817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "933fa51683cb43d28bda52e42e812a16fcde76a4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wz6aji68kbhg58dbwn0zmjg2ywk6cfdq7j7awg38zl2q26nfmq9",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
+  },
+  "external/google-fonts/cutive-mono": {
+    "dateTime": 1617238963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b629b6e3f3cda91710525a67f6028b94752c682e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00wfjacl0sqncivpa3za9jmki9wva9q0vf85ads6g2rz4z6nkrff",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
+  },
+  "external/google-fonts/dancing-script": {
+    "dateTime": 1617238963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d8522aa0f565f9357627a4eb36a125ec141e499",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hdp4a0gn23n88gzdi65dfqq3pmvw3nadf1p8xnqxan34yv8adyl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
+  },
+  "external/google-fonts/fraunces": {
+    "dateTime": 1613865805,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "400291dba7060de6dae2b3aa49b902eebd28e057",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gr0x87wrs8qh2ykpggcvxkxc1qmd6hw0xq6hn6p6s8078pw5b6w",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/fraunces"
+  },
+  "external/google-fonts/karla": {
+    "dateTime": 1613865804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46d4a0de932d4c8088a9aba7a5f42bba2172865b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c8ny537pvhjfh0b87lfpc0aga4x0mlry203wkacgx2a1h00irhx",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/karla"
+  },
+  "external/google-fonts/lato": {
+    "dateTime": 1613865808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1bff3c913525b01e5178d2fcb1c537a2012fdd05",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hdy27r466jd7ik69257hiazjqsdzv0hbpzkmid6rq1gk2lkijgz",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
+  },
+  "external/google-fonts/lustria": {
+    "dateTime": 1613865804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b69ceac2adc42aa0e61000077a0e5c36f008c81a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16i0vknh3z23mr79iilxyf6kqs5kqp198by9cx9rmzcg3phgx03y",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lustria"
+  },
+  "external/google-fonts/rubik": {
+    "dateTime": 1613865809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bbe862afbf31376ffac8bc80e20d47b6c36aad6d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10ap1n0s7qs742m3xzxrs91xyirp0280xvg4wz8hmpyip631h7f3",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
+  },
+  "external/google-fonts/source-sans-pro": {
+    "dateTime": 1613865809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e659a62c3473f866e804d9cff4bd0161cdc7410",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nmdmb80pf2pzcdn369q5skspmlqv56sn9in0fcfhx14pib64w86",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
+  },
+  "external/google-fonts/zilla-slab": {
+    "dateTime": 1613865810,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ba6f56e500d3ac915d1d137c37e1a9b32248f09",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rm6wp6849wpw32ys5wbrx9836937j1zx310fdyyl07kqgx4vhmh",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
+  },
+  "external/google-fruit": {
+    "dateTime": 1621047842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ab76662cf3d6fa74e9fa5ae02d576786a93774a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wksa168xyk42yijf2idhpvzp8225ww165px3lc9ff9ph883g0ya",
+    "url": "https://android.googlesource.com/platform/external/google-fruit"
+  },
+  "external/google-java-format": {
+    "dateTime": 1613865811,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0eb116560d8cb66fc5a0188ddb83a5d2ac4ec548",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0g1i78c3km8lly0rb3b6axma754vxl9s9s48jfa0n2l565h2zk0q",
+    "url": "https://android.googlesource.com/platform/external/google-java-format"
+  },
+  "external/google-styleguide": {
+    "dateTime": 1588028419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5c1e47bb2b14e5e127cb9697eef95b06c28835c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1krqv8srgkf85hrj0shwz9j4xs6nx4jbj8fzjsbwjg1f589dd8iy",
+    "url": "https://android.googlesource.com/platform/external/google-styleguide"
+  },
+  "external/googletest": {
+    "dateTime": 1625706431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ce5396be8e40fe6c5527d695b04fa62e439a824",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hs29iy2v24vl66qqa85sdzvxlw7awjravhy53gjv9vnq2dzpb84",
+    "url": "https://android.googlesource.com/platform/external/googletest"
+  },
+  "external/gptfdisk": {
+    "dateTime": 1613865812,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42bb32b800062989613dde33c2a5081753241202",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "062g4a8s71lwdh2rkqjcdklbxsb551334rd07hhipygjllwhixzy",
+    "url": "https://android.googlesource.com/platform/external/gptfdisk"
+  },
+  "external/grpc-grpc": {
+    "dateTime": 1616720576,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "1b38befcd5a8372a91e956991b9cf1988ac4afcf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b8mdx9x08djdm8fss25r1dc2xbq1hb70zdm782k2rmbwp47axa8",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc"
+  },
+  "external/grpc-grpc-java": {
+    "dateTime": 1613865813,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "5486f84125f511b0e544535e99edb16bb6b98a95",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hwm7wb4zg81cx784piqc316ik0dihbm19iiyn3y22ahhkd3ma4r",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
+  },
+  "external/guava": {
+    "dateTime": 1613865814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d2b8115e7675750b56f0258f26a96e03873598c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hdvqppxkyafrpkv9qzs5c7kab57vi4xhqacbqbwfr7dj0plca56",
+    "url": "https://android.googlesource.com/platform/external/guava"
+  },
+  "external/guice": {
+    "dateTime": 1613865814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "23a39d691164872aa97720385ae32f526b5d542f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f9k7ribhyf0n7p9ff2jqk18qk1gim4vbln1bhiazdlfs3v5laws",
+    "url": "https://android.googlesource.com/platform/external/guice"
+  },
+  "external/gwp_asan": {
+    "dateTime": 1621047846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63f8521ca5d5e64107b6841a1051f1ce7ff06d76",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k71w8a36dhr4l5r661rvnmj4bxz49is9md78hndks4jqcnzn036",
+    "url": "https://android.googlesource.com/platform/external/gwp_asan"
+  },
+  "external/hamcrest": {
+    "dateTime": 1613952212,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f733d24a93ea6651bf7b63cbad2a8670ea9c0f94",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0i05qdmz9zd904apqxk6kdbffbydgj7k7n9yjvgrlw0m7xbynadj",
+    "url": "https://android.googlesource.com/platform/external/hamcrest"
+  },
+  "external/harfbuzz_ng": {
+    "dateTime": 1613865816,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "ea243455303ce2567a63b18381e1fd6114d4fdac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m7a4ln2v5dxy5dkcfdxyjsvsrsd3hjbxvmhb4gyx6am6lk6lca8",
+    "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
+  },
+  "external/hyphenation-patterns": {
+    "dateTime": 1588207981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "353d6608c31c1312e3b5f545e4ffda52a23ed3ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "184jm20gaz36kwskqkhax7n1allfjanax6rz3vqs70rjgsdvv5i4",
+    "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
+  },
+  "external/icing": {
+    "dateTime": 1630624039,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d128e205c9c2ccda26950ecd5807bef80d0a6333",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s4d26gpqhh1hzjknfxpjf3ch6qls9rvxbkfl0mwwkq6vzcvzss3",
+    "url": "https://android.googlesource.com/platform/external/icing"
+  },
+  "external/icu": {
+    "dateTime": 1641607364,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8325eedf8a37d70d3dbb84ddd70858f36e0c2ebf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0skwlgyyb8a3r1n0a3v508k7bf9i5dc17yvic9a7rk8sy46fzdbz",
+    "url": "https://android.googlesource.com/platform/external/icu"
+  },
+  "external/igt-gpu-tools": {
+    "dateTime": 1617843819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30c3af51750748221e42b923bd64da8b3b0db35f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c5cw7jgcfny776y5cqx7jcy8w4sqanx4b0qwrza6zqhgcc2cqhi",
+    "url": "https://android.googlesource.com/platform/external/igt-gpu-tools"
+  },
+  "external/image_io": {
+    "dateTime": 1613865819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7566ac6ce37115d2e1900cc66c593bd7d7e05b42",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0257h57ygzpj2vknj5k8whkznrsmqd2fhzzb9gl3rys9qgljjmvx",
+    "url": "https://android.googlesource.com/platform/external/image_io"
+  },
+  "external/ims": {
+    "dateTime": 1621047851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b45e3be645bf01e4f5d34f4423a50912449dd62",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1476c1dbyhsmvak2m5ffrgjxrf8ixigx5fsi5w805kfaifignmin",
+    "url": "https://android.googlesource.com/platform/external/ims"
+  },
+  "external/iperf3": {
+    "dateTime": 1613952217,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8feee9327f107e5199cccf3108a0486cc60d4fdc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1malr0g6ha2s0qb6qrr4cly161vcj2d4xy5wbnxj43pnhg0k4gqb",
+    "url": "https://android.googlesource.com/platform/external/iperf3"
+  },
+  "external/iproute2": {
+    "dateTime": 1622768643,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa552c078132cc513ef970116fbbc486ec0f2aaa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1527d8lzl7px9b84fxm1742nvz6d4h0r8nwibjh0d18j62xhz1mg",
+    "url": "https://android.googlesource.com/platform/external/iproute2"
+  },
+  "external/ipsec-tools": {
+    "dateTime": 1613613830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "245361e8b185dfe833a20e6edcec87e3adf00ea8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qz2058mcb75x22jarlls8ki6zhh9zd422nsn9wdzq29xk4a9cg1",
+    "url": "https://android.googlesource.com/platform/external/ipsec-tools"
+  },
+  "external/iptables": {
+    "dateTime": 1622768644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "359f9a6ffedbdea843f275c36ead45d7b0f14295",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0d2vfhzixszwl3nwch9f996yx7kafr9rn7fni41hbzrh8nra476y",
+    "url": "https://android.googlesource.com/platform/external/iptables"
+  },
+  "external/iputils": {
+    "dateTime": 1613613831,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2df1e99945fb09b746310d7df928cdfe8ee8fbd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q24bn8swbjsaa19kc6jdk2fw93cbipi6xbdh95w07pdp3v1xazr",
+    "url": "https://android.googlesource.com/platform/external/iputils"
+  },
+  "external/iw": {
+    "dateTime": 1613531703,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9caaf991aa126ec6164e4ef7d4dd824d36fce564",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01k08an490nvpzjyb7f6p8l67gxpkkg9fnc44f1lcc6ygb1rymsb",
+    "url": "https://android.googlesource.com/platform/external/iw"
+  },
+  "external/jackson-annotations": {
+    "dateTime": 1616972584,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cecba94069f01714d6b5f11347d66d6459ae3d88",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0apc5cffr02drfhfxri1fqs449i6bsk62a5kb0yfk73maya5wlw2",
+    "url": "https://android.googlesource.com/platform/external/jackson-annotations"
+  },
+  "external/jackson-core": {
+    "dateTime": 1616972585,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa08a99b9f53e7c584a651c522ac761a13762600",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c1amlrk7idijwhbhr2xvs822kc8cvfcmz2vxw9y03ylbicwnq42",
+    "url": "https://android.googlesource.com/platform/external/jackson-core"
+  },
+  "external/jackson-databind": {
+    "dateTime": 1616972585,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "287065810b868505c7f90ea864bef2adfa8cad2a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f4qf4dy0cyjv9cbmsvqawq0xp3r68snv5nidhj00jdnxcixh5zi",
+    "url": "https://android.googlesource.com/platform/external/jackson-databind"
+  },
+  "external/jacoco": {
+    "dateTime": 1639094606,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c7b444a01e89cc43e498ad4b7c7a14b111d8fcb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s5lr1q7ag4pv9s8nzfrgpwwmprw86c41b3605fvfz4sq2cfbs6i",
+    "url": "https://android.googlesource.com/platform/external/jacoco"
+  },
+  "external/jarjar": {
+    "dateTime": 1613531705,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1eae49c02653d8b4423819a581c865f6710b4150",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vn1j4pmksskgdjak31yc2vc1l8ph4m3mw06nsm0ql7fhbmy00yg",
+    "url": "https://android.googlesource.com/platform/external/jarjar"
+  },
+  "external/javaparser": {
+    "dateTime": 1613531706,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d076b1c67fd2577fc9cfc39fdb776871270af77",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l5hikg3bhk5fasrbwgbiascl8jwimacmpj0if2yqmbzcr6bglzs",
+    "url": "https://android.googlesource.com/platform/external/javaparser"
+  },
+  "external/javapoet": {
+    "dateTime": 1613613838,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72151ec80cc59e6d87d400d4877d954b85c79aa2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kwklwk1xjnnvwblfb5hga4ks1p3jdmh9dc30c5mifksrp8fsyr6",
+    "url": "https://android.googlesource.com/platform/external/javapoet"
+  },
+  "external/javasqlite": {
+    "dateTime": 1613531706,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "62eb149934f38289cb62bf71c61afa8f1c5d571b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1801cchvl1nys58y41qxk9if6wamrakpvpq6c2k3fj65053kizi6",
+    "url": "https://android.googlesource.com/platform/external/javasqlite"
+  },
+  "external/javassist": {
+    "dateTime": 1616972587,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4ad57e927c16255bce320ecd3201b649df93bda",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zfcnqlgyl59pv4h0s0nnc8lhgljpq5dq4p05anay43lnrszn3ca",
+    "url": "https://android.googlesource.com/platform/external/javassist"
+  },
+  "external/jcommander": {
+    "dateTime": 1613531707,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19e0be9527469d97ac8072ea1fcd3b783565c127",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m4a69hc9k4ixn8sah9rz9n10xgbz06swcfcsx96cjk0svpqyw4w",
+    "url": "https://android.googlesource.com/platform/external/jcommander"
+  },
+  "external/jdiff": {
+    "dateTime": 1613613840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5977bb9ffe8170ed7f251df20a79e0e4ea77e19",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j5bnl4lmm2288dvbma7mxyx0x52d3jn5d9wpd6idg44ii9ra1ap",
+    "url": "https://android.googlesource.com/platform/external/jdiff"
+  },
+  "external/jemalloc_new": {
+    "dateTime": 1613865829,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "38a7eeb555036a10813bd9560f1eb31cbfe819fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xbgga8jnizv1588dh1bd2av005wfmc69xzh867269j0523djcdr",
+    "url": "https://android.googlesource.com/platform/external/jemalloc_new"
+  },
+  "external/jimfs": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dcbc9acabcf246e7405f37457ab557bbbb8826c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lgiryx40d8a5854yczzvm5x6fydncj06vaclq4hw07rlwh7kvn0",
+    "url": "https://android.googlesource.com/platform/external/jimfs"
+  },
+  "external/jline": {
+    "dateTime": 1621047861,
+    "groups": [
+      "pdk",
+      "pdk-fs",
+      "tradefed"
+    ],
+    "rev": "7a70110d432a5d154e9b42e815b51c7e6958740a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qxn0vwnbz0sh9ax9ad52wg7373f48dcpq624bgfiypjgxfniqls",
+    "url": "https://android.googlesource.com/platform/external/jline"
+  },
+  "external/jsilver": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e653ae52f8a510792e1d67e670abe683a71b433f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "198msf9yaqbjy52aj4wfshdnxy5nyf1jwn7p2l4gndn1212vkqa1",
+    "url": "https://android.googlesource.com/platform/external/jsilver"
+  },
+  "external/jsmn": {
+    "dateTime": 1613531710,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "175e7641c055c4a3377d048a5c22815fe9368766",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0czn4n8j87svwm1kgsnjd8qzyriygcjlkwskqj2w79v1s113rlb8",
+    "url": "https://android.googlesource.com/platform/external/jsmn"
+  },
+  "external/jsoncpp": {
+    "dateTime": 1615680206,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a873c832f147125f9ebb345713fa45df076dd65",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00985j9k2yspfp6vi5rhnb4pwbzig055l3p08mq8k1sqm3q47vqy",
+    "url": "https://android.googlesource.com/platform/external/jsoncpp"
+  },
+  "external/jsr305": {
+    "dateTime": 1613865832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af45076444bb6c0c7c256b1b8fba9e5126389310",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q8sc6rb67j35r6jk55ap37b9bbrgdca0a8dyyy04ipx07ccw05y",
+    "url": "https://android.googlesource.com/platform/external/jsr305"
+  },
+  "external/jsr330": {
+    "dateTime": 1613613844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ec90efe6719538ff42d276b11ea571d698ba030",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s0jbmdd3vjaprwalf10i06n8sfmg1x356y5gz0jfimbsknva989",
+    "url": "https://android.googlesource.com/platform/external/jsr330"
+  },
+  "external/junit": {
+    "dateTime": 1615514583,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75c4202da1e9404b161ff60cb8df017101752eff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n7rfvpi0pg1m6qjh6wza310gf01p2kv564bnkf3dfsjsczfs0nb",
+    "url": "https://android.googlesource.com/platform/external/junit"
+  },
+  "external/junit-params": {
+    "dateTime": 1614308875,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "457e672a31a76965120d7e3f36a5b51ec4430fa2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wda5sh5jy1ww8y50nfsw508ijw185h6g0mn5nba9iv95zs44zmq",
+    "url": "https://android.googlesource.com/platform/external/junit-params"
+  },
+  "external/kernel-headers": {
+    "dateTime": 1621047865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "886a7910a9e3512e55b6c03367ad042e16ae1258",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vj1hy930nr1pxrc0jdm9j4fhxnlcr05lcg6700ai5qqgz9i06rw",
+    "url": "https://android.googlesource.com/platform/external/kernel-headers"
+  },
+  "external/kmod": {
+    "dateTime": 1613865835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "767b70e1b76673bbd0324c8b54a6ba4f6fec7f98",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xv7xwkz8mhn41fq7jv5hq2fy9r2l4srnwkcf3xbaca2ai177g1m",
+    "url": "https://android.googlesource.com/platform/external/kmod"
+  },
+  "external/kotlinc": {
+    "dateTime": 1621047866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf1c7dd055a0bc4fb73ce962eaa0b6e04667e2ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0dzms659jz4zjm07pwissifi7v57xhmrlzkx7j63s9za6az63719",
+    "url": "https://android.googlesource.com/platform/external/kotlinc"
+  },
+  "external/kotlinx.atomicfu": {
+    "dateTime": 1621047866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11f1a993bb4b477a73107d8aa32551c0a78261b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "14zbi4fc70xnspx5kn6jdqq9yf8p177qmhx2bprsflrcdb1np9r5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.atomicfu"
+  },
+  "external/kotlinx.coroutines": {
+    "dateTime": 1621047867,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68d93101100d3acc6525b1086a295d4b1de97fc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xg0g0yn8qzk23p8vvh4laavmvinbmqch5ib1ca44g6fkf7f7df1",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.coroutines"
+  },
+  "external/kotlinx.metadata": {
+    "dateTime": 1621047867,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61eb84a9c5660671c017220749a7daf1ce652804",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0fz2mbsb51b6h5d8a1p099iccxi4ll2w4cnw3i8yikjmq5pl64k5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.metadata"
+  },
+  "external/ksoap2": {
+    "dateTime": 1613865837,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "773b3e423945afba352683beaa5226893ec5e31a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kvfan6g57xczcv075439zlqaw3rxmi5mdz7rrfjxv2qyh3sp2v2",
+    "url": "https://android.googlesource.com/platform/external/ksoap2"
+  },
+  "external/libabigail": {
+    "dateTime": 1617757431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d82cfc8a87f11b6079c7a69f33c70b4a5cd4e94d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13rn7mvpwsvahryp1c8ka6rghblpa0vjsvrji3g86map3ij0shac",
+    "url": "https://android.googlesource.com/platform/external/libabigail"
+  },
+  "external/libaom": {
+    "dateTime": 1624410259,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af317f35a906194709ab1444027a6f16e8b7d7f6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01v88ya40i58w9fmwc0ak4rl9l2sc5rm9yyh7j8r388ynhy1rldb",
+    "url": "https://android.googlesource.com/platform/external/libaom"
+  },
+  "external/libavc": {
+    "dateTime": 1639094625,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3172b23b82d0b21dde79c4ff481d75b18859deae",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c87xk9v7g7s1dylv7v8j53ma2h74mfxhbjcvzxcmg19pcf7qdxv",
+    "url": "https://android.googlesource.com/platform/external/libavc"
+  },
+  "external/libbackup": {
+    "dateTime": 1613865839,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "45a5c0213364570169bb985921934b8f26f1b61b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ll3ryrbrh2xz90b6r928jck1q0ghnq8wrn5zdy4y9w6naxjy8vc",
+    "url": "https://android.googlesource.com/platform/external/libbackup"
+  },
+  "external/libbrillo": {
+    "dateTime": 1621047871,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac2d6b669aa9fdb2b4888b07e0d0c2fb81d42cf0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0p9fnd8xjv5xf7jbkp7vmqzfmj0ip219lpmp4d291wxzc1jhy1cy",
+    "url": "https://android.googlesource.com/platform/external/libbrillo"
+  },
+  "external/libcap": {
+    "dateTime": 1625706470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f025e642d3c669bdbed04acee3c2d29499dbbad",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f4jkab7ws0sjzfgfvrf6mwrrl8q3ghnm885l8nkrlghqd7s3j9c",
+    "url": "https://android.googlesource.com/platform/external/libcap"
+  },
+  "external/libcap-ng": {
+    "dateTime": 1613531718,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1781e831b50bbe5b1953f04c6c4d0abef0e6820d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dsr6r0s5m2aqm2wz9zq023abgvjxdrajjnsfrs8ssi30zxzrxyq",
+    "url": "https://android.googlesource.com/platform/external/libcap-ng"
+  },
+  "external/libchrome": {
+    "dateTime": 1625706474,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d00806ef7574ccbffc9f0338baec6f6e15327a41",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mi55n6sb3wzc67a279cnabhx179s8dh4bh0j72ngwbaj9sln1fr",
+    "url": "https://android.googlesource.com/platform/external/libchrome"
+  },
+  "external/libchromeos-rs": {
+    "dateTime": 1613613852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4791ed36c41031de4913ca6636eeb8c172c33b77",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0lkwghnsaniv3v9lbc1r011ff4dk9d0ja9xzxxk4b58xds6zjpil",
+    "url": "https://android.googlesource.com/platform/external/libchromeos-rs"
+  },
+  "external/libcppbor": {
+    "dateTime": 1642032352,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3f70a9450aa4867a7d1a2633c55fdcae557ddbf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bsania9zv0raww5ki7b4sf8p63x15fng14zr2rx2wn4mwplkiaq",
+    "url": "https://android.googlesource.com/platform/external/libcppbor"
+  },
+  "external/libcups": {
+    "dateTime": 1613865843,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "7bfd5e5e75635046b71bd5a73aa5450bb2dce60b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1986mbxc28sxi377ydjj8b7mdhwwvsb1df4n3da1cf0m9rrh90vg",
+    "url": "https://android.googlesource.com/platform/external/libcups"
+  },
+  "external/libcxx": {
+    "dateTime": 1625706478,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c13261777f8487c066923146a9cf631321962b1e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qvz2zyl6j8pnwbjv1rb7kqvjgq13nmbym2zabb64nch2h0vfs4w",
+    "url": "https://android.googlesource.com/platform/external/libcxx"
+  },
+  "external/libcxxabi": {
+    "dateTime": 1617757437,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c74b2fa56a375da1f8f2905b385fabcaeed416e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11zz64d974bs5gm1b4vin5bjvq9a13h9gzjhk68lm4ksi1yaga96",
+    "url": "https://android.googlesource.com/platform/external/libcxxabi"
+  },
+  "external/libdivsufsort": {
+    "dateTime": 1613613854,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c72544a3e91d8fdde1e6ed5bdc7eb639e5d7c1d5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lh8s06r0fvkjsrdb0ns3iv0n97sibvbv3jy97c9s0zp29mfi3wg",
+    "url": "https://android.googlesource.com/platform/external/libdivsufsort"
+  },
+  "external/libdrm": {
+    "dateTime": 1624496922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f5df9bf9b2f4a572ef62a08edf982fc6f36e7d40",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v85xcr4k6vmdplnq3apm20yvd3jzwsv1rh570prrj15ba552alm",
+    "url": "https://android.googlesource.com/platform/external/libdrm"
+  },
+  "external/libepoxy": {
+    "dateTime": 1613865845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b96bda08a537d379dbdd00f37cf16a6b19f5189a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wdjlwf9cvy1wz3xymrxmjxlqj1w7zxd2vxy0g90bnpslwcngc7l",
+    "url": "https://android.googlesource.com/platform/external/libepoxy"
+  },
+  "external/libese": {
+    "dateTime": 1613613855,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9bbd43b8425cde08058c4272f8f4e9b6bc6de9b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0g10bprh155ys18zvsxs0annjzh39cnyxfldy9zbxcpcj5dlvirl",
+    "url": "https://android.googlesource.com/platform/external/libese"
+  },
+  "external/libevent": {
+    "dateTime": 1625706494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a88c510ed3614dd3101c1f13f5c3e2e1155609a3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03gjyf91xycyd2g8nfkvvjg1kibvdm1dlzxn9x50sbhbig43i9gx",
+    "url": "https://android.googlesource.com/platform/external/libevent"
+  },
+  "external/libexif": {
+    "dateTime": 1639094630,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddfc8d32d0ee4905ac583813bf45c738c785f94e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ppfmlnbh8vmhicdnvs4vfmsfg608pvmq60g8yylbr44c2bg208a",
+    "url": "https://android.googlesource.com/platform/external/libexif"
+  },
+  "external/libffi": {
+    "dateTime": 1613865847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e5deaa78c696a8ad341df548546dd092cb51c064",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1kfagm0922z80061324a4w74231aic3p9wsw6qi67nasf7f1fbjs",
+    "url": "https://android.googlesource.com/platform/external/libffi"
+  },
+  "external/libfuse": {
+    "dateTime": 1621047879,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19067258392977f0c7f67ec03a4ace30e165dd7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10c514vzj2mihk97d69zxzdqgxc65fyqkllyx5glfsqhsr156lwy",
+    "url": "https://android.googlesource.com/platform/external/libfuse"
+  },
+  "external/libgav1": {
+    "dateTime": 1621047878,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c628e6aef5d410ab43d732234224bc9996009ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0w3rkagg3c83rf8j0i6409jxx0wya7yxyx5xx3kgq89axymlb7gx",
+    "url": "https://android.googlesource.com/platform/external/libgav1"
+  },
+  "external/libgsm": {
+    "dateTime": 1613865849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "558f595be6c835a4a5fb5b56b4ef96db70a035bb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13np111m5nqvzza0mllnvmm0frvazy1nmlhp6lfn31d00vdrn936",
+    "url": "https://android.googlesource.com/platform/external/libgsm"
+  },
+  "external/libhevc": {
+    "dateTime": 1625281482,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d5194f202b7d91ee8c4b092c95eb0f2707b509b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pwsmr437jags5xyxpsdiqg4axjp3n9i5fpcfcp1d2mha3win6ry",
+    "url": "https://android.googlesource.com/platform/external/libhevc"
+  },
+  "external/libiio": {
+    "dateTime": 1613613859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ef2dfb9e279aff7d526dc83c2afd059654d805a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "049lcsyzmzympsk6s3rphcmql3y4rs2c1fsh6bfjpg4sdqjcf5w6",
+    "url": "https://android.googlesource.com/platform/external/libiio"
+  },
+  "external/libjpeg-turbo": {
+    "dateTime": 1621047881,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6f929b33cd726ce845c82cc196feebbbb4f86de",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "003d689i5zbmfv9xqqi3bfc1fb0q9xl37x8k0lb5lv4pxr27i432",
+    "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
+  },
+  "external/libkmsxx": {
+    "dateTime": 1613865851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff01082a5d9d08847dd482abde84ba7f021852d7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f3vr8khghmcw1pr9kn71ql7s1a0vwnclmqgm2dl27cbkfzf4qmx",
+    "url": "https://android.googlesource.com/platform/external/libkmsxx"
+  },
+  "external/libldac": {
+    "dateTime": 1613865851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35964eccc25ab99b296f9de3dc5178918516f3fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wsy4g8bllsnhdca0s4kh7g986qixrqc3x4pn0jlwg8hnzdc26bg",
+    "url": "https://android.googlesource.com/platform/external/libldac"
+  },
+  "external/libmpeg2": {
+    "dateTime": 1615075457,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e1a3fb546a848258883b8b41514177574311462e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04qb3lvjnizsyzs59zdxw1i9ng1dibnn3a15szzw8dmfrdwdfjv9",
+    "url": "https://android.googlesource.com/platform/external/libmpeg2"
+  },
+  "external/libnetfilter_conntrack": {
+    "dateTime": 1613531727,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9fda0567d312300f202aacc7e8a93da3f610dd9f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v6lpqqw7h19l9jzs43apw4kws39av9bhikarzlvym5xs3b6jhm6",
+    "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
+  },
+  "external/libnfnetlink": {
+    "dateTime": 1613531728,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad5339231a4f167cb7d73784c8e48567b9c1bb7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c6w4mi3xc6gxly949fh30ni84yk5w0bwqmipv857hpbq4cl3p9n",
+    "url": "https://android.googlesource.com/platform/external/libnfnetlink"
+  },
+  "external/libnl": {
+    "dateTime": 1613865853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a290d3a63da3b74a7265162d618ee196e4bc1491",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f54wdvb46iwmm725yx2hj6nmfh6g3sfiar27m6qd2i01ah8fb8i",
+    "url": "https://android.googlesource.com/platform/external/libnl"
+  },
+  "external/libogg": {
+    "dateTime": 1613613863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6e59233c48b31058ecdcce08310b9087db2615f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rdync9bnrw7gxwn69nkk1y8vn42il7145jlq9ry247qskd06hg9",
+    "url": "https://android.googlesource.com/platform/external/libogg"
+  },
+  "external/libopus": {
+    "dateTime": 1633043459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72597c4b99550fa0eb395933d1f909ffafe2b823",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0z39qr4nd2cgsckhzif4dbjchxqgq72xrql7ckjwyp769g599pz9",
+    "url": "https://android.googlesource.com/platform/external/libopus"
+  },
+  "external/libpcap": {
+    "dateTime": 1615075459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e05962ef209cff3304b14694f417ed83d711658",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16pjxifk3vmzkb66ga85ngcwmx555nzbms57fwm66k19v526m1m7",
+    "url": "https://android.googlesource.com/platform/external/libpcap"
+  },
+  "external/libphonenumber": {
+    "dateTime": 1613865855,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3bddc645347622cadfac15cf2dbe60c17efae85c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rn08wi8q4b6bb00rcchiv4zida0i7dz9vryfkadb15k4mqh79d4",
+    "url": "https://android.googlesource.com/platform/external/libphonenumber"
+  },
+  "external/libpng": {
+    "dateTime": 1616547824,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5963c3210429d9bc673709db89ec280bed698d0b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "177jf1vizmmkp7zx4kh99jp66zaqqxkcj6zgk3n080qc91jh3xbx",
+    "url": "https://android.googlesource.com/platform/external/libpng"
+  },
+  "external/libprotobuf-mutator": {
+    "dateTime": 1613865856,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd115d7a1815ade047f9b7cd322803fcb391cf35",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qd6v41shmz918cv8h2jbgh3pvg65mk7c9m03afzz8gy26zl6rai",
+    "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
+  },
+  "external/libsrtp2": {
+    "dateTime": 1613865857,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d99a371917aea1cb7f4e79909c379ccaacb18e6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mr1gb60ryh71makvab277w1lrwlk7bv6alhh369jikm5sj78dyw",
+    "url": "https://android.googlesource.com/platform/external/libsrtp2"
+  },
+  "external/libtextclassifier": {
+    "dateTime": 1636416232,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b7889d09cae6579ef9ffa99acaddff0cef310365",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ibclamamp6g4g8887sx45g42ms5xharrjiqxqq4wyv5zkqmgwm3",
+    "url": "https://android.googlesource.com/platform/external/libtextclassifier"
+  },
+  "external/libusb": {
+    "dateTime": 1613865859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21c9f1c2561958394dc9144a1ec3d30b387c3768",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v007hjbbbs07mq2y84511mv31b8h8hhac7hp2lqmrwp8f2jldxx",
+    "url": "https://android.googlesource.com/platform/external/libusb"
+  },
+  "external/libutf": {
+    "dateTime": 1624496935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f0523cf55c7c6b1269dfc4e7f694bda388752b0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d0d5ljsb4amc6a8xwkx1hmzy712gww5vsh4fq0926nnl195vp8s",
+    "url": "https://android.googlesource.com/platform/external/libutf"
+  },
+  "external/libvpx": {
+    "dateTime": 1626224670,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "185c2373cd38020d30cdc73111456ad67149dc9d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y883jrkywpy64xay77kxh1j2ijc77lmggyby8860y608a1227f4",
+    "url": "https://android.googlesource.com/platform/external/libvpx"
+  },
+  "external/libwebm": {
+    "dateTime": 1613865860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1bbf7c8a778e1e940a588fb06b15ef8fb003ad0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kkb0mm6vqbv1ri6br6d4xisvbgx947r8d9vynbbw9bl03g2fbpp",
+    "url": "https://android.googlesource.com/platform/external/libwebm"
+  },
+  "external/libwebsockets": {
+    "dateTime": 1621047891,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bdc6e9ce07cf4334d6d47feb49a40e2a80f94205",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "14l852ww7vwc5vpi0b5vdqall31afz743qyqs67kdy1xdzz906mq",
+    "url": "https://android.googlesource.com/platform/external/libwebsockets"
+  },
+  "external/libxaac": {
+    "dateTime": 1615075466,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3c20ea44fda2da9c7c41043dd24c81b4c162143e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k85nq28kwa9jhma9xypm9i3p1317njryhcsvmiqk0w3cn5xxlr5",
+    "url": "https://android.googlesource.com/platform/external/libxaac"
+  },
+  "external/libxkbcommon": {
+    "dateTime": 1613865862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69c560a3f5bc5d232a831e2021982c0decdd4885",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ffqp52cwhvb7kkkvr993sj0z63jk7cx0jkv4fb3apjczp8rlnlx",
+    "url": "https://android.googlesource.com/platform/external/libxkbcommon"
+  },
+  "external/libxml2": {
+    "dateTime": 1621047893,
+    "groups": [
+      "libxml2",
+      "pdk"
+    ],
+    "rev": "e92ac6f10355b9f5f57cdec168158f3ce92deec1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kni8714vrwwrrbh3pg3fa5q7fillik22qzsrgy2i2d8y1jsbgp5",
+    "url": "https://android.googlesource.com/platform/external/libxml2"
+  },
+  "external/libyuv": {
+    "dateTime": 1613865863,
+    "groups": [
+      "libyuv",
+      "pdk"
+    ],
+    "rev": "566cb5ae37b452875aa1b05d213b46029bce9789",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wqd724hbmyk1nqyz2ixk14dq074897raqnb72h8zfbshkxrdvp4",
+    "url": "https://android.googlesource.com/platform/external/libyuv"
+  },
+  "external/linux-kselftest": {
+    "dateTime": 1621047895,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "4ec7075190779f08529c612b93abeca5f3c51f71",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wfr5vcjbswirbk0dla14bkz7q34imxd7l7r311c82vqf4wdk04b",
+    "url": "https://android.googlesource.com/platform/external/linux-kselftest"
+  },
+  "external/llvm": {
+    "dateTime": 1613865865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f32021d2349ca68d450782d74fb708b976c801f0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vsbyazjkpdd4gpmr9cbj94bl4f3ddhqx56rz9apyd50bzbi8dnb",
+    "url": "https://android.googlesource.com/platform/external/llvm"
+  },
+  "external/llvm-project": {
+    "dateTime": 1607536677,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3da12ac8a0e6931a477d65ffd4935970b453b8b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ikzmd238agp9ldng39y1yn4yj2nqah251h5nrsp3b97qvd05wk5",
+    "url": "https://android.googlesource.com/toolchain/llvm-project"
+  },
+  "external/lmfit": {
+    "dateTime": 1613531740,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0092fbbf359464b28f8565ad0da10c58406e5d33",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11nb4xcnbnqgq0b15hqdyppixhyri8kwymbvaznfi1y370jw66bp",
+    "url": "https://android.googlesource.com/platform/external/lmfit"
+  },
+  "external/lottie": {
+    "dateTime": 1623891890,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94742a206088224ca8b73a2fd1d1c2ab937dea26",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xbfmzrpj7j32s4m7ygvhbx4x4s3gdvzqn07jkh2bmi7r3kws8nz",
+    "url": "https://android.googlesource.com/platform/external/lottie"
+  },
+  "external/ltp": {
+    "dateTime": 1628975035,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "5925d52050faf71accd5850fecb55c869bab86bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mqyz806pbqm0m40p3lnxjnbnkh7y4rasymk1n8c2a48dm6crxdf",
+    "url": "https://android.googlesource.com/platform/external/ltp"
+  },
+  "external/lua": {
+    "dateTime": 1628903188,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b76c928b9356b6f616ba00c3c3e9c7db86c330bd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1anzd8bz8vm224z62km4v6i6jvqdys18kzrh0c6ss6gq6v85l1b5",
+    "url": "https://android.googlesource.com/platform/external/lua"
+  },
+  "external/lz4": {
+    "dateTime": 1613865866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b81b604d68e1f3d8215eafda260c7f3716ff6715",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z9qlmhzzd6zssc897sy2yz2iqpq812qfpyszxv5nsmj9ml48swq",
+    "url": "https://android.googlesource.com/platform/external/lz4"
+  },
+  "external/lzma": {
+    "dateTime": 1625706528,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1ca0fe196acae3b70dcdac121083e08b9160d6ca",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08wi3bisnknkz26iw3r3lna9zxwnmbql6iz550793nbq8bnkvci3",
+    "url": "https://android.googlesource.com/platform/external/lzma"
+  },
+  "external/marisa-trie": {
+    "dateTime": 1613865868,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "59b8f80dfa3de7fc36155d45c1fe0ea97b63b56f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "131spy2m80s752028pqqkhylnd2y8ibz1bajdssxjhw6ybhfh4yc",
+    "url": "https://android.googlesource.com/platform/external/marisa-trie"
+  },
+  "external/markdown": {
+    "dateTime": 1588189365,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1542c1f866ee569219bdbfe8f9788fa3cce1ca34",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1g8ziq2pf7gnyqcv6cbpigs7vaghd269lxzqvq3gkmqq5nvvp51k",
+    "url": "https://android.googlesource.com/platform/external/markdown"
+  },
+  "external/mdnsresponder": {
+    "dateTime": 1613865869,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "28337b51d50c877c591ca8bed169500ff513b9ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11fw71ghxij6q9zrn3bp7plz05yrw0a8w9yjkdcfjiicf4may28f",
+    "url": "https://android.googlesource.com/platform/external/mdnsresponder"
+  },
+  "external/mesa3d": {
+    "dateTime": 1621047900,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "86249c59c109a6cbdfb5e410c2cd13218670a98c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gj14c9wnhqpfpf3wkvfpf967rcsf151clamr6d1prf36m917a43",
+    "url": "https://android.googlesource.com/platform/external/mesa3d"
+  },
+  "external/mime-support": {
+    "dateTime": 1613531744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e04627a78940eb328c1c6fbee590c2e465133eb6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lkwshpnbp0hgz4azb63c83xdk8hrqywcbh501frjc8d5zgxvm6s",
+    "url": "https://android.googlesource.com/platform/external/mime-support"
+  },
+  "external/minigbm": {
+    "dateTime": 1639008299,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ed1a3461ed8305399821a7afedf46e6d05ea72e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rk16cf47yc4mqdginjifshzxlmiknba3jckp9kkfx0n3kmilcvz",
+    "url": "https://android.googlesource.com/platform/external/minigbm"
+  },
+  "external/minijail": {
+    "dateTime": 1621047901,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d534f8a54beb7ce63a210818c8b78f5aeddfe1c2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18341lkx5k0svyj3z60cdv153h8aq0fvc00dssxm3rssim4ax3gl",
+    "url": "https://android.googlesource.com/platform/external/minijail"
+  },
+  "external/mksh": {
+    "dateTime": 1613865871,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d47b527833c7d7a3b1af5c3e55fb87e5a42ac679",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d8xqv9r3qa7vvwqs6ifpl77j5whvn67dk0b4xgfbsqf2rryrk71",
+    "url": "https://android.googlesource.com/platform/external/mksh"
+  },
+  "external/mockftpserver": {
+    "dateTime": 1639793023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4cda83a2d5431b2996fe7f8952cb673285bd8f13",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13v4wf8ympfh18w233jzc9vy2sddh1qkrbkrwcmzs6smw84z5d4m",
+    "url": "https://android.googlesource.com/platform/external/mockftpserver"
+  },
+  "external/mockito": {
+    "dateTime": 1613865872,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "66bdd8871531856c9ee25bfc4c5d3af72a46ad79",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0fvgaw450rhb5cmq2blh2y4zi86x23jjngrskprz9k4is3yw8zn9",
+    "url": "https://android.googlesource.com/platform/external/mockito"
+  },
+  "external/mockwebserver": {
+    "dateTime": 1613531747,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7cc7b8ed241075b8a04d9846cecfdf1af6cfa662",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yxf1fgfkb7kgzz5pqac8171952gfviv2043njxnxbaysmy5sn1n",
+    "url": "https://android.googlesource.com/platform/external/mockwebserver"
+  },
+  "external/modp_b64": {
+    "dateTime": 1625706541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "079a45941f0fbca6d791c0add625632e0b4f0891",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l11d9qw0qlh6ab2ybwciscspqscdydj23q5998va4qxpapdcrjg",
+    "url": "https://android.googlesource.com/platform/external/modp_b64"
+  },
+  "external/mp4parser": {
+    "dateTime": 1613531748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9aff1abbf2c8ad98a928b9d685490135f426411f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "167wv822ssx9n3z0bnbk72p532wy7ck7a0ayi0rrppz5whilg262",
+    "url": "https://android.googlesource.com/platform/external/mp4parser"
+  },
+  "external/ms-tpm-20-ref": {
+    "dateTime": 1613865874,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d76da834b8bf9e933ee7f29a5f2e56b1fbdf269",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j5gdirvbvqr3kw0d212s35awisanlmc1avyfk2ky7rqa82yqp85",
+    "url": "https://android.googlesource.com/platform/external/ms-tpm-20-ref"
+  },
+  "external/mtools": {
+    "dateTime": 1621047905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44f86d1145ea7f1eb5ec9e0b73772aeaa45af35d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0i0dbrkfj889qx63dz0iwvs6klablp5ydyria9s4j21bp3zmgzp4",
+    "url": "https://android.googlesource.com/platform/external/mtools"
+  },
+  "external/mtpd": {
+    "dateTime": 1622768696,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c4d5143dd03a190ca008eb59e4443614bddfd0a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kgmcl1ll4mpzfwnl95y2qhv7d825s4i3rkd36wgvg5h6jkf9zjv",
+    "url": "https://android.googlesource.com/platform/external/mtpd"
+  },
+  "external/nanohttpd": {
+    "dateTime": 1613613882,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43158da0b1bd348de22e6ae24ed20ce948d8bb63",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gq2hhgy0rq5ws42vjkqjdawn6dns6kl8cb5h46lx8psvh7pdgz4",
+    "url": "https://android.googlesource.com/platform/external/nanohttpd"
+  },
+  "external/nanopb-c": {
+    "dateTime": 1639526642,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b56291fd718d5c6eea0ca13ffa67e68103154eb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r2mnfxskl50figqqvas1zs0n4zd9hy5qa2g7jfnlm5q0pzwpyjr",
+    "url": "https://android.googlesource.com/platform/external/nanopb-c"
+  },
+  "external/naver-fonts": {
+    "dateTime": 1588181530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3af2db73e75529bcf1f254747d72797aba203c47",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ihcg6mpzf8lnygnn82l5z8pv6m8iyw0mzsc76wmyn9j7wdyhg9s",
+    "url": "https://android.googlesource.com/platform/external/naver-fonts"
+  },
+  "external/neon_2_sse": {
+    "dateTime": 1588290974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07a3aae500ba4a907fa3e0e5cb0bd27673dd2ed7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12ivga8rnf1ibchrwczfs38n8kpjrjkyrfn9hav2w8z3xdrhz8p2",
+    "url": "https://android.googlesource.com/platform/external/neon_2_sse"
+  },
+  "external/neven": {
+    "dateTime": 1613531751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43776cc8ef09ad4bf3e239de7500b4c9da12722d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wl4zg5zkcgnrj9lzvm6l49awpar07hny1admj6hi06k0w2id3f9",
+    "url": "https://android.googlesource.com/platform/external/neven"
+  },
+  "external/newfs_msdos": {
+    "dateTime": 1613613884,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c15a95e9e91e48843080cb62acb166524953c53",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0shrw82gl4bsvsdyk21fwmjvdk9mjg24ylng2jbabki63xp4dmgw",
+    "url": "https://android.googlesource.com/platform/external/newfs_msdos"
+  },
+  "external/nist-pkits": {
+    "dateTime": 1613531751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "53b54220e7d9699d6181c0fc53df30e7d6483ce4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xdr99aqr4g7drh4gmr88ah0q2im8aq5cs8w834qanygpg694dr1",
+    "url": "https://android.googlesource.com/platform/external/nist-pkits"
+  },
+  "external/nist-sip": {
+    "dateTime": 1613613885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7974808cefacde2bc952fa79cbbb7bae49eeca0d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0k5qg8bbg2l6g3fv9x4bikpa7b0sf08lacayxgm3pnpyn2bmai43",
+    "url": "https://android.googlesource.com/platform/external/nist-sip"
+  },
+  "external/nos/host/generic": {
+    "dateTime": 1632604002,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c107bf4e7894bb544d9f74afa3b3f3c102c58735",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jwxahjz1qib7l5bsjzinjl0a1incqvns2msrl469gszdawvix7a",
+    "url": "https://android.googlesource.com/platform/external/nos/host/generic"
+  },
+  "external/noto-fonts": {
+    "dateTime": 1637373853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40b214b2d261072b9ba0661bcbac5e1e3b2ea5fb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1q470f9vdr3nrygwfggjdi7h7wc9g8h7alhc2cjvd5czmwzhwkqc",
+    "url": "https://android.googlesource.com/platform/external/noto-fonts"
+  },
+  "external/oauth": {
+    "dateTime": 1613531753,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "265a0261b7b9d0a2a1ef8c57804ca046f16aa09c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1iy7n0krrann5fkm46znlm1q598wzr4jlxv17d5xw4dwc5jp6p5n",
+    "url": "https://android.googlesource.com/platform/external/oauth"
+  },
+  "external/objenesis": {
+    "dateTime": 1613865881,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ed4934941b03de0e3040f4b8610eddad7cc4805",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cvmp0wrf5lqag44wfjil3bdq4zkdc3dm4fr49g6qcchd7h65gmm",
+    "url": "https://android.googlesource.com/platform/external/objenesis"
+  },
+  "external/oboe": {
+    "dateTime": 1627002287,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c9e661590cbdd64d91a3cd1a01473fd16713f2aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z95091yv1akx277a4fsy0hxdlav1b7kn969b6cn5z6cnzm66fyl",
+    "url": "https://android.googlesource.com/platform/external/oboe"
+  },
+  "external/oj-libjdwp": {
+    "dateTime": 1614909846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ad11039e1a5deb7fd01954a14152a9b2530fbe5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l4l046zxwqw991qadiawlwsrbv2chwh0rapbqry93l4ygikmbqf",
+    "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
+  },
+  "external/okhttp": {
+    "dateTime": 1628975052,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "921e4ebc7cd0d4c3921e2c39d1710259e2946747",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "097dqcz04kxb379dvrhzkgn7w3dm65lwpq0g9hadqaq6pv1ymf9r",
+    "url": "https://android.googlesource.com/platform/external/okhttp"
+  },
+  "external/okhttp4": {
+    "dateTime": 1612297295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "583dbbcce9f7b3a70ad2b27712154152efaad6b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/external/okhttp4"
+  },
+  "external/okio": {
+    "dateTime": 1621047914,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fcde7bdeba6950196ffd98ea90ed7c89f8117e39",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ln8mr5cr324v8dzjk35hhy0333sa74j9ay3xns35yk7g2pprxbg",
+    "url": "https://android.googlesource.com/platform/external/okio"
+  },
+  "external/one-true-awk": {
+    "dateTime": 1617419034,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d65f6523d3118c41def7ebbfed69727757af669",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1g7v3ayb691jhr8fpcrdz5a5396qbilf9gkddx5wvl52cxrfd72j",
+    "url": "https://android.googlesource.com/platform/external/one-true-awk"
+  },
+  "external/opencensus-java": {
+    "dateTime": 1613865884,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "3279463c13a849c4c3f4d4494bf90176e962212d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1i22bm033fn223k4hjiqn55aj1xr3mvcgl6880cqhr2i8cnw7ij2",
+    "url": "https://android.googlesource.com/platform/external/opencensus-java"
+  },
+  "external/openscreen": {
+    "dateTime": 1617757480,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddfb121e7677bdb695ab0b752510926a3007e447",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v1y1ar5ak3mn893gi7jxrfkly7wl45m84gyj33pspcni831bsfc",
+    "url": "https://android.googlesource.com/platform/external/openscreen"
+  },
+  "external/openssh": {
+    "dateTime": 1614045897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "642b1ec41955298e6d109625762dd0b7cde02e38",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ch7jqxxw4cv80w60k9nkfpxjp3i60xd575rchlyizvlxka6zwjq",
+    "url": "https://android.googlesource.com/platform/external/openssh"
+  },
+  "external/oss-fuzz": {
+    "dateTime": 1617419037,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b11838d4f86b299a9aad3b089c9cd8602193107",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12ysv0nncqlx7gry6m10ac6x34y1kqs3y9jg5bzkb6dsb677mi6r",
+    "url": "https://android.googlesource.com/platform/external/oss-fuzz"
+  },
+  "external/owasp/sanitizer": {
+    "dateTime": 1613531759,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af364df23290d0ddadf7c19a42e9671522df17a3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bw90dnh8irryj7sn0n0swlx9vllvasxj8r01gh7prmawi97lh9r",
+    "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
+  },
+  "external/parameter-framework": {
+    "dateTime": 1613531760,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72a00f22b02021a0613fa5af47da0103f9b3a573",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bf4fjy9p4fz7rp2plga2zam62s2k8jcwgn8mg0qka7jkddf1qrb",
+    "url": "https://android.googlesource.com/platform/external/parameter-framework"
+  },
+  "external/pcre": {
+    "dateTime": 1613865888,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8251b0ae22c86691d19c3bf0251d6f21f689a99c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dpm303wwx264bc6hxqlrfkfmavqwzb1k914gpxmdgfn0iv7hn2m",
+    "url": "https://android.googlesource.com/platform/external/pcre"
+  },
+  "external/pdfium": {
+    "dateTime": 1616461455,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b007fd594044d500b8970024082ae5b2868ab3fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1g50kxs8y74bklsmnjzazd4nk8ajhksyapm5r0g2qidb3nmx3cl8",
+    "url": "https://android.googlesource.com/platform/external/pdfium"
+  },
+  "external/perfetto": {
+    "dateTime": 1642284248,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a9074eb8794050dda6e2d4bb03c3cd98038a5a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f1dzp2vf3z0yjfvdnd7a5cadxwdrlfavaah5a8in34dn9imp7pm",
+    "url": "https://android.googlesource.com/platform/external/perfetto"
+  },
+  "external/pffft": {
+    "dateTime": 1613865887,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d57f667d14f78fa23630fab33831db8b785355a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qgf52lcq58ixhrhqnwcpixkkbrd586n23r14yikvbqhspdfar0s",
+    "url": "https://android.googlesource.com/platform/external/pffft"
+  },
+  "external/piex": {
+    "dateTime": 1613865890,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "89f86e032967692e05501f43ec8bcdd8134ba35f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05lyk7vmhf7kq9bcwpg07nwvx1pdadjv1g3c1ny2wq2l2jchbps3",
+    "url": "https://android.googlesource.com/platform/external/piex"
+  },
+  "external/pigweed": {
+    "dateTime": 1621047922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "671bf32b13cb0c43decf0480509e32e289de28d6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zh25gjyykp19xpg9jh5xjqaz87j75nb5qzqg08gf7smspb34rvz",
+    "url": "https://android.googlesource.com/platform/external/pigweed"
+  },
+  "external/ply": {
+    "dateTime": 1613531762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "32a7850184bd058f31d7db3155092a8ba382f035",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04ran6mcqvfm06d2pqw9x62vwdr782h14xmn9zw8c7pw0hqzkqfz",
+    "url": "https://android.googlesource.com/platform/external/ply"
+  },
+  "external/ppp": {
+    "dateTime": 1623114302,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca48d666d401ece84012898c06aa501d697cf74f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x8kmf219svcclr8yv94f06y9m7i4hf1sshs4vw557l7g0c56rs5",
+    "url": "https://android.googlesource.com/platform/external/ppp"
+  },
+  "external/proguard": {
+    "dateTime": 1588698674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6654c4bc5e3d85b04c7894a96b061a362074dd8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0y15jn4kysl40rgbgh68z7gy9d1g5jjhkvms6gz1jz0vql7a0izc",
+    "url": "https://android.googlesource.com/platform/external/proguard"
+  },
+  "external/protobuf": {
+    "dateTime": 1625706616,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "13b1054abf20b3aa96afdb3c0ed86f3d7d752652",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ikjv3r0yg4iffq7s13l87va3f8hhhbinp4bb37kl26wb6wdjkzx",
+    "url": "https://android.googlesource.com/platform/external/protobuf"
+  },
+  "external/psimd": {
+    "dateTime": 1613531764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb675492e074fd9b37cd3bc12d018899a95c89a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rq4alzwxxvls4pb4jb02sapag63jpvijjpjh2g2gb3rxnh9kg8q",
+    "url": "https://android.googlesource.com/platform/external/psimd"
+  },
+  "external/pthreadpool": {
+    "dateTime": 1613865893,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1319d4db369049f95d38c881184b5a811caf4491",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ixzpaa6335mcn3sd2kqxrbfr3835fxnfrz2afdyq17h65nvx3b2",
+    "url": "https://android.googlesource.com/platform/external/pthreadpool"
+  },
+  "external/puffin": {
+    "dateTime": 1613865894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2f79b6ec6d1c9a343db5ecb1ebab83d2af92b861",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02jrnkqcr9jp2s6igb1nz3gbcr5zsb28x1983p5la5wq8cvykvf3",
+    "url": "https://android.googlesource.com/platform/external/puffin"
+  },
+  "external/python/apitools": {
+    "dateTime": 1613952290,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6af2c6d2d23c3d990176a1f0a0b1bcf704d09b68",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17caach33h2m4a25fwbdkfab2kmj8c5gbv3wf5zfzh84k27v18md",
+    "url": "https://android.googlesource.com/platform/external/python/apitools"
+  },
+  "external/python/asn1crypto": {
+    "dateTime": 1613865895,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "674f1edee59efecb8841bc13a1da142f4d11974f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00a85gygijpclgdcpp6ggr9zyamxval6k6pkq5ps97c88d2av40h",
+    "url": "https://android.googlesource.com/platform/external/python/asn1crypto"
+  },
+  "external/python/cffi": {
+    "dateTime": 1613952291,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e4fff6199f0a420341dee150c736791e3d1f1f14",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m4cr3zy22iahhiskp5vpn0b60rp08a368vkg4jzbkvwcap1z6ag",
+    "url": "https://android.googlesource.com/platform/external/python/cffi"
+  },
+  "external/python/cpython2": {
+    "dateTime": 1615264820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "686c289e52104f053fa0360656312c474fef7531",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jki6h7sgdaak46rff8iijzdcdf9phrdi5935j86595xk5a3d9vi",
+    "url": "https://android.googlesource.com/platform/external/python/cpython2"
+  },
+  "external/python/cpython3": {
+    "dateTime": 1615264820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f3869c66290b59cfb3f23be3224979c248c82d9c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07asjr9d3wlbphfy1l55xbvkxdilc6wzm8fhjqkmha70a7bxj7vm",
+    "url": "https://android.googlesource.com/platform/external/python/cpython3"
+  },
+  "external/python/cryptography": {
+    "dateTime": 1613952293,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65dc3725bbfaa5d613d600e332325eabcb172957",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10dgm0mh4ljqaj3b5wl39a2v0lgch1jcsrsxbjzx3n25alph1cpw",
+    "url": "https://android.googlesource.com/platform/external/python/cryptography"
+  },
+  "external/python/dateutil": {
+    "dateTime": 1613952293,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "226933fc4bfc184d18d87dd6ab56782f6dcc88f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pjs7hnd3yd3wqqacxis72jyzjcwd0f2bq967ysg8j18vzwjsx0q",
+    "url": "https://android.googlesource.com/platform/external/python/dateutil"
+  },
+  "external/python/enum34": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "5e8956978f94a588e5484e0c03808a3db3a021fc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xzl7iybydjfwj5wg6bmxzzmdxv6zpl6qn4w6aw0zws3mra6jhk4",
+    "url": "https://android.googlesource.com/platform/external/python/enum34"
+  },
+  "external/python/funcsigs": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b2eaace21bcf829d84b4115056b728d5540f424",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05v4kd9697gpxiyh83gsghh8c2vwc2gn9zlc9naj8k3apnc9k2j4",
+    "url": "https://android.googlesource.com/platform/external/python/funcsigs"
+  },
+  "external/python/futures": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "3f178829909626252056d346ea56cd9adec92533",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y2dviz6khx9as8kk3fq1dci62mi08yddpqfcsca79nqsfwf6rig",
+    "url": "https://android.googlesource.com/platform/external/python/futures"
+  },
+  "external/python/google-api-python-client": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "5d76e360aa60cdcc8fd814add45cadd77c1fc5cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hc7mrg2sjghznm5fysxqwq2rq8wy55rw1r66g57ripnzrn8xbqm",
+    "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
+  },
+  "external/python/httplib2": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "060ce890d8ab88a3d89b9974df9beaa8cd879437",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jfbxrd2prjm3nv3bmwlqqwgx6iqna777ydd430ljki9dymchj4h",
+    "url": "https://android.googlesource.com/platform/external/python/httplib2"
+  },
+  "external/python/ipaddress": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5ea833cf712b638e3a88425a93ef29ca82ec99d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rvld36ky44qc8yz64a5k6g52qsss96dadvsdd8yqmrx8zincd0b",
+    "url": "https://android.googlesource.com/platform/external/python/ipaddress"
+  },
+  "external/python/jinja": {
+    "dateTime": 1614737089,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "910dc886f6bb378afca8d26199f15c3b25d3ed78",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0syg2yndr59f4mf3hvw6vs43fx8hf60678ky4ha2liypymazf2kf",
+    "url": "https://android.googlesource.com/platform/external/python/jinja"
+  },
+  "external/python/markupsafe": {
+    "dateTime": 1614737089,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11d4318b64fb067a2d0c7cadfc843eb2c6af2001",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18qjh0xrnc59w7divzjrriz7ppclhhlisypzlgd8b8hbd4ali3rz",
+    "url": "https://android.googlesource.com/platform/external/python/markupsafe"
+  },
+  "external/python/mock": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca1bfc132357d92cd759ab6fb12718b3a54be02b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1c8fbmxnl0h00dnwqywba008lm6bs8zrmvhagnp7gpr84if60gr7",
+    "url": "https://android.googlesource.com/platform/external/python/mock"
+  },
+  "external/python/oauth2client": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "cf19ecad65991f72f17bff637dbde2f38c87fe69",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0snxs8dzmx5farizh7dk6kyw3pnw9dwq4lgjf55pz57zdw4w5h7c",
+    "url": "https://android.googlesource.com/platform/external/python/oauth2client"
+  },
+  "external/python/parse_type": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "18b55cdcb53f6c38967481005da690de73e7268d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jl9ij257zg68c3vbb8wnkpl9cqyr0k115374hh0xwl86cc38x5x",
+    "url": "https://android.googlesource.com/platform/external/python/parse_type"
+  },
+  "external/python/pyasn1": {
+    "dateTime": 1613952298,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "0180cd9bb63a7ca87ade7a20e13fd60209a2e276",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0m5fjmifgskidmbvnnq4rvbqkwzkdmvhpi7pya6b58s3cwmrwc7x",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1"
+  },
+  "external/python/pyasn1-modules": {
+    "dateTime": 1613952298,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "dc878fdd7eb051d823ed6f8eeecdc111aa62c247",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0n7isv62gq7h7i605p3lpkp67hqdbmcnmzzv30jr2m0g8bb52fjr",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
+  },
+  "external/python/pybind11": {
+    "dateTime": 1613613908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a9f965f3762d4e8acb6f0939e0a52096528d0a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r4s6cadrw8g60zhq9nh2cyzvbc52w1amj4ydp5apz2z4hz24fmf",
+    "url": "https://android.googlesource.com/platform/external/python/pybind11"
+  },
+  "external/python/pycparser": {
+    "dateTime": 1613613908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40724ce9b800e70de90f63f6a6d0cc024b0da727",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "120qdb67ag3yy0cgwdxijjc32s54irpvyid8dgmkd4jdl3jii7ry",
+    "url": "https://android.googlesource.com/platform/external/python/pycparser"
+  },
+  "external/python/pyfakefs": {
+    "dateTime": 1613952299,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "395b7ca8711a22c2c4b299db0af99ba0d40e018c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jw07iqzrjac1p3vfs3r2g0lg4nsfqxxi6vkk67as939ggkas836",
+    "url": "https://android.googlesource.com/platform/external/python/pyfakefs"
+  },
+  "external/python/pyopenssl": {
+    "dateTime": 1613865906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6031a346a7b97ac19a628dfe316816546e56fa62",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h50kdfwm9wp4c6vyhf34p3lirz0r69dckdm6hjw45h4piqafdwf",
+    "url": "https://android.googlesource.com/platform/external/python/pyopenssl"
+  },
+  "external/python/rsa": {
+    "dateTime": 1613952300,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "6361b6de466919ebf36a29be143740e92733e982",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x7jflip5dcbxd4z9ax3pzlqd0lw1dmgbjjffrrrjbq3ms5vg88v",
+    "url": "https://android.googlesource.com/platform/external/python/rsa"
+  },
+  "external/python/setuptools": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "9888159b5fcda89333043652bc87c4fb2d69af23",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ypsmnmng16c8sqx8g3nsiybw7qfxyykpd74i1nqkx0x8qdfs9pi",
+    "url": "https://android.googlesource.com/platform/external/python/setuptools"
+  },
+  "external/python/six": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "cabcfd3982eaaa8ecf49cde8a8eb1e927de2fbab",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j9sx6jph7hz7axrmrmd2wpyvlp8d1gn16ph94vnwcm3izx9a7vr",
+    "url": "https://android.googlesource.com/platform/external/python/six"
+  },
+  "external/python/uritemplates": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "05636bf66809bf0952b05bd14d42ddea1b9fef15",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mzkgmy5lxgsbd1az98lvqz50z12l862zgqhrak5jvmgxy33asm5",
+    "url": "https://android.googlesource.com/platform/external/python/uritemplates"
+  },
+  "external/rappor": {
+    "dateTime": 1613613911,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "690b1adad7d1b858239a14cc87616f6edb68ae33",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0k2pwhs721qh0h3x77z9jzl9vww7gvfdqf9ypxlgia2mha9m2y97",
+    "url": "https://android.googlesource.com/platform/external/rappor"
+  },
+  "external/replicaisland": {
+    "dateTime": 1613531780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b8e4abad8eb1f7e7f7831ed72fdc2f386ba28032",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16bi4iv9ya7ylwhf4qm7rnymzzcl6wjl68rrrjqrsp9my28h4mrx",
+    "url": "https://android.googlesource.com/platform/external/replicaisland"
+  },
+  "external/rmi4utils": {
+    "dateTime": 1621047940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7be6b3fbf6a568f027f415f2be227ab3afc17ec3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lwxkzw2xl6mssvzivzgrnn3wmxkpbm9r3hpd0iif8124ha02zq1",
+    "url": "https://android.googlesource.com/platform/external/rmi4utils"
+  },
+  "external/rnnoise": {
+    "dateTime": 1613865912,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c0fc5229b6fff04a5cfa51c89bfd1321f8b74b0a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1flgs86w4k7vrrq7mh962rf7y2vxnzfwsd12hpa44375rc06lrm1",
+    "url": "https://android.googlesource.com/platform/external/rnnoise"
+  },
+  "external/robolectric-shadows": {
+    "dateTime": 1639094700,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9a871a175f187670df6095c5dbadea9f97cf1b2b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1la9xkbzd8x4djq6p7jlfd8jdbigv6q1sc84zh1x5p29mrfng6mq",
+    "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
+  },
+  "external/roboto-fonts": {
+    "dateTime": 1623287184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "241d979f8a697fa1fbda1a5ec1244c55e0e952c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ygzmkkp1nj8c4spq3rgbdjx40vgmhkivkywikrab3wp3c469lw4",
+    "url": "https://android.googlesource.com/platform/external/roboto-fonts"
+  },
+  "external/rootdev": {
+    "dateTime": 1613613913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ce674fc4817ad232827d446c10027e36664d34c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kyqrr4lavpbqz47ajvf03vylgxs72l1nhxkx93hpl52w1kyqih7",
+    "url": "https://android.googlesource.com/platform/external/rootdev"
+  },
+  "external/rust/crates/ahash": {
+    "dateTime": 1621047943,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b7009c4733d8b32c4b0912c975b6c629a38aa1a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hq34bv8dhqq4dh16bqlv49fsszfp1y08llsycpv8wwxhjwjbc1f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ahash"
+  },
+  "external/rust/crates/aho-corasick": {
+    "dateTime": 1613865913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "70911d8dd4d115df71e9153d2eb00510eba55c4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pjnv2f5g34fd8qrzdkhqi9fz1x5mrcg4539gjrkr3kfrwbxsnb4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/aho-corasick"
+  },
+  "external/rust/crates/android_log-sys": {
+    "dateTime": 1621047945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "890e732c782ed8f0cd1d6d29af16250edddae1cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j5zn9ckhs1l9n8wgq1j5r4ahk7z5wny7idxqg5zlpf4nn0m6kr3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_log-sys"
+  },
+  "external/rust/crates/android_logger": {
+    "dateTime": 1621047945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "78594ce5b1a7b95190f3812258011e457c776eba",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xvwcn8dy0nas0kx33k8hhxvirkngyd8rn5d37bl07xr8lnqw82y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_logger"
+  },
+  "external/rust/crates/anyhow": {
+    "dateTime": 1639094704,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "56d1c1ba7f7fb670d64e18711cef398fa9601d22",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mpyq29wnw9wjv191hmilppxszg7rfl93flhf2476vkqiq1q85by",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/anyhow"
+  },
+  "external/rust/crates/arbitrary": {
+    "dateTime": 1617757509,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d839a7cbe8d18f45f428c287325ae75b51c318d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zw3zrfzlwaidbzsl0d166jpmi2hywk1gfjrs2b9wr2dln61dg2k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/arbitrary"
+  },
+  "external/rust/crates/async-stream": {
+    "dateTime": 1614650720,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "05e97a1627a03e9fe8041f6c1f7c63ed964f64af",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s0h4zsr8bkygz1d4i78cp5897yvm0bz5iaffbph53n1gryh8ddf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream"
+  },
+  "external/rust/crates/async-stream-impl": {
+    "dateTime": 1614650720,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15a2b8cb8c42505a13eb5c30ada878e2409fb3f0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d30bmadkkr0hjly1033l7f3jr0bl1a30q8sdz1l58nx93c2sayp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream-impl"
+  },
+  "external/rust/crates/async-task": {
+    "dateTime": 1621119921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "66af87b02fad62871f5d40563a6905a0845004d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1a0j7nxi30zng0i6q2dkqqkg70a8bxgbspl3pflv98bsxjhcnc19",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-task"
+  },
+  "external/rust/crates/async-trait": {
+    "dateTime": 1621047948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b563167fbed0ad1062c4621da25b69c8c805b7e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rfbqsx81bhz1arfgzgql5kggqgfqq13yc65h69k44z91lq18227",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-trait"
+  },
+  "external/rust/crates/atty": {
+    "dateTime": 1616547886,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "84ccca8ab12f898ff04ccf78b4fceada71c2ff58",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ypvk3r03x00sq5qxd7c358049mzv2f0z364zkj2lr15yakp40f0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/atty"
+  },
+  "external/rust/crates/bencher": {
+    "dateTime": 1613613918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e63f049ccf8ac5c659049a4cb921cc23a82cddea",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d7skrpb2ipsqlcdsrl46cgdf8q7jf8bv5izmxd6cnw733zf5sv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bencher"
+  },
+  "external/rust/crates/bindgen": {
+    "dateTime": 1621047949,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e71fba89d39e3235b4856b0f7bcb684f7909fa0c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "185wjwx64ldpyk4y3w67jjqd8q54pgy34pi0cif198zk6wjz0v11",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bindgen"
+  },
+  "external/rust/crates/bitflags": {
+    "dateTime": 1621047950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46ecb6f3d1e73bbaad5b7beb9ea8659e33d72433",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ahjp9jmjwm6gm9wgfi4znwvpjpyfkyixk9pjrkx88v7d5c3jmdj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bitflags"
+  },
+  "external/rust/crates/bstr": {
+    "dateTime": 1617419069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "981ab6854f4667617cb3dc1db5db93dbee7876cb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sri0n70g1iak5831zqmkh00w90kk3g70cypy86g4zpzpafyl250",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bstr"
+  },
+  "external/rust/crates/byteorder": {
+    "dateTime": 1617419069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c47b7567c1a8f8ea9eb63d817183856a8e1a341",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z56bdlmm8jf5bvb88ddk95b386xlc6hdaczm530jrzi07r77xjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/byteorder"
+  },
+  "external/rust/crates/bytes": {
+    "dateTime": 1621047951,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "388cfc005c208edb6535648e4bd897c4ca8114a8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f7g96awyhi3sj71rbllbsq9c64j228r2g4wabnncrl99clma441",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bytes"
+  },
+  "external/rust/crates/cast": {
+    "dateTime": 1616547889,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7be52a60e524f94c46220d608c961233a1ca3a93",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17c2z30zxyfqni9b9j1778xxjc1lvrhafhzlaw6jajp9a6kwn61r",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cast"
+  },
+  "external/rust/crates/cexpr": {
+    "dateTime": 1613865919,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6d4d4e97a01d4b5c3cf2d5c7eb6881d624a6a45",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xq9rrmn61yjwzjv61zad20b5irsznvz5w8c7pn5hnjw83aa64ac",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cexpr"
+  },
+  "external/rust/crates/cfg-if": {
+    "dateTime": 1621047953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52ef61253a365c22fa3ca4cb9a228fc82080cd81",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08666bjm2z2hagfmwbhy7nxa00fprq4dbv1si5slhi6mlkmhhxf3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cfg-if"
+  },
+  "external/rust/crates/chrono": {
+    "dateTime": 1613613920,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d620b411ac5106043754595ac81f148ae9644237",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x8si59fb4z6xpmn5kg48lamfx76s76vd443pl0qgc37jcdxx0wy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/chrono"
+  },
+  "external/rust/crates/clang-sys": {
+    "dateTime": 1614650725,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a2e3cd47cf5c61f8ceb8f55b9ecaa8ff73479a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15x52kc16ak83l3l08x0crp2rk5x594bj6jkqbjkkws4728d14xa",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clang-sys"
+  },
+  "external/rust/crates/clap": {
+    "dateTime": 1621047955,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2025f8a0dd406dd71b50c159addf3bd81954f0d0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wwiss20xa3x2dxznfglzrkb36v0x38c651dbhl9h15swjirwqf4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clap"
+  },
+  "external/rust/crates/codespan-reporting": {
+    "dateTime": 1617419074,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf9e10cc4f969e598d4f884247e0738693a86a33",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zsiq4anwyv212zznq8cm32rcigvf5xjvn817zav4pmwnq0gjqci",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/codespan-reporting"
+  },
+  "external/rust/crates/crc32fast": {
+    "dateTime": 1636160694,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6d52e4373b71754aabc5ddcfc8a502171f8ca09",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bbyaqmiraqn9hkqhw9klah113w5jgxbapps7xh02qdm9kw2vjll",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crc32fast"
+  },
+  "external/rust/crates/criterion": {
+    "dateTime": 1618362312,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f9d5f4884baae59e04d71ad9b23331eb43504193",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rv1c32p524j7v0cn0lhin8g1qy0v8nnnn7670ak6w3vb3lvxb12",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion"
+  },
+  "external/rust/crates/criterion-plot": {
+    "dateTime": 1616547893,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8205a45aac0c9fb06d23cf5975a2d3c6a3ae34b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0a72appa3mnq7rjpv4q3kpnmrbmvv3hrk14yai12qbzw72v08syg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion-plot"
+  },
+  "external/rust/crates/crossbeam-channel": {
+    "dateTime": 1616547894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c220b629f82cb6a53a1da8fda391c0064aa1358f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nj6qicjbdkdrkycc43fgg0w7gyskmy3ahl6r9zhsb0dpqhys6c7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-channel"
+  },
+  "external/rust/crates/crossbeam-deque": {
+    "dateTime": 1616547894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e41b3e28d54d106eb8982169b4eed4c7f447ca8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q88z0w823ap29c1qv6fqy9bmgvb82zs836332hpka1lbrfw0c0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-deque"
+  },
+  "external/rust/crates/crossbeam-epoch": {
+    "dateTime": 1617930327,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5a792e03e3131d2bfb06c07c0e4a6970f73ea1c5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gwdzc4f1p0ch46zbfdbmrk59mg9848nj1acas9x91xcrn447j77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-epoch"
+  },
+  "external/rust/crates/crossbeam-utils": {
+    "dateTime": 1621047958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b652ca4c22b8dda220d7cee39a7e62032b1f97a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0n97x42nmc8mmwraz879ld6nqdgsq613wiahq066w5j8jvsn1ll6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-utils"
+  },
+  "external/rust/crates/csv": {
+    "dateTime": 1617419078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14da278800e75f710f076e01183b1e785396f237",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10z3nh974sckbcfdxw8ah7h8mxvx1c6mfcjvcfr6pw8vzbq84mdc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv"
+  },
+  "external/rust/crates/csv-core": {
+    "dateTime": 1616547895,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee24cb004431bd71dde397a5b971b245aa94abc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y6kq025hkpl5yl4vakqd3h08ipbx15n2yayvw654k3vwl9290da",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv-core"
+  },
+  "external/rust/crates/derive_arbitrary": {
+    "dateTime": 1617419078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7656f4d0827c36abe04febfe463b7e1292b30232",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d83srj03644dvy59r5612779gcp8g9dj3r6c1gf7c03vlfpdm8k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/derive_arbitrary"
+  },
+  "external/rust/crates/downcast-rs": {
+    "dateTime": 1621047960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ea0f52cf050fde41629e03567f31d4364f4291d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1325khrkxyr04bzypvdf44azyq5fvbgf3rxxygyfwx8567vyjhcg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/downcast-rs"
+  },
+  "external/rust/crates/either": {
+    "dateTime": 1616547897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48ef135a3a6516417d42715d70a0fb7123d27c2e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jbnwc9iiiyyyf5pa425ysnjv14awhpzylc1f65xiw4zg16l8d6l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/either"
+  },
+  "external/rust/crates/env_logger": {
+    "dateTime": 1621047961,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69604b3f0bdc1692263445409e4c97ea14be7a4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j8s6pp9l87lpj5cx73cqkwsbxgza1hjv376h35sdf5zznv8gp1a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/env_logger"
+  },
+  "external/rust/crates/fallible-iterator": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "47de4e895a44524ff2b5c100128888905acbabbf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wwq8gzcwmwn8nd25m0p7s165d2fpm3gd0bh5qvacca5krdwbapx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-iterator"
+  },
+  "external/rust/crates/fallible-streaming-iterator": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1b21233e5739e35ff4358586bf92dc91f795b2f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0934fiwj33yqkyya8fxlbkwncpm1p48xcvs4058nc8xz92jxms59",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-streaming-iterator"
+  },
+  "external/rust/crates/flate2": {
+    "dateTime": 1621991189,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c2a2b3c32660c1ea52bef048ea12b3adea5b120",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1j5kchixqzs9axz3k0k27mp7bwayjln4xks52r59rmzp1vxnld0q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/flate2"
+  },
+  "external/rust/crates/fnv": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7e73ac24e5857c71c91fa9898ecf1cb6283904b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "176wqsijl9f64scdjgj92r1q4l9bb96s2wapsgj6ldg5d4sh04q7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fnv"
+  },
+  "external/rust/crates/form_urlencoded": {
+    "dateTime": 1621047963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c896fe3760bb93aa54a959f1d224bedafab33c18",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bm74vin0rx5h0ihgzg258ihkxvmx2dsrac7wj76y8xgj99x2k0z",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/form_urlencoded"
+  },
+  "external/rust/crates/futures": {
+    "dateTime": 1621047964,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c6c440d40ed175cd8faf59c819082913dc7efbc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0d0w7s3rbb90x8y6sxzg22cqqlfy2zabcbbzyllq40dazg5f0rzi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures"
+  },
+  "external/rust/crates/futures-channel": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "168fb0199841457052562fa20d042845e072951f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mjrc60cjhkfx1s4qzd7xjwb44wfff41p1vh1l2ibvmq3f80z15a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-channel"
+  },
+  "external/rust/crates/futures-core": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7e4c23b22fdb9feb245504f14df81faa2bc83041",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07fp7v1lcln8v4ajyafq71s80z0904i5xrmn5zqn4mv4q1az1r8v",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-core"
+  },
+  "external/rust/crates/futures-executor": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c5a2d6f3a22ab6db3009053f5e26dcebf5f0562",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0myqw6i9ckl72hdb1yklxjn1ay4zs81pflshy5p8336lqfw7v7ly",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-executor"
+  },
+  "external/rust/crates/futures-io": {
+    "dateTime": 1621047966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "96aef269ccccd69b1f1154afea72b63ea5810281",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d573cpchcpahlcbgfjkmqj1mdlbn70p2yxhzzgnna6a931h358c",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-io"
+  },
+  "external/rust/crates/futures-macro": {
+    "dateTime": 1617419084,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "656cae658a0f26fd94f93d74226629efca370e06",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1p5z0scaqqsngwgwgrmy1m1dzavalj8al9566q48pnrsj6xr8lbc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-macro"
+  },
+  "external/rust/crates/futures-sink": {
+    "dateTime": 1621047967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3103491c194f75db5512c44d189ebd312f919a4b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sm91gkcaif1qgalfv8pakak3jaf6x9ryy63w9hcb6vv1rj599k8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-sink"
+  },
+  "external/rust/crates/futures-task": {
+    "dateTime": 1621047968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15b0a235c976ef28914d98bd4b6097845e037c33",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19p56hy20hrs8b1pd1ba6cpnhf3pcbpy1vz5hqsrnzhca1yb7mfr",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-task"
+  },
+  "external/rust/crates/futures-util": {
+    "dateTime": 1621047968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "881c74ab9b41967d4ec24903f243f02aef3c18e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v5rpkakmi3yqakzwmyn3n9dvla3phwjq2y1h5rn7qm8ymvkfgk9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-util"
+  },
+  "external/rust/crates/gdbstub": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0a11d50d2585545367d00166f0174cccbb1038fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09521zaxa0ijyhk3nbkh4y150cb5kxbr3nbkza82gspd4lagnby9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub"
+  },
+  "external/rust/crates/gdbstub_arch": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "64e0b9570713aad300c5c2c6ab4112d4c773e774",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wsxbr0z5hxp8h4mgd6cb1kksgdkls01rfnaspyx1cshpxav0z0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub_arch"
+  },
+  "external/rust/crates/getrandom": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "815c974d10bfba12402163cb56e59f42c67bb195",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16simpsq12x6xq7l99pq62lag76svm5w0flsrnli9saj9mxrq7rw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/getrandom"
+  },
+  "external/rust/crates/glob": {
+    "dateTime": 1613865931,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "118ebb9bf05965fda3e4833cf020d5cfc2fcb5f0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sd6b3y7w2lhma4d0y4930sv3adi97pkyq6szd765mxzaxm5dh55",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/glob"
+  },
+  "external/rust/crates/grpcio": {
+    "dateTime": 1617419087,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bfe12d1cf4ac6e1b83b760853b11049ba212d21b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dc2x1jl20lb93833dkrjksszkqnjlwh9lzf2z34kjib5whxyicc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio"
+  },
+  "external/rust/crates/grpcio-compiler": {
+    "dateTime": 1617419087,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d014949691fed92593e86fd4fb651b9c4fc5655",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xd739ka5f56zywd9xnm934z472c7drqiz6hqg64cw9qxgp96fyc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-compiler"
+  },
+  "external/rust/crates/grpcio-sys": {
+    "dateTime": 1621047971,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e64557f5aff6dcf27bcbf633ac669c6d9b4b07a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hmydw85ih7cjdb3rdmpv1hmfqqb6wvz24z4ba9kwxn2y4vf2hnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-sys"
+  },
+  "external/rust/crates/half": {
+    "dateTime": 1618276021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fda11108f0010de1a2e1245ab617197a383ba680",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08l0jgdfi6qmbqp5v2q8hjpf9rwqmampl9ki7qramhin3p6c620f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/half"
+  },
+  "external/rust/crates/hashbrown": {
+    "dateTime": 1617671151,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "678b4b960bf47f26754d91ebc68399b1fb3a1670",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0lkksfn0kqd6sqjlm35m4h6nv8bx78fw4c1dbkj2q82sqy63r88j",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashbrown"
+  },
+  "external/rust/crates/hashlink": {
+    "dateTime": 1613865933,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e1c63521fc2c66cc4642402d7afe24193227974",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m1zxa9kcq561wckji7m2rsrp7h32zcsl67nz8sm3crmfiih89p4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashlink"
+  },
+  "external/rust/crates/heck": {
+    "dateTime": 1613865934,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4961428fd3d0eba8404a09766b4010494287fe57",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0x4djw1sjsl4p906fpx8davjlrnxar843aiap7qph620fa8f5p92",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/heck"
+  },
+  "external/rust/crates/idna": {
+    "dateTime": 1621047974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "78f8560b3a960475ff584f221b14831a6ce71b8c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ymmrdxp31wpqwhfcaan2rjfhcj0gv7zigshhpcai1xv5zfb9ax2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/idna"
+  },
+  "external/rust/crates/instant": {
+    "dateTime": 1613865935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f11fffbe9d6ab10b58e70cfa989ccf483ae6d8a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07w1pii8i6qkfnwvhsm4iivflxqq6hpbmiyq7jsw4qbigsrjjrc9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/instant"
+  },
+  "external/rust/crates/intrusive-collections": {
+    "dateTime": 1621047974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "601079c82e608f8aa3d45e05ec7d93862c8a7d2b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06rv3d12ds3kdnsxlzv4318i1nykvsmh9hcvcapvhpxc8av9xj9q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/intrusive-collections"
+  },
+  "external/rust/crates/itertools": {
+    "dateTime": 1617757538,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9d514f37bf5c9205be9cbd338e0a6d10c72c471",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0w0h9zdc938l057zjbsvai9s5mnhyx9nga55agwarflg39gr12xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itertools"
+  },
+  "external/rust/crates/itoa": {
+    "dateTime": 1621047975,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34b1779d10b137b17b76f9d445359bef79703cdc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rji01a0sfkfh18jx243hbm69mqjx9i013df0zwisnvq4680536i",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itoa"
+  },
+  "external/rust/crates/lazy_static": {
+    "dateTime": 1621047976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c132b69e04fe90a7e1dda776ea577e134f870cdb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wbi944w289ihsvirwzy9y0casx6xfnyd6vlbrlp6mrly8i9f1n8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazy_static"
+  },
+  "external/rust/crates/lazycell": {
+    "dateTime": 1613865936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2efe57a98a078fa08353146617d63b4ded4247b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06di56bnsz4msyj77nwha4g1mi08k19ymh15isd79wc6x44z9h5h",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazycell"
+  },
+  "external/rust/crates/libc": {
+    "dateTime": 1621047977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "307855eabea50bd014fb47d57556ef9e51db844c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zx4l0w87azhy1pc6mnvzw0ksbjbfrv6gvbvnn2d5g2plp3ssja0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libc"
+  },
+  "external/rust/crates/libfuzzer-sys": {
+    "dateTime": 1617671157,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7804fa17b056f0b012da2257496418a6ab1bcdb3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f5a2zl26ydvffwzfw3yk2mfpy63qkhc97vbmg6nqp03jd3gxdhv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libfuzzer-sys"
+  },
+  "external/rust/crates/libloading": {
+    "dateTime": 1613865938,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b7dd7b99ca6922aa5f1b2c72aab36dd7b7703cb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "125hn4cvm7d73y1caagf2vm17qzrkl6hppw8icibiwzc3cvq509p",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libloading"
+  },
+  "external/rust/crates/libm": {
+    "dateTime": 1621047978,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "edc27184e9e0cb6447cdc39662dac6a5ccbb4782",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "111agfhx3rid2cgg0va4rblsdvr5xa0lpzwqbbk15nh184ckbn14",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libm"
+  },
+  "external/rust/crates/libsqlite3-sys": {
+    "dateTime": 1621047979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5e5ed848f8cf98ec2b3ba37dfbbc178e3fa68bca",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zw7ak9v8fayazqi33nvy6laysh2rxd424l2c8sxb5sshp9csp8m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libsqlite3-sys"
+  },
+  "external/rust/crates/libz-sys": {
+    "dateTime": 1613865939,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "56eaf92165c7d9171c10a48ad721fe9613f1756d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1snrdfqxghyiwd3w7yxbp0vl0kpx6w1ciih3hhvwhfg83yh754h1",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libz-sys"
+  },
+  "external/rust/crates/linked-hash-map": {
+    "dateTime": 1616547915,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bbbf115ae57f0bf3896864e4df6a5819fcf435bd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10avx3pavwvc6w9pwwbkazahbrjffkq1bw4rd48fwbapsx2c1axj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/linked-hash-map"
+  },
+  "external/rust/crates/lock_api": {
+    "dateTime": 1613865940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d895674b88dc0e846a6e6a28a0d347a58a2a66f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18m7p6hd57zbhc4nr0l63i38zk9riw8vkrs172j5zzwfc086v3vy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lock_api"
+  },
+  "external/rust/crates/log": {
+    "dateTime": 1621047982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8747d2175c0d4bccd3906cdbd26189f891d6b817",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zzb335rk5bpi75jm4sb5pf8rmnpf6dznbd5n4nzl1i226zfqvz8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/log"
+  },
+  "external/rust/crates/lru-cache": {
+    "dateTime": 1613865941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0cf6f24e2622bf66fc6cbc69d27f46aa1ab4a0e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cba2cgnkp681l5dhppipfidlj244mzzv0iwgi0qmaja99cdyzfz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lru-cache"
+  },
+  "external/rust/crates/macaddr": {
+    "dateTime": 1616547917,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "95e22871a10dda14b52876c5d7251974e0817c4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ih34msm26vya16vkqxsvf0zrxxhbdgm3gbxb80md6wlv4vmskjm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/macaddr"
+  },
+  "external/rust/crates/managed": {
+    "dateTime": 1616547917,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "60575dc25f15350e9948254444916c6e546b7cb0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05a90v3jq9yw5bj547qjx31l5fm6fafdl1mbngbkglmmw0i2bzmk",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/managed"
+  },
+  "external/rust/crates/matches": {
+    "dateTime": 1621047984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50003ca8c20a716be2dcc7450e9c90ff95603c08",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sp2ddidbl3h0hbrkbg194jpqpdb1l74pi8kdga3sxczp3dlmkyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/matches"
+  },
+  "external/rust/crates/memchr": {
+    "dateTime": 1621047984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf9d14a10a16c9711fc5fcc57b14cdd2aef1a671",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hwsviz4jz3c7n7lcf95m6brifngx1r6s3h57d1xkqqz6vz7y716",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memchr"
+  },
+  "external/rust/crates/memoffset": {
+    "dateTime": 1621047985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "119b5bdb877cd1b252aadea7f9cad419d2449452",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1vkrp3y4l7vxcsbgf8wxfl1w9icwnikb69b2jjw77cy3r16c43qg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memoffset"
+  },
+  "external/rust/crates/mio": {
+    "dateTime": 1621047985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0f3424d8522db2a16df4fbaf9daacfcddea9f9f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jhji521v8686xn5zzl3myy4q6jdnsw8wn3bh6fa0cnyl60gmpb2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/mio"
+  },
+  "external/rust/crates/nix": {
+    "dateTime": 1621047986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4e7ff990b621a00cc9cf8094a92df2f5adb05bb8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wvpj5950hvj55gajh3yp2pf514shscnp4z39h9md9rjzig9qwr7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nix"
+  },
+  "external/rust/crates/no-panic": {
+    "dateTime": 1613865944,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f8feba30150cd40a2be5b23de2fbc2e1afc78aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cz0nj5d58s0p03pf4j3k14d9my2iss4gap87ln7fkx63kll7l9b",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/no-panic"
+  },
+  "external/rust/crates/nom": {
+    "dateTime": 1613865945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35cadfc49d19b8a56d1c488e28b0485b279d3afc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00iz5lgxgdlshwmsbppiw509y574dicmk3zfyba4xz0scd564xnv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nom"
+  },
+  "external/rust/crates/num-derive": {
+    "dateTime": 1613865945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "346029e167dac504071484b20a41fbf81cc6dd20",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07l72iv3aikhcfywfll8rjh7ylclndxr7cidcq6a8i0klxfibiv7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-derive"
+  },
+  "external/rust/crates/num-integer": {
+    "dateTime": 1613613943,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "903fac691cddf4bed2b10ab005dbf3baa2c91e69",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b0i5j8vgn1xvp66dcwdvfcq8hymn7hx04411lrbcha9v1zrjl23",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-integer"
+  },
+  "external/rust/crates/num-traits": {
+    "dateTime": 1621047988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7742bce75f9341ec5091350df7e9c052acf7a546",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05ar1k2x8pqqr9hn4cchy5kbv5cg80aaxq0k6xp794m3cn7j275s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-traits"
+  },
+  "external/rust/crates/num_cpus": {
+    "dateTime": 1621047989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "572437eff39c4e370647d6aab544aad7bf281357",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13l3ss2303qgx780ppsp7y8zkz5rh78mznml1mbnhk1j177zdjwp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num_cpus"
+  },
+  "external/rust/crates/once_cell": {
+    "dateTime": 1621047989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3badf78d2830c3c599478b4c9fa6937c85ecb586",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pn4aj49f25r5jz4dm9wmdf1rmmghzff2yzplikbgkx4kl31q5zx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/once_cell"
+  },
+  "external/rust/crates/oorandom": {
+    "dateTime": 1616547924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8cf48fc9468d7f3c75e3e445aa92ebef3cb5310f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05xsrs0hvzh9z28lmfq3slmjzia6dg6nqlsx5qzwzn06qximykaf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/oorandom"
+  },
+  "external/rust/crates/parking_lot": {
+    "dateTime": 1613865948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48e6b24e468b71de98d86c42d056738df46dc415",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lfv9la7lm4m8k5wln2xv4ghv1yv4z99mgzl2rx5hz1rfrgg38g4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot"
+  },
+  "external/rust/crates/parking_lot_core": {
+    "dateTime": 1613865948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92d9eaadc6f2bf062df28fd5e6e5b1a02e7cbcd7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rkzqb6is3c3s08m4gf16s17i6siy5xhcc77s25rwlvx6waq4k8d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot_core"
+  },
+  "external/rust/crates/paste": {
+    "dateTime": 1617419107,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2850bd999d7b0987a42131082c17a9261c6f91bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vy1knxk1rckadyjyl72dcyqc6wz8dvq0c986z3652cl0g0q1pji",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/paste"
+  },
+  "external/rust/crates/peeking_take_while": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "504117dd90ad5e358d5eb14c890e77119b66253f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12901vqlv7ciffpdq7bfdcfx2vpylwv16czvrm6174g7d9l68fv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/peeking_take_while"
+  },
+  "external/rust/crates/percent-encoding": {
+    "dateTime": 1621047992,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ae8ea922754d9fbcea0509782832dd1606d4196",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vrdcvkv72306calx7q3hxmsk2b0kcac9hjn9s92l01am2svpa65",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/percent-encoding"
+  },
+  "external/rust/crates/pin-project": {
+    "dateTime": 1621047993,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21b9af1aa1428f3eb57306bbca7acd93b3081d0b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y0037f6zw4qyjjmb8qgxr15mdf8a36iym0r2in978bx6vickbyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project"
+  },
+  "external/rust/crates/pin-project-internal": {
+    "dateTime": 1617419109,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "158d926103469a0a3f29e8e5e720a29c374ea571",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dyjczyl7rjyj3qlslhvks0cb5hfmiz98g6il06837sl7sa7r435",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-internal"
+  },
+  "external/rust/crates/pin-project-lite": {
+    "dateTime": 1621047994,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98d3aec3272dec00d6f44c1b4603319060bacb21",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19hx6g9vkwl07f5d65irylb82dj96w9sfcrpk2g5jnj4q35991di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-lite"
+  },
+  "external/rust/crates/pin-utils": {
+    "dateTime": 1621047994,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4c9ee5bad2bc1f764bcb4edfca2870866c998f9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wc5x25b440l1qlfslhpvnm9yppwxjmx284wy7s0wz9jr9ikdn3k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-utils"
+  },
+  "external/rust/crates/plotters": {
+    "dateTime": 1618362350,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffcffd7f0c138beb2dc01c7779104eec6a8548b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0w3hzsr0hz5zz7cyn9r6hscan9arf8nbiq6fbgjaw67vjzzgjamd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters"
+  },
+  "external/rust/crates/plotters-backend": {
+    "dateTime": 1618362350,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d51a78848c0b5e8fe521fb4728f239d3bf2e3eed",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f6vxfgg2nb130cs0ykr4clhzwm9sd37hh87zk53v2yh1k2nsx63",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-backend"
+  },
+  "external/rust/crates/plotters-svg": {
+    "dateTime": 1617757558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee4cd70ae3bd92dbffe178f170bfe41013d601ad",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0knjd1657r31h5djbkacpiapax09adk2ryf8izayli46ifyx11bz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-svg"
+  },
+  "external/rust/crates/ppv-lite86": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4643954e235d7547ce1aa62fd552ea8258cd41f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02gkxcgik9jaw36hm59bs2pkgirrgz71ngsmxdda98h1ydip7i04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ppv-lite86"
+  },
+  "external/rust/crates/proc-macro-error": {
+    "dateTime": 1613865953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b3c88d43228e950bb20e18b9c0d0a07f1303664",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1knxgc7r9x289qmm38vmrh6sdyfp06i4n4ajlknyirb7gkqmw2br",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error"
+  },
+  "external/rust/crates/proc-macro-error-attr": {
+    "dateTime": 1613865953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1bbb0e89d2e196c50d3b6850a572e18f07fa528",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00zdh0yjlvp8lfc55a9vpf30b1q4m5cnyqdd1sfxxjlfv5fjbddc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error-attr"
+  },
+  "external/rust/crates/proc-macro-hack": {
+    "dateTime": 1613865954,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8caf5d454077422ff75a9ac7bcc1a4469fe58adb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k1ljy6alvx8hq3ym48ajavdljr6199xfd75ql72926nwk9aszxv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-hack"
+  },
+  "external/rust/crates/proc-macro-nested": {
+    "dateTime": 1621047998,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d847e42a1869c5d64e01ec4ab41a4b0796f879e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cm5csfpjbxbqs80javai4s0cdaz1d0a9i9mj45ck1dr1k9xzd5d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-nested"
+  },
+  "external/rust/crates/proc-macro2": {
+    "dateTime": 1621047999,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03158b72e693dc9e9e36c3fd6d0e0f0341d60a25",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01f5n87cdwhmw31b2433hv8fq9345haqhpg6k54as37g5pf4r052",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro2"
+  },
+  "external/rust/crates/protobuf": {
+    "dateTime": 1621047999,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6081bdb87ceba5b66bb058793daaab20e5c3e859",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v05llm5p3y1w36vnxlb58n0p5bdg5k2sr9vjrcq14biqapcm3di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf"
+  },
+  "external/rust/crates/protobuf-codegen": {
+    "dateTime": 1618023958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6cae58eac32f1aa39ff659550ef86012f8fa480",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yp4dly0d57gcyh4jp76jkvwxrbnv5w8vdklfmdd2gnad3gg5qjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf-codegen"
+  },
+  "external/rust/crates/quiche": {
+    "dateTime": 1621904896,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "66037dfcbc34e0c9cffdfc19595d60bb927e46f7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09r61vnj962kpz4s4r47mj21823244lnm60j0vnf9gp6yr10xv6w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quiche"
+  },
+  "external/rust/crates/quote": {
+    "dateTime": 1613865957,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "822be848db50fa87531de8783988bb5a1e688780",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lmnm2xvq7sqz0vqprqfgah04rwfgs3jga4za3ijpzmqr4bfqxbs",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quote"
+  },
+  "external/rust/crates/rand": {
+    "dateTime": 1621048001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1747afe2d94a47601cb4915d7f9a1b1be116fb96",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1q0xgznpka23616c4c52jw87yf2yf1nqxk4nrbs37idvdax3370w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand"
+  },
+  "external/rust/crates/rand_chacha": {
+    "dateTime": 1613865958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a1a8eb5c800e957780e4ffb9de0b83208d0aadb4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11nlq925r5jay7akqzimrk5lpr38cyi5izlpzmjqs73jv6j21n4l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_chacha"
+  },
+  "external/rust/crates/rand_core": {
+    "dateTime": 1614470744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "adcb777143f47c9f0bcc633b137e8e556e19403f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yagpl8553a611mywlvf7zqdsqdgqh661y51lw0b9alh3m0dix5k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_core"
+  },
+  "external/rust/crates/rand_xorshift": {
+    "dateTime": 1613700377,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c546f1f5cf777e72c5bd7c62b413d86444af80e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pxla85gls4kib4ydlpzzsj3yw2s7ryk1yvljgjx7avkam3ba86m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_xorshift"
+  },
+  "external/rust/crates/rayon": {
+    "dateTime": 1616547936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5349a40d15d3b953155e3f7744b86a009a1eb4f7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xffdyamd965vw93hl7zw6mgip01mybck8pfljr9msza39wfvp34",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon"
+  },
+  "external/rust/crates/rayon-core": {
+    "dateTime": 1616547937,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2cca588523961866d81f16faec59aba713dbd06",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kswciinmwn6f3xfgnxgqpnd6m3v6sm3m7d14vn2xp7938hi7s9w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon-core"
+  },
+  "external/rust/crates/regex": {
+    "dateTime": 1617419120,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ca27719cf345a05c13e23b81e4d9a1d27c6f8443",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0liqpk6bqwdypjawgcgwpdiy76a6ab5vvhi249430spb8552rvr2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex"
+  },
+  "external/rust/crates/regex-automata": {
+    "dateTime": 1616547937,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d333495069f0851e93e94599a0a22dbf1e9e96ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "060cvq9v43k2wca81bcyxyqspgyww0lw08xkiq0bznrql2vp7f04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-automata"
+  },
+  "external/rust/crates/regex-syntax": {
+    "dateTime": 1618362360,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f3b6c58ff8cc2cd42a2961c7f39c237d1a03972d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1amzxpm2072myiyzwqvipr1nsxbdikhz49pvm19kbzmasnnx7gin",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-syntax"
+  },
+  "external/rust/crates/remain": {
+    "dateTime": 1613865960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f1ddeb81a3d8ef632576e1ad041244bfb4cce7f7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0d53xbgp935395b99anix9l3193ss2imi0dwzxqpr1b3x5imbff6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/remain"
+  },
+  "external/rust/crates/ring": {
+    "dateTime": 1617843976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d03c44de894c4a6597d3a1af1071e7a0708ef9b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1svc2bj08si0x9frpkz90i7zal3lxbfi4kgl20w8r4018hk30c28",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ring"
+  },
+  "external/rust/crates/rusqlite": {
+    "dateTime": 1613865961,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "709fa6c179bc0fedcae8846ed45ae18d024cdacf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vq390rcdxx95pnj75j3dp393irh0rxsc0frz6mwpcfy7qvlkz7k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rusqlite"
+  },
+  "external/rust/crates/rustc-hash": {
+    "dateTime": 1613865962,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba731d7d5190756fd317035377aa219f560ef280",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v30cz4b7ckpz4i6yzcz4xcnkjvvpfd9ijz2qf0xzfqjaybfhlyb",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustc-hash"
+  },
+  "external/rust/crates/rustversion": {
+    "dateTime": 1614470748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8cbb98cfc1da4b568ba6cf9a28d28a4b89c223a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jjn769sm5h0j1g2ysxip2c3qn5fgiyklnc80kpwpbc8pz359vlm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustversion"
+  },
+  "external/rust/crates/ryu": {
+    "dateTime": 1621048008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8ff5bbe9844e91bec79c43dc2853bb032c7175b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0x7nx4w6pmy0bwbrlqgkdmjmbp4823gd1mfxxk240g0wy7zbpc8w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ryu"
+  },
+  "external/rust/crates/same-file": {
+    "dateTime": 1616547941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ec79c2dc625da1b842e80752e944ab9abcc7ddd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hqv1pdqmjpnicwzmk5ysjicp552l61ppqv9liy201iz7bl2yagn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/same-file"
+  },
+  "external/rust/crates/scopeguard": {
+    "dateTime": 1613865963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0123f753b23d9f5a4ceb3f52026914f8d05c1b51",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0yc9w5xz3vyjyyw17la529kz4jy4ayk1s98js871ha4xkbjwh840",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/scopeguard"
+  },
+  "external/rust/crates/serde": {
+    "dateTime": 1621048010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b239b92061d35b21f276f56ec3f971a804d650f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z74h4ir11fk52g0fs54mmalc4cd1ixycmngz3dam3li86hami8n",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde"
+  },
+  "external/rust/crates/serde_cbor": {
+    "dateTime": 1616547942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4e6d5cfe552450b00475e77ed681129a70ac4f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hcd2xar0ymvly9qn9sxkwzg9cgx4isnks3v51dfdhz7np2rrj06",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_cbor"
+  },
+  "external/rust/crates/serde_derive": {
+    "dateTime": 1613865965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cbdcec36aa2582cb12e2e89244741fb040c8a4e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1api77r6ylamm2zlhl76n3jbfrzqkqbjq42kn9y3bq6akn7ixvw5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_derive"
+  },
+  "external/rust/crates/serde_json": {
+    "dateTime": 1621048011,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9503b461ba0bdb00b54a162cb4e6af1721c38c83",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qcw6skd8wqgy6mdh14am0wp30dlc7cwp09fg2ml0k3w6d6zrz62",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_json"
+  },
+  "external/rust/crates/serde_test": {
+    "dateTime": 1613531823,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24d8de71f766d3f7dbc870ce422c67a659299d65",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07hdv8n29f5rrngjn7qxmq9dw37j1y5awlbpga204jzj52bg8sax",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_test"
+  },
+  "external/rust/crates/shared_child": {
+    "dateTime": 1621048012,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a793165fcb7b0fe6120fbb64edb6ec96fd620e7b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l52r5sxgr164fqmlhfhdk7hr5jwwqfrp558pk41h314y3pr1gg4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shared_child"
+  },
+  "external/rust/crates/shlex": {
+    "dateTime": 1613865966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3264ac98ee44a9bcad64db06a91fceb08e8f96eb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "135jawxfirwgh6dh0k25bl1k8acmvpwwpah62dcr775x3g885srj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shlex"
+  },
+  "external/rust/crates/slab": {
+    "dateTime": 1621048013,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d737ffeac976e97f34e8dde7a21cd72ae7471aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rvrph29d850l06wi8z0j3gzsnfbzlxnpgpqwxqwy3nqvvi90d9s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/slab"
+  },
+  "external/rust/crates/smallvec": {
+    "dateTime": 1621048014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0bc17aaf24fb904300b6160491f05cacad2e966e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02mvm1c3d9axdf9qkg2rylvhp7sgxcx9n338xfmaaq1c76wy0l7x",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/smallvec"
+  },
+  "external/rust/crates/spin": {
+    "dateTime": 1621048014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "abca6a18061d59452bb1e03027b0e5ae963e6aaa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00kv0aicmq07y6i44hz382h4fzhz4gbl31ckbch0f9c6xyhm0g8a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/spin"
+  },
+  "external/rust/crates/structopt": {
+    "dateTime": 1621048015,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d44e6de0aa82f18ec217fd795bd691c961a5308",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0n6lk2i8z0brsrg8gilmlx58h58c6j02jhln9rm9x9r13vhy09fq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt"
+  },
+  "external/rust/crates/structopt-derive": {
+    "dateTime": 1613865968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a726fde881bc75fb45d61e7b12530cdca1c7095",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16yjhl98qilspdi2rk0bhs3ckav3rysdccbq7nm6w6zpvn4jm4zq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt-derive"
+  },
+  "external/rust/crates/syn": {
+    "dateTime": 1621048016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c079fb6a08858786c561d503038bdee4c29a1df3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "086z6n4nkw8sdjwjfvnrzrsmiyahq2s6aw4fp776kgwg7lxl7shp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn"
+  },
+  "external/rust/crates/syn-mid": {
+    "dateTime": 1613865969,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "96e8dba27b2c8ea5fd2dc2568b72fd5f6928b2cb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hhvqxhk4rkwm0qkfh71rc1h3p1naldxw11691igmn6rgr8q94in",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn-mid"
+  },
+  "external/rust/crates/termcolor": {
+    "dateTime": 1613865970,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ecc8ea307c8ad30ee251e97103eac3bf96895c2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cqjgbwvccydjz2xrsrbsia3lmfzw275g1lmxw4jla1zfja4q9n0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/termcolor"
+  },
+  "external/rust/crates/textwrap": {
+    "dateTime": 1621048017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21d0194d0d141107a9921c024569c2237789e6de",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hc46d3jlx6v5swfj4d0p9267snl4xx6wpwx26s3bb4s98z4bdfn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/textwrap"
+  },
+  "external/rust/crates/thiserror": {
+    "dateTime": 1621048018,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1731b1a4c4386c4ecaf27048d21cdf5eeb565167",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02n6qiz8qpq972a06xdzgxs5bffpgs6mwx63chyxgnqy6726flh3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror"
+  },
+  "external/rust/crates/thiserror-impl": {
+    "dateTime": 1614650776,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5b1e3638b7e0fe784732ef3a5adeceab5e712903",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gg7s24ady7zlh46nffk7yh11rrddg8wvsdcr7c711dsbxxb5584",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror-impl"
+  },
+  "external/rust/crates/thread_local": {
+    "dateTime": 1616547950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bc597af9c350a377f290d7f568713b4d31608e19",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ln79byy89kpxygpqd11bbi5xsjypy1n28wrp91hy6sx786hla85",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thread_local"
+  },
+  "external/rust/crates/tinytemplate": {
+    "dateTime": 1618023977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "37e65f3cd8d44968fcad3b13f6438b93b45774fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10wg6wj3bzynr1z9pb50bmr6pc8i7xq56lwjydgwilhwi6p2g96w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinytemplate"
+  },
+  "external/rust/crates/tinyvec": {
+    "dateTime": 1621048020,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a9f627745323aa8d220d4299008384228b180c4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1iarzdmdck0f5fdwidd665m45wxl9aj32s1lm30nd5379cprmrwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec"
+  },
+  "external/rust/crates/tinyvec_macros": {
+    "dateTime": 1621048020,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c3782a0882c7d18f1b14ae5a6833a426b2da1782",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0y1c5xaq9nbiyi52zaapdbbhm7vmq6hizxmg0kd0nlyagd95smsx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec_macros"
+  },
+  "external/rust/crates/tokio": {
+    "dateTime": 1621048021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9499c59d896f755acc6484842ebf5c2a9f219c99",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zjh0cik5kwp6vfisza3bifjyplp8ymc52navzgqyf2zc5x4lnvx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio"
+  },
+  "external/rust/crates/tokio-macros": {
+    "dateTime": 1613865974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "150b5378357bcd5ca00f95cbc57db9f30fde3b02",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0py405c2b4bci1gj7gf4swv8s80fzqncm8kppfv04xd78ph9mmwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-macros"
+  },
+  "external/rust/crates/tokio-stream": {
+    "dateTime": 1621048022,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a2e6024fe00c588c521d5ebce4cf0aa6374f2440",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1369f0daiyy9yvbf9k3caifcnp7b2wjywy29if55kl0rb0pgs764",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-stream"
+  },
+  "external/rust/crates/tokio-test": {
+    "dateTime": 1621048022,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "05043d5d593867fa4d6e756447f25ce297303302",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r8ddxhlrqdi8qwwj9frqp40l8jzzp3jk2w3bmm31n97sp8ma0xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-test"
+  },
+  "external/rust/crates/unicode-bidi": {
+    "dateTime": 1621048023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0b9240db38fbd3c3eb2a896a7f5dba3f4ed4a3b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r6bd31wn5nbs18rrgaf47gyrivlxd2rni86qm78f4r7kabzadhc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-bidi"
+  },
+  "external/rust/crates/unicode-normalization": {
+    "dateTime": 1621048023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "deb1475301f67e932fa250dbd9ea49338facf1bb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z5amlnpv23q5n01093rx4j6byjc58yg1r1y0f0lcxxky293r718",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-normalization"
+  },
+  "external/rust/crates/unicode-segmentation": {
+    "dateTime": 1613865976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "70b1b1b582b452463a99a52d1f25b54e08ff828f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07fp8jn2fm4jpy523ifpc7fh9gsb1dqja1x9f508ggigmklgxhic",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-segmentation"
+  },
+  "external/rust/crates/unicode-width": {
+    "dateTime": 1613865977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da55964ed56357330d1f0b66edc3316be51f3d65",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xqr3v1kq561xbw126kj4xfvysd47sfj7rz4ld9pr9vm1nxmgr46",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-width"
+  },
+  "external/rust/crates/unicode-xid": {
+    "dateTime": 1613865977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98caf692c713a877c1323d068160b3c9fffd9f13",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11j24rxm4r9zykcidasjhgiy37p1lqrmkpa7dl0rdb7c1hyj7lnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-xid"
+  },
+  "external/rust/crates/untrusted": {
+    "dateTime": 1621048025,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b485556a1d39c976aba4dd78bfff318622c2393",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "135jcnwi4f8a5lx7lphdc9w9qsdv0xj63lxh7wxgkkz00d12hh93",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/untrusted"
+  },
+  "external/rust/crates/url": {
+    "dateTime": 1621048026,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d548f10154c4931010b78fce4e50457b2d59c6c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wm10msikrg7l999qkrwddiy6q609j07agddz71gk83gar6nfid2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/url"
+  },
+  "external/rust/crates/uuid": {
+    "dateTime": 1636160765,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c7529942794929ffbb906e9b8f69678b7f523c8f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pc8c5dfr58srbz9f9fpdx9gny327kprvxf29bvzhi4cl790a2p3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/uuid"
+  },
+  "external/rust/crates/vmm_vhost": {
+    "dateTime": 1636160765,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d307b33f0b589eae76cde69a21d5a43ef4bd1cd7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mcpfjh0yvbgbhn1v4n71rbai4spcxb9v2iy1cr859wh679niq77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vmm_vhost"
+  },
+  "external/rust/crates/vsock": {
+    "dateTime": 1613865979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31541c5432acb4ef626a631db657d6ebf73ae5ff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13x5kiyz72rcssg5ldfdq77ss5xq2q6ixixijcn4sq5411j75dmd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vsock"
+  },
+  "external/rust/crates/walkdir": {
+    "dateTime": 1617419143,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b3b68f5d3d0ad3bc9c88cbc6d3fc8a67e15f419",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "081x2cvl8zh0xh0nb2402kgdv1pak1j5hijlh3iz3msndcsqgrmm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/walkdir"
+  },
+  "external/rust/crates/weak-table": {
+    "dateTime": 1613865979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "012f87e12e3e3a9e512b24a3694f80597a02bd57",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18hkrqykf2rh7hbwzvxmwr58ixybbi7m6sl9mvb3pwk8yf2qzq43",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/weak-table"
+  },
+  "external/rust/crates/which": {
+    "dateTime": 1618362382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2eeea9e6d6eaadf54a61f982230f85ae9e7b516f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0svgz9mn1d6a14dnhghvw102s82bjyk3s9kh5ja6h08kwch2yzv5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/which"
+  },
+  "external/rust/crates/zip": {
+    "dateTime": 1621811192,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf12c92d5f31cf1eed1eb840a18ca923f92b6660",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07da00h2m2kar3r2r891jhc625d5z99jb03vb3c56135kiasnzqi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/zip"
+  },
+  "external/rust/cxx": {
+    "dateTime": 1618023987,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0743d0738c54d6f171d4c207d02ba3a7a8b99849",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jlw2bpzhynqzgdaw4f23j41njwxhd47gi3iy64g29z6hqicmdcg",
+    "url": "https://android.googlesource.com/platform/external/rust/cxx"
+  },
+  "external/ruy": {
+    "dateTime": 1616029584,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1e89bc55dfe327a0d1a51c1baeee1cad3c03be9b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sl38mw33dcla901rq0dmw98lvpdsnwyis8fsxr5qkvar7fsfai3",
+    "url": "https://android.googlesource.com/platform/external/ruy"
+  },
+  "external/s2-geometry-library-java": {
+    "dateTime": 1615341966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ff05546d0e54736e8130c03ad3f54a8c6e82d376",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x5lyg0jhcnyh647vyyhn28l7x3qgf3x7b5pasd732rqi6kkcibz",
+    "url": "https://android.googlesource.com/platform/external/s2-geometry-library-java"
+  },
+  "external/scapy": {
+    "dateTime": 1614909950,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9cf5e616b6ac663d10a9dbd2e635325c79486b30",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vq0sjbxagkkinxvzx77h6sxcvqlbl9fz9z5845q8kb9wrf2a0b7",
+    "url": "https://android.googlesource.com/platform/external/scapy"
+  },
+  "external/scrypt": {
+    "dateTime": 1612577190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5a228d99cfd08d51c5604da3236124a240ef40dc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12y4bhrw9wbp470b6pzpwcnxgy8nvlaskwa13vvpskyydiwxwr4f",
+    "url": "https://android.googlesource.com/platform/external/scrypt"
+  },
+  "external/scudo": {
+    "dateTime": 1637280366,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0dfd334ea49a4f28b4c4618003f84ca422ff4330",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05429chi5gla921898w0pfr40sw4am433xhaqbcafchk9yhgnian",
+    "url": "https://android.googlesource.com/platform/external/scudo"
+  },
+  "external/seccomp-tests": {
+    "dateTime": 1612577190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a59fbcf644c55f7c15794d07e228c98b8dca664",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "150n3hfdna544dfxw4xcd74idcz1c6rzdfzpxz26pv88ki79nzds",
+    "url": "https://android.googlesource.com/platform/external/seccomp-tests"
+  },
+  "external/selinux": {
+    "dateTime": 1621048033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b9414ba97e0f459df619377517ad39768a8f485a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19lc7df0wygsx22iljwg3528vxsib78ancc1rkq7xjdkhcv8nz7p",
+    "url": "https://android.googlesource.com/platform/external/selinux"
+  },
+  "external/setupcompat": {
+    "dateTime": 1639008446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0673488ec63ae4f7eabf9e937298b11e15174af8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "088kw109h6izpiq7abm3gkl8gz3i6zq2fdbayk6ikg1w1v5dxnhs",
+    "url": "https://android.googlesource.com/platform/external/setupcompat"
+  },
+  "external/setupdesign": {
+    "dateTime": 1639008447,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "27a19f2f87dfeceae96cfc9b3ca2979687f833d4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12blkkjlfdqkxy04idacg00qdnldqygnpp51b76vg41gblqacwj4",
+    "url": "https://android.googlesource.com/platform/external/setupdesign"
+  },
+  "external/sfntly": {
+    "dateTime": 1613952381,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "fdd425d0df39e65f37158c3cced4571b93798cde",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kakd4icw5z61imziwk9xrvrmzr0kz0c3xkx7ajqf313jl9i895w",
+    "url": "https://android.googlesource.com/platform/external/sfntly"
+  },
+  "external/shaderc/spirv-headers": {
+    "dateTime": 1613613977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35a7806c0287eae19c4928087fbd302d166f7cd6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1krwchhxqhsgjkj701884g0b40dh0j0ys78psi5g1mzvllbcnpq1",
+    "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
+  },
+  "external/shflags": {
+    "dateTime": 1613865986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1cf14048e62a5280836dd129436f5ef8b51ca347",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ffv97gprb7a2j3apfj97ss1ddj4l6zhpjacr63kxkwd4cd1sx5w",
+    "url": "https://android.googlesource.com/platform/external/shflags"
+  },
+  "external/skia": {
+    "dateTime": 1632265566,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "c1af3a4fd9d979321c103389684b746b0397e201",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06y1y8148wswb0y49ziax0yiw4d7v5glzp483dsx2pzn52ggkj97",
+    "url": "https://android.googlesource.com/platform/external/skia"
+  },
+  "external/skqp": {
+    "dateTime": 1613865987,
+    "groups": [
+      "cts",
+      "pdk"
+    ],
+    "rev": "9405f3f6b816035531b311ecbb3aab3a52d20c57",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rbdbripv9gbym5rannpyjycz7jc02rdsnf92l3ji6xz1k962a0c",
+    "url": "https://android.googlesource.com/platform/external/skqp"
+  },
+  "external/sl4a": {
+    "dateTime": 1641607554,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f10337263d7c693d8af9b3fee538d81555f29b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ir1bzc0hhj260f5gkz6w5azgqqhdl5l0bg7zms1kqbqd1p582mk",
+    "url": "https://android.googlesource.com/platform/external/sl4a"
+  },
+  "external/slf4j": {
+    "dateTime": 1613531844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "95cd7e52fcb4d65c12268b342b0cb4653bb571bc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rqxhr85x42h7nl59j3hg9zdn3f8wgv44dk8g2nmvgzfd3l63ymp",
+    "url": "https://android.googlesource.com/platform/external/slf4j"
+  },
+  "external/smali": {
+    "dateTime": 1613865989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a5ffeaf7d8402aa0fac6c695e5073c401763cc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m2z3hm7q7hyqfabnw21sglarig5g5kjhv4b12387ckx9lzyxz9b",
+    "url": "https://android.googlesource.com/platform/external/smali"
+  },
+  "external/snakeyaml": {
+    "dateTime": 1613613980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2bae0c403292be26106cd6f5e52bfcc9f6909bb1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11fyx45gqx1rqbk9cghj8lliv7g7qhfrfdbif9r0zjrmq56ap128",
+    "url": "https://android.googlesource.com/platform/external/snakeyaml"
+  },
+  "external/sonic": {
+    "dateTime": 1612577197,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87866b2fcad3531bc01978520c6777e04c70ac4c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17yl2bd3zy8wf0s2snz5734w3appr33c5f3f0jayw9crzdb8kksm",
+    "url": "https://android.googlesource.com/platform/external/sonic"
+  },
+  "external/sonivox": {
+    "dateTime": 1633475174,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e272a691b9a6e8d28478eb4ec8ecfb3ff66ba7a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z3w30hz7782xww6qgk3l5h7j899cdbvmnxvrwq28hnpmdhqlmap",
+    "url": "https://android.googlesource.com/platform/external/sonivox"
+  },
+  "external/speex": {
+    "dateTime": 1613865990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63cbe49a5e5d2d91b7eec54801e2d4177c99eb09",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b4iafcxynjq2y0i6hh3j7wgqzr51bnqm09ngwql72d12g7pvx8v",
+    "url": "https://android.googlesource.com/platform/external/speex"
+  },
+  "external/sqlite": {
+    "dateTime": 1628975180,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ce38e924fcd124e3a5ce849e6e10251702ac43f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nfx4l4ip228y03p6wpd5rwyq0sl8101xscgr3nb981vn2b8nny8",
+    "url": "https://android.googlesource.com/platform/external/sqlite"
+  },
+  "external/squashfs-tools": {
+    "dateTime": 1613613982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af637cf1fc7c92c1bb7cc1cc68592a6aa0a430c8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18yry9s66q0569l6kgnavxd84lpgqqg2zh7wqad7i7ca8kppagqn",
+    "url": "https://android.googlesource.com/platform/external/squashfs-tools"
+  },
+  "external/starlark-go": {
+    "dateTime": 1618096003,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "57e6219e60d1fd53af1d58f2a31caccdf5d44dc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kq1npxz7skla11q33az976l0kk4n5wpf3djyrhw0kglcd176vi2",
+    "url": "https://android.googlesource.com/platform/external/starlark-go"
+  },
+  "external/strace": {
+    "dateTime": 1613613983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef63a41b2ceaf5f18ec1200387a2f8437669caf1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rx0660d6z6s9id9mh8kjbmalm7qj38qrc3557k817iy81ac6n3g",
+    "url": "https://android.googlesource.com/platform/external/strace"
+  },
+  "external/stressapptest": {
+    "dateTime": 1612577200,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5860645802281e55a9bd926e72dfba37d20d8f78",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q9kbldax37x783ijnbwsr052kmqb87hs0m6z0cpnw29gdkmfai1",
+    "url": "https://android.googlesource.com/platform/external/stressapptest"
+  },
+  "external/subsampling-scale-image-view": {
+    "dateTime": 1616029596,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "104424066d57aebe3884ae97bab654143b3e4955",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0brk3l0gd33d4h8rjb06r7vnlaz821yc3bhpsyskvfv6inkpxh1s",
+    "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
+  },
+  "external/swiftshader": {
+    "dateTime": 1615856774,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2674b15f1f28bd837b8ebe5b6e4516a1027115be",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19drp33i5ha2qlxj3xgv37s8lxx0h0gmzh834fga2ydiazc2lprx",
+    "url": "https://android.googlesource.com/platform/external/swiftshader"
+  },
+  "external/tagsoup": {
+    "dateTime": 1612577206,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b4c9a66b969a3e40ca3de864d01fd3d7f3dcc313",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "092v7vx5md9lkgsnds9iaknsx7n1hm7daazy3icmahiwkq3fs684",
+    "url": "https://android.googlesource.com/platform/external/tagsoup"
+  },
+  "external/tcpdump": {
+    "dateTime": 1613613985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6d65eb89caf2b069afdcd8d1528aaa21ff823f2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sy5691a5g4lbdzq449jlywn2pl7g57bfc5a70238ivdi57351bs",
+    "url": "https://android.googlesource.com/platform/external/tcpdump"
+  },
+  "external/tensorflow": {
+    "dateTime": 1616720777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd1b1c169f9049a499dd7728721e9d5be34ad461",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "163p13dy1ghbpii05y2z2ljcnaf6w40i1cbd1ipv0wbf2pi57d7y",
+    "url": "https://android.googlesource.com/platform/external/tensorflow"
+  },
+  "external/testng": {
+    "dateTime": 1613531848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3fa437f297b631eb648e3141d6eeb2fe3c37c12",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06hxhlmx7958xbfj925xcmmzm5h3s16jxwqcahh5yp4zzn19af37",
+    "url": "https://android.googlesource.com/platform/external/testng"
+  },
+  "external/tflite-support": {
+    "dateTime": 1616547976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "079171660cde3db1119e72ccc29c81533ae98700",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00mj6sp3h53wpwgyfwmnxfch4j53sfbdijfrwg1n4g0ymafr2adr",
+    "url": "https://android.googlesource.com/platform/external/tflite-support"
+  },
+  "external/timezone-boundary-builder": {
+    "dateTime": 1595932940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e866680a7e982a20d52fe658779ceaa208c03a2b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09laamss9pk6q4fbl6gppz8d8ix47qvazqd3r8x4p36qga68n6wc",
+    "url": "https://android.googlesource.com/platform/external/timezone-boundary-builder"
+  },
+  "external/tinyalsa": {
+    "dateTime": 1625188199,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3d75798eff3ec7459f737dfd9d07ffb5f44635b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ka8qwa9j78gsiygs7rlk78lf79yir26202rf0j26xwb5aq2rw7r",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa"
+  },
+  "external/tinyalsa_new": {
+    "dateTime": 1626743249,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b7a6cab0af8bc590e56e160db46f8b5b9b941fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jjl611jjrh65kk92zdp5y5jar0qyfrcv2yz86wsf71rld5ljm48",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa_new"
+  },
+  "external/tinycompress": {
+    "dateTime": 1613613988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cec975b918a768bf022306c9225c082b88713c07",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "148k9dgzbrrrpx8c1f8plv9zdv66m0kia8ijc0j4mgfz05cnl0wa",
+    "url": "https://android.googlesource.com/platform/external/tinycompress"
+  },
+  "external/tinyxml2": {
+    "dateTime": 1613865998,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68a11508bf62e620b44212ff8e0e2197142b4991",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02cns5hw21sqy0vdd7601aj8v4cdi4rzm08fvpf8xav04xc6n4k7",
+    "url": "https://android.googlesource.com/platform/external/tinyxml2"
+  },
+  "external/toolchain-utils": {
+    "dateTime": 1615428376,
+    "groups": [],
+    "rev": "954470fea19fbdcd66b6da5e705f4c442fb8161f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pi0shn1aqwn59yxids5v0jnbbhn3gafplfhp5iy9waazwhl3pfd",
+    "url": "https://android.googlesource.com/platform/external/toolchain-utils"
+  },
+  "external/toybox": {
+    "dateTime": 1621048050,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e00d5c7a8baab306e5673cc6c60d0990482b5120",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19msz3f8ggk2qy0xif0m92aa528phlg74ibssy2b447yj735vkrn",
+    "url": "https://android.googlesource.com/platform/external/toybox"
+  },
+  "external/tpm2-tss": {
+    "dateTime": 1613531852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c055982abebabd192f9893e2f9957b435d6ec7d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11niy75h4yrwp73sbrx24v36l20syyl77cvnfy8lnxz51khs73g8",
+    "url": "https://android.googlesource.com/platform/external/tpm2-tss"
+  },
+  "external/tremolo": {
+    "dateTime": 1641946033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "036e46a7c63a9f677fc2ead34d2d2cbed2d1c8d4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lw1sd49xfcamwvwq8nfxyihk1a5mh8sld9ck1xm97ygdk8lia6z",
+    "url": "https://android.googlesource.com/platform/external/tremolo"
+  },
+  "external/turbine": {
+    "dateTime": 1613531852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0c7236f08c388250504c106f2059cdcd1679d8e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m3n7da7cg181nd9y80fm6zg7dr6i26baxg47yxkgls1agc0garm",
+    "url": "https://android.googlesource.com/platform/external/turbine"
+  },
+  "external/ukey2": {
+    "dateTime": 1613866002,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "764ab5becb950733f2bf7270817003342b30358d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wprw0h3d5qvzikh24b019506fwmjgzah0j0lmdraiv24vqspldj",
+    "url": "https://android.googlesource.com/platform/external/ukey2"
+  },
+  "external/unicode": {
+    "dateTime": 1632531985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e7abea17c90c0259010437862a27c39a585d5a68",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zldjkgxi9kl2sk9ny38nc1693frbyd3z7swnagv987p0av6q8wz",
+    "url": "https://android.googlesource.com/platform/external/unicode"
+  },
+  "external/universal-tween-engine": {
+    "dateTime": 1613613991,
+    "groups": [],
+    "rev": "804bd8e4742c1a0c414a5fa3fc118739b9e656b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ah027mh8lgrsdcqp8pbv1l6gcxjxaj8ksyji4v244awrqdhmpx0",
+    "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
+  },
+  "external/usrsctp": {
+    "dateTime": 1613952398,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e5c6e9ff8ba9aa4bc25ed0c5528685a8393c98b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ys21xj86zc4rx0x49d3r62mdi8kwx4035xbyslxqs4qlrai618c",
+    "url": "https://android.googlesource.com/platform/external/usrsctp"
+  },
+  "external/v4l2_codec2": {
+    "dateTime": 1637107566,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1736e0b1dad78d00f225038be9b85e09ad114b54",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1l1n2jjb7pwb4kfx9dy5k3jr5f3bhcph867xxflc5799f6x7npxg",
+    "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
+  },
+  "external/vboot_reference": {
+    "dateTime": 1613531855,
+    "groups": [
+      "pdk-fs",
+      "vboot"
+    ],
+    "rev": "3b85a4a6fadfd30fa28552aa4e6406d2a2025a92",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0dbrh8hy96vrfdxs7p4vz6y7k256sr6rk9dn1d0nk69pzf58xssa",
+    "url": "https://android.googlesource.com/platform/external/vboot_reference"
+  },
+  "external/virglrenderer": {
+    "dateTime": 1615075616,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "faf9acca9f98b2f78d1585ad0940cb19533d67d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m5588rz56xb42hghfkqw5qp5s4mcwcwy97hqnrxcl4sbngmmpx5",
+    "url": "https://android.googlesource.com/platform/external/virglrenderer"
+  },
+  "external/vixl": {
+    "dateTime": 1621048055,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35c5b3bba00167e263d87f98b03af9c92969f717",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1kgrgqmprmiy2rha9idcqljy7xixgn9cs64vwx3b8swpb08bymar",
+    "url": "https://android.googlesource.com/platform/external/vixl"
+  },
+  "external/vogar": {
+    "dateTime": 1621048056,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fdac4fc10f732122af4c2d577b6f368fce8e9bf9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pzid6jal940rcrimdf22128c458rkjqalnhz56k8mh0i049pzgg",
+    "url": "https://android.googlesource.com/platform/external/vogar"
+  },
+  "external/volley": {
+    "dateTime": 1613866006,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8f15244faecf9da20539210acbceb8892cdf727",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1679hx3m8h1k6q8c38pqam01dsbdvrb9y16ylxahi53cc1xqj9c3",
+    "url": "https://android.googlesource.com/platform/external/volley"
+  },
+  "external/vulkan-headers": {
+    "dateTime": 1621048057,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a10ea7a0405e7ab687f409b5cfcb5a6ff189bc57",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04dgizyvxg2p8s46n8ha24yhjmxrzqvaqy8w9v6q5q9v62z2qix0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-headers"
+  },
+  "external/vulkan-validation-layers": {
+    "dateTime": 1613866007,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7f6ee45b6d32a9857494bb2afb647340973dbf0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b07rm2880j171mswhqmppf6mn2ijrdl3hz6bicaw41cixz4ckm0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
+  },
+  "external/walt": {
+    "dateTime": 1613866008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e0c0eb36e765e4dde7b09c2316414bc44277803",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04g2zdf06pyk0k6s9ss6yswannhjqhz2m60msq206nvl1qdz81l1",
+    "url": "https://android.googlesource.com/platform/external/walt"
+  },
+  "external/wayland": {
+    "dateTime": 1615075620,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b9df3d81c7fee9977d24a577948ce574cefa083",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03wp3x0k8lys9jkm4arkcf0zkc9xal2jx9yhi2j9j3qk4h25pi4l",
+    "url": "https://android.googlesource.com/platform/external/wayland"
+  },
+  "external/wayland-protocols": {
+    "dateTime": 1632784001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a96697ed711c6dc4d20488883b5687f45aa43ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xczs3l8p79dkgi4hyy0czvp6r1cz9jiigf6sss5j7vjkk2mx9y2",
+    "url": "https://android.googlesource.com/platform/external/wayland-protocols"
+  },
+  "external/webp": {
+    "dateTime": 1613866009,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "e1d053e1994cbc20a55a526d923a30b6dbf6d064",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15zv6w3wcw11qwx5f95p5cxb1dbrfkyzlmcl6w5dx9wn0cyxjd55",
+    "url": "https://android.googlesource.com/platform/external/webp"
+  },
+  "external/webrtc": {
+    "dateTime": 1613866010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e930723900dfb3052367f9ac08eadfad5863fdd7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00jjyl1zwgqdzmakvgsw6iyasiz1y9fwh2k3n2yff0050vk6499p",
+    "url": "https://android.googlesource.com/platform/external/webrtc"
+  },
+  "external/wpa_supplicant_8": {
+    "dateTime": 1638922016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "630b21b03932f4f3e525bcae03dfb5b4650cdfd3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16mnb2lpy31dqyglki0p2j4ppx5z6sw87w1d5zfkbd5j59mdmzfw",
+    "url": "https://android.googlesource.com/platform/external/wpa_supplicant_8"
+  },
+  "external/wycheproof": {
+    "dateTime": 1613095637,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "064d735862fb647b18d638c923986abb9111d728",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0waib4n8k684l4nl339w9h1f5g52461qh51kk1inknj2bpvy78vn",
+    "url": "https://android.googlesource.com/platform/external/wycheproof"
+  },
+  "external/xmp_toolkit": {
+    "dateTime": 1612577223,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df338797196d39b1c80bf6af97dae917b558a40c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vni2h737zxzcd9lg7fgxh3vv88508kn1kli04nh2cqmld9a9x1v",
+    "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
+  },
+  "external/xz-embedded": {
+    "dateTime": 1613531861,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db58ee8469187cf255a053cb8ad7c45d917b8d50",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "073plk8szhih5chpaf91jfi9w3f8sgx3s38y79zk9g11mms40dpl",
+    "url": "https://android.googlesource.com/platform/external/xz-embedded"
+  },
+  "external/xz-java": {
+    "dateTime": 1613614001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ac0f033000a0b44aed0e966e6f65e769f681698",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "106wni1mvkx7jjag4401v8dkmqrl7kyd17a8nlik0wqwai9akmbb",
+    "url": "https://android.googlesource.com/platform/external/xz-java"
+  },
+  "external/yapf": {
+    "dateTime": 1588621644,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "d814b4752c490089139f3ee55c67e91160a0bc9d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04cxpdc46h0z75d2b8a73lx3x25k881qkps309sa7irxvqjlq4av",
+    "url": "https://android.googlesource.com/platform/external/yapf"
+  },
+  "external/zlib": {
+    "dateTime": 1621048064,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ebf1f2ed6c7238f33b30f19af14a811a30ca27d6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12640wzjmqgjdya2zdb14ir5d3q1fds04hs878wsw8jw84aw3jkp",
+    "url": "https://android.googlesource.com/platform/external/zlib"
+  },
+  "external/zopfli": {
+    "dateTime": 1612577227,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "915d125c38fe8867e06f8e0194cd8d3ec6160400",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y0lrn1mcw9233dr93361d0mjwpqlsrq4d31l1kgr1lyfdx2lf5l",
+    "url": "https://android.googlesource.com/platform/external/zopfli"
+  },
+  "external/zstd": {
+    "dateTime": 1613866015,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba2638ee6baafedc78ac49ba55ec8456bfaae36a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nc7pf97s580c66hyd11zjcj1ah7dd2ls3nkgdia3qmrfphwl74x",
+    "url": "https://android.googlesource.com/platform/external/zstd"
+  },
+  "external/zxing": {
+    "dateTime": 1613614004,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5cca09b24aa57e3564c80841fb77bc68bc564daa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hn3cmj8msdwggbqzaqvscri38df1j35c921i2k518wikghi7wh0",
+    "url": "https://android.googlesource.com/platform/external/zxing"
+  },
+  "frameworks/av": {
+    "dateTime": 1641607582,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "538772b9dce6cfb785d82e648a95d93bacd0421d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0x3zqnmkqvkc7vcfdl2vmhaz4kfz5q0hmx3p61ib8yiaw7ds95l1",
+    "url": "https://android.googlesource.com/platform/frameworks/av"
+  },
+  "frameworks/base": {
+    "dateTime": 1644453735,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5ffa3c496f736f82d31b37a1f360171853bdeeac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "048bgc7vrwgz295s9y6mba26qis4zz7fwhyk6z9mhjaxpfwyavgr",
+    "url": "https://android.googlesource.com/platform/frameworks/base"
+  },
+  "frameworks/compile/libbcc": {
+    "dateTime": 1613866017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5104e8e765727243363e0c529052cbf1ca4831df",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n03c58wxfp76z0hk2y93r6jfhi7rvrbmv5iwnj6gy9aw6a5a4fg",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
+  },
+  "frameworks/compile/mclinker": {
+    "dateTime": 1621048067,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cee7af315b48e10caee89fdeaeda49875914c592",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "162nkr6acndsx278g31ygazpv9raxigb69qnic1sv97n94v7yyvy",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
+  },
+  "frameworks/compile/slang": {
+    "dateTime": 1621048068,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "78b0b8c51d9987c7456ec511026aba7e5fc23e9f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16jzz2xrgipqlp8ixmssapxpqnhyz0x8rlwkv52v6g90psl25jl8",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
+  },
+  "frameworks/ex": {
+    "dateTime": 1628975244,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "fdec410b759fb6ab69cf9331d72d8315fba1bfdc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1pr2k2a0hk47khbl1bp9ljxcw95k78b37qbkql9vh51r89hrhyis",
+    "url": "https://android.googlesource.com/platform/frameworks/ex"
+  },
+  "frameworks/hardware/interfaces": {
+    "dateTime": 1634252977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0195f3f24716c7c46df5f70ca0eb794d4d127681",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1031nf3zchb7jgx4jr3qrmssjr6l5jb54iwdalx616avaj8c9wxs",
+    "url": "https://android.googlesource.com/platform/frameworks/hardware/interfaces"
+  },
+  "frameworks/layoutlib": {
+    "dateTime": 1621048070,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5896bb4176667e841e5b4da7fd0aeee0cc57da28",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cw2y7xcd3w1nzljvzgckli8d328y5xxj5ynmxpnszcrlyiymish",
+    "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
+  },
+  "frameworks/libs/modules-utils": {
+    "dateTime": 1623978477,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "97829faafedf9c8e688672e90680080e5e20a751",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0fsixxvkxw1g26jjlwmmrybbzzwgxl1gswbilyk73dmf1cnmx711",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/modules-utils"
+  },
+  "frameworks/libs/native_bridge_support": {
+    "dateTime": 1639188382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ee438b089d87625b8688e08993c63d4e02faf3b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "117pjlrcjrxz0269q47zhhcpspcy5zyq7mcpr84f3f7h7dc4kjr9",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/native_bridge_support"
+  },
+  "frameworks/libs/net": {
+    "dateTime": 1629241608,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e405d7606701733689f3898f38314dbe4bec5a65",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0raxv23lflhvcgnz1ci2w6fn6gv5kyb6zx5fmmv8s8bqsq3sbsgm",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/net"
+  },
+  "frameworks/libs/service_entitlement": {
+    "dateTime": 1627521188,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "35330aeb94b8ef00ad61714ced8537579d92b1a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z9kin6rn0dh7h1av6larf9swnzcni5ckjc4v8pzyrdvff9qj3l3",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/service_entitlement"
+  },
+  "frameworks/libs/systemui": {
+    "dateTime": 1641513993,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bbe05485ee74c53c76ad91f70cba7fda2051db5e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "038h1pmp7sz7p7pwayxxvgwndp55wsyl7pmqq11wy2fd8yzcx3mb",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/systemui"
+  },
+  "frameworks/minikin": {
+    "dateTime": 1623805659,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1f7d0e8385abf4f36b3e0aab4d860b00172fb638",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gja9jpb28rzvjk25ii48vq8mzlnsrhv3ja9k9xmab0jhkpfam99",
+    "url": "https://android.googlesource.com/platform/frameworks/minikin"
+  },
+  "frameworks/multidex": {
+    "dateTime": 1613531872,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "108ff0dec82e65e42d0cc43db82ac34e13ada358",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xwqn0ik1in5rpwnr1xygbggjm8ysiknp2hvf2m24859zg90lng7",
+    "url": "https://android.googlesource.com/platform/frameworks/multidex"
+  },
+  "frameworks/native": {
+    "dateTime": 1642284403,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2cb6dbd934cd68bfade69554b1c6df5ce3105182",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0z7ilybkmc2z68ar0jkbl3fmas77w2rwnwfqix2q2nr8gkvanywn",
+    "url": "https://android.googlesource.com/platform/frameworks/native"
+  },
+  "frameworks/opt/bitmap": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "cf0cca9e43fc638adce77c112c30d15c83358bc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ipvhhkj8d1fpixx5s51133k87riqdczaarw9lnr65anx4s781sb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
+  },
+  "frameworks/opt/calendar": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a2e122a35b9ff98b85917ca9fa029d2e6c871946",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jjj2y6qsj5q20fj4rr1kbx7cn233myv6yk5l2j23x41nryandd2",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
+  },
+  "frameworks/opt/car/services": {
+    "dateTime": 1636675597,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d4ffc1fc532f8bb31dec18c106d8d55429e73005",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1iiz2gyvfdsl3m2c05fhyfi4s45n93bwlim1qly6k1pcpb2yi2wb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
+  },
+  "frameworks/opt/car/setupwizard": {
+    "dateTime": 1638490023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d23aedd955b9ba87f569da27de446e75b01762f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10jlx17qgc069rfkisf3303vg33jcqb5b11xcdg7dddyidbjvkpw",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
+  },
+  "frameworks/opt/chips": {
+    "dateTime": 1634951219,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b0d4a71792a7f8332c3f04d3b05ec171e0e6413e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "074p77mfj9w9b7k17r1dhr4y5p55r8095jhan9xz8v405zxzxl08",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
+  },
+  "frameworks/opt/colorpicker": {
+    "dateTime": 1621048075,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bba47ce4c5d563cb236603ed3ee3c8dc6ae0f4c6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vvn2sc29sc2yhvk5lz0gcdfb12321w4bcy24xkqvsnfsyddc877",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
+  },
+  "frameworks/opt/localepicker": {
+    "dateTime": 1621048076,
+    "groups": [],
+    "rev": "0c360d04a4f8baf5758e61b2aa042264a6b97dc1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r125r6xswixm6b6d68bzc489h6xhb7s0bjgs8fnay4vbsq4419s",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/localepicker"
+  },
+  "frameworks/opt/net/ethernet": {
+    "dateTime": 1624410476,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ca7650bfbc01e41c44fa0f4062209f54ba483df0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1w5v0hr8a7qwrnf8f63fb6lnw19hggzjp7a1wrpfg1l539jaxv8k",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
+  },
+  "frameworks/opt/net/ims": {
+    "dateTime": 1637885266,
+    "groups": [
+      "frameworks_ims",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0026f3cfedd1d4f0a512513afd584822d7cb65b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10436q6ls2k9xgwvr6gg52ijia0vqj096zldc81cbqv4ckzcz90v",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
+  },
+  "frameworks/opt/net/voip": {
+    "dateTime": 1622768867,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "870cd9bf789348315e77f6f67ecad554e365dcf8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y3mffpp81hgzkp9qlwl49s82b5zlb2vbznxc3x5hp5kv2p6i7bi",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/voip"
+  },
+  "frameworks/opt/net/wifi": {
+    "dateTime": 1641766101,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8656b6d13561fddcbd8b2703a8d11b023a7b4391",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07vmqp5yhswl96aa707g3qzba3fvklqz1w8n8jz69063nqcnvx40",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/wifi"
+  },
+  "frameworks/opt/photoviewer": {
+    "dateTime": 1629508007,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b9d7cb0ff102180db08560d37b4169601a525e9a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09k0svr6wgxs9dras8ycz4lb1mf94l5q60cark0akggjsm6q0a9x",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
+  },
+  "frameworks/opt/setupwizard": {
+    "dateTime": 1621048079,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "92425693c1e455ec5d26d976ae5d5dccfbed1930",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sdvs3n3nxd0dflqyjqqhf0g1drznwqrkbd4qv5za5n0g9dqg5x1",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
+  },
+  "frameworks/opt/telephony": {
+    "dateTime": 1644453737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ca72c04e3ce3627045498910ea5c4c2f479ffcd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06phw8jrnawm80iwjw16l03kw20mlk38i7f82vdibp8kfr7m5dfw",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/telephony"
+  },
+  "frameworks/opt/timezonepicker": {
+    "dateTime": 1633208819,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5b82532cd194c8b4f321cf6da93120836f86a034",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yz5byfqgkra3qim8gnrafna4cdxss3cfl6gflkggw768viabbgz",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/timezonepicker"
+  },
+  "frameworks/opt/tv/tvsystem": {
+    "dateTime": 1621048080,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4e123d96cfe8a52c50cb1a3d6c89149dcb8a5388",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1008lz757hs6yjl71xcblv8lny21xlkvsh70sbqnv7akbn4pk3m0",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/tv/tvsystem"
+  },
+  "frameworks/opt/vcard": {
+    "dateTime": 1613531879,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d77f309e44367a54af29e4565e9366a9566dbf37",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ahqdbqw285rpk7cnsjq0fzb60jmpf5a5z32vz52apxlg68k5l1g",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
+  },
+  "frameworks/proto_logging": {
+    "dateTime": 1642212415,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bcc53d06dd41c853105ee767c82d2cea5c67e140",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1a7n4dpd4i36ry7v3lrby0dw1s4iczph2q4fqh8a7hvmxl77zd2c",
+    "url": "https://android.googlesource.com/platform/frameworks/proto_logging"
+  },
+  "frameworks/rs": {
+    "dateTime": 1621048081,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6368b0c145c162bbce4e98740583ece662a2b19",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gybw0hsp2p5mm7g2v737kg0ca5nys2f0333p9ma19sz5dyww3ma",
+    "url": "https://android.googlesource.com/platform/frameworks/rs"
+  },
+  "frameworks/wilhelm": {
+    "dateTime": 1623200882,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d0a3787691efbfb5499f2297d2995865dddfd1e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nf5sx9zjs2ybcp4fqwzphgan379l83fml58dhs5x4f24rj80bxz",
+    "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
+  },
+  "hardware/broadcom/libbt": {
+    "dateTime": 1615943218,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9603a94de6207eff352eae13b86621640cf8eac3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12945i09sz39ygg91szzabmw7kmhasn9b18sb2v8fkxxzqcy7nih",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/libbt"
+  },
+  "hardware/broadcom/wlan": {
+    "dateTime": 1640218032,
+    "groups": [
+      "broadcom_wlan",
+      "pdk"
+    ],
+    "rev": "4c8e10d0b400d66cac0a51ba43e25a621f3ba19e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hpx8s0lfzmni6ypca0nk5m5qidpn9jw76wnyrggl942x1rwhixm",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
+  },
+  "hardware/google/apf": {
+    "dateTime": 1613866034,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65a88a1cac6e38dda215c3d8e946860cfaef56a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "144hxkgnbh4jvm5a830mjwsj5zcp4z0g61731r9vj9kx8kaxqxrr",
+    "url": "https://android.googlesource.com/platform/hardware/google/apf"
+  },
+  "hardware/google/av": {
+    "dateTime": 1633561918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7569e6d9dc2bf6c858ec49c70ec4cbc2fb8ec440",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d3h8g5fbvqyxj8v7q1b2y049gi17wq8dd32yv2671f5rv5a668j",
+    "url": "https://android.googlesource.com/platform/hardware/google/av"
+  },
+  "hardware/google/camera": {
+    "dateTime": 1638922044,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2569a666677a37c176e463f2918948b8e4ea96ff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1inbbmghiizfwg627ffdrihhi4i8zsm61lg4v94ql3fqmkcczxsr",
+    "url": "https://android.googlesource.com/platform/hardware/google/camera"
+  },
+  "hardware/google/easel": {
+    "dateTime": 1612577257,
+    "groups": [
+      "easel",
+      "pdk"
+    ],
+    "rev": "3066fc984b1052b00421e5c7d2757b5f2a116b32",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0a8hgw2y5z36vqn9ifwsci7bn6qznz1kjzvswhzif2cag7249nvh",
+    "url": "https://android.googlesource.com/platform/hardware/google/easel"
+  },
+  "hardware/google/gchips": {
+    "dateTime": 1635980845,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "e3ff7429d5226cfe0bcbae505a8092eb40e79cb8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15n2xxbpjm7qdca78q769f8jpbwgr3w2116mm2b4w3m6bsddaxgn",
+    "url": "https://android.googlesource.com/platform/hardware/google/gchips"
+  },
+  "hardware/google/graphics/common": {
+    "dateTime": 1640650073,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "77466d5f48046fd1ce8656cc7d52fb1dcbdf90a3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cjs2y5l2ph113kldgfgiv94w0i06flmlzgf6srq2x3gcy5b082v",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/common"
+  },
+  "hardware/google/graphics/gs101": {
+    "dateTime": 1638583625,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "c27f01dd3ef5190e7a215ba80c8981569202fac1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ip2lc7qxg6h0ryqnb7n5gv8n2pa88cyrdgxh3mssg6n743ifhii",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/gs101"
+  },
+  "hardware/google/interfaces": {
+    "dateTime": 1639008531,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "27065829a1756da2b34492b9ec6d07fd107b3363",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ln465hm51ih5zjvlf1aff4xvqna7aass2sph0y0fv7134sqnfgk",
+    "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
+  },
+  "hardware/google/pixel": {
+    "dateTime": 1641607606,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "f5279316585aca37300d252e7a87bee1db90c73e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yqpki4hpa2ziqzl2skj69hxmrwzcpf7rgsyby1vv1yzdgpid6z1",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel"
+  },
+  "hardware/google/pixel-sepolicy": {
+    "dateTime": 1635376050,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "4717448e488691159c5db073e08a3cd00d1400d8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1s1m9ba5mgis0rq0rlg87ab37128xymhd0d3byl106vv1n2n6fzc",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel-sepolicy"
+  },
+  "hardware/interfaces": {
+    "dateTime": 1642284420,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2eab4395e5e77c82b263dcae57b5f7039da21308",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v4khlbbczr3xl8q54f9iv8ixv2zwdqlfkslgp0fjq3qw7vcxfbv",
+    "url": "https://android.googlesource.com/platform/hardware/interfaces"
+  },
+  "hardware/invensense": {
+    "dateTime": 1613866039,
+    "groups": [
+      "invensense",
+      "pdk"
+    ],
+    "rev": "6ee695f17a4d214502054d9099210b03e1b0989f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12sqj3i0avyqpl6nqi8flaskfqlsfvvxzllskkfa67n9cknnv2p0",
+    "url": "https://android.googlesource.com/platform/hardware/invensense"
+  },
+  "hardware/knowles/athletico/sound_trigger_hal": {
+    "dateTime": 1614910016,
+    "groups": [
+      "coral",
+      "generic_fs"
+    ],
+    "rev": "96adc2bfdff4c0fefe97a284dd4d8af3f12361e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zh4cb9rggg5in2ha4sil7qn28m97iwldwn7d07nz6xyqiwxd4i8",
+    "url": "https://android.googlesource.com/platform/hardware/knowles/athletico/sound_trigger_hal"
+  },
+  "hardware/libhardware": {
+    "dateTime": 1639699664,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb87be31ed7773f84df316054383f3cb39472f8e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04a0njwhqyyd35jpkqj2bzwygq0f3jvx00p922336sr9n4bz4rcz",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware"
+  },
+  "hardware/libhardware_legacy": {
+    "dateTime": 1622682513,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "59f265df62320ab1fc46de0c7f8f99a82198fb5d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18wjm9bcka81flw01gkldxslg1vgr0vypsh3ic4b6jxaavxi0b43",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware_legacy"
+  },
+  "hardware/nxp/nfc": {
+    "dateTime": 1642032627,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a2fa3b32cfde176c8cc681877a0da75e01afbe50",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0p9njiskp259jq9b7j3g227cdc7ybwmjyirr45hz57i650n2gqsc",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/nfc"
+  },
+  "hardware/nxp/secure_element": {
+    "dateTime": 1621991321,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab64b716875cc2309a98f99594bb1a0346c0009b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "063k3nh3vp9nffvq2gl3zirn2wx9hna8z67fkcdj30f9bm6vglcq",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
+  },
+  "hardware/qcom/audio": {
+    "dateTime": 1621048092,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "cf4f81c1d2a39523ac7caaa8893318425bed77f7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hikyx0hvmycblqpapviqbjkf890b6cn4yqpiyrs4w4isbf8w37j",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/audio"
+  },
+  "hardware/qcom/bootctrl": {
+    "dateTime": 1613866041,
+    "groups": [
+      "pdk-qcom"
+    ],
+    "rev": "584bc93bfc10f8119fd75f22813c40fa7c99014e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04dv3a0zj03af7g4c19kiif4v1gff0fby467kh3ji440y4z00r31",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bootctrl"
+  },
+  "hardware/qcom/bt": {
+    "dateTime": 1612577267,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "5ce2458331468097c4c5071a59dc219911609a3e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0a6h3jcprciwxjq86nfiiij8f7475mah4qgxgsfdd2b54cy37jbc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bt"
+  },
+  "hardware/qcom/camera": {
+    "dateTime": 1613866042,
+    "groups": [
+      "pdk-qcom",
+      "qcom_camera"
+    ],
+    "rev": "50df0ed003475cea24195c349d68ba02b72d5286",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0p2932v9hsmv6i729zvzq0fypxcdh7xdhfyiz57pspm3xpv7f9yk",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/camera"
+  },
+  "hardware/qcom/data/ipacfg-mgr": {
+    "dateTime": 1613866043,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "e0f1fa2403e97f54b7d3c76cc0ce2d8aec55088b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11zhb0diqxlz9vsxzbvxn8pv6amxrclvqybnr5acbs8awlc6h6xg",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/data/ipacfg-mgr"
+  },
+  "hardware/qcom/display": {
+    "dateTime": 1613866043,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "320c7d7d39d82c91ac8925cccd3d1976e8ff27f4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1w8fr68drhj6wjqvla801wianxb71ybpxwfia4v7mjrf7krs09a2",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/display"
+  },
+  "hardware/qcom/gps": {
+    "dateTime": 1613866044,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_gps"
+    ],
+    "rev": "39ece015723b1486b3ef777de2fadf207f37949f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r99iirahalmj8w9v93cqi9lhandavj88jqwlcgd01czlrynwm9x",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/gps"
+  },
+  "hardware/qcom/keymaster": {
+    "dateTime": 1612656444,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_keymaster"
+    ],
+    "rev": "94bfe64333952ff045d4f371900fd17cc41fe37d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09882azkwai7h3xdr0krqv4d5k63qdyvpwzcw6d16wljbfkf525r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/keymaster"
+  },
+  "hardware/qcom/media": {
+    "dateTime": 1613866044,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "27b25d73563ee4a57bc5b5f0c27eed98ac159faa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1djq7k9gi7d359cdif0rysfprcfs16sjmfjqkj88a6px9sl0mdy8",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/media"
+  },
+  "hardware/qcom/msm8960": {
+    "dateTime": 1592337238,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8960"
+    ],
+    "rev": "35c2ed559e0290a927d00959796cd609ea7589aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13ss8wgnd4306024174vsfv6ka2sf45jzx7d4b8z5ywcpqiyczwm",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8960"
+  },
+  "hardware/qcom/msm8994": {
+    "dateTime": 1592337170,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8994"
+    ],
+    "rev": "70871a27b0cc3aa0012a62654c2689dfceb42362",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15zxcb9dx1862fvasyn11iav765a3522my4mxby5iymjax8sir99",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8994"
+  },
+  "hardware/qcom/msm8996": {
+    "dateTime": 1592337277,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8996"
+    ],
+    "rev": "986d8b54ed0817f1e6c1462a85f439d540848ff1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0g381r0mv2rv0yzq0qw2m65z6a6wx2wsc14xln7q9pphn7x7kfyl",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8996"
+  },
+  "hardware/qcom/msm8x09": {
+    "dateTime": 1588715629,
+    "groups": [
+      "qcom_msm8x09"
+    ],
+    "rev": "c00622913dbcedd65b4a4ecd4c463c3c16512054",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17hq55hsfyzknrjfmw877y5cnm4mgxi7bdj0fpb920gcn6klfdrs",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x09"
+  },
+  "hardware/qcom/msm8x26": {
+    "dateTime": 1592337224,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x26"
+    ],
+    "rev": "0b666b78c6274792f112d2811f8a3953d7616a2e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kxbm2sk5lxzydh2f8jv1z6j3qpjxrb2b2vr3q71mfwms76z7zlc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x26"
+  },
+  "hardware/qcom/msm8x27": {
+    "dateTime": 1592337231,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x27"
+    ],
+    "rev": "fdbaf086799154eacdd2a35626a577f4a390330d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bly3vx1ykfm251fz9c86znqzy9f8rlmgijaczzz1hk78mrk5sy7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x27"
+  },
+  "hardware/qcom/msm8x84": {
+    "dateTime": 1592337218,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x84"
+    ],
+    "rev": "cd1b870854d932f8c2e9c20c905ecb7588efe19b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ds8p9sr9r3m9lncav7kjzma9m1v6abapddjx6xjncn9ghv3ga08",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x84"
+  },
+  "hardware/qcom/power": {
+    "dateTime": 1613866049,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "6e43051cd8b3889f894d6948762bdf2fd6e44ef2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hgjhbm8bj66nm29xgmg9xb32y12kz4jn8bm4fpflxn1cz4gb38g",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/power"
+  },
+  "hardware/qcom/sdm845/bt": {
+    "dateTime": 1613866052,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "6218b463625279aa4c6eea59cb5fa144385bb60b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16wxyxlvywkqpvlxlch8czcdjchnqnza5z8qhb1qgwv0kylrh1pp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
+  },
+  "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "dateTime": 1616029670,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845",
+      "vendor"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "6b4f68c872c91bcf0f7c4db5786d4d986ba3ed8d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ymwzhq5n5cawc6cwspz5xbdc1vzxnxrp7nslmf9kc7mvln56hr4",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sdm845/display": {
+    "dateTime": 1621905002,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "475f4b43bd0d136ed8a59229b86341a9c3268097",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hh37liap88gw5rl1yn15mpx3b96iw8qk7agsvrrxszyxvbksii9",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/display"
+  },
+  "hardware/qcom/sdm845/gps": {
+    "dateTime": 1624497192,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "fde638ca747dd98952d82f9e200b7f762ffbe183",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15ibil263invfsc8p2889lb92370zxi27gkgx14b8y0jnpf4jx14",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
+  },
+  "hardware/qcom/sdm845/media": {
+    "dateTime": 1613866054,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "9ff6f2fb41573dc9c933828d150e477b9c8530db",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10csk645fbbkcszv3lb835h2v1il4x6dihadxg23g7y2cxfi6nvj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/media"
+  },
+  "hardware/qcom/sdm845/thermal": {
+    "dateTime": 1613866054,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "4b9812ddf94c3fc1ef2ae9e4935cf02776738756",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08jfmac2ac6zgfxg8hgvxmv70xk5mlz15vqrxy5xcfsg2f4q1c8r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
+  },
+  "hardware/qcom/sdm845/vr": {
+    "dateTime": 1588703755,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "b8d2bf7f8e48a9782a64c69b5cb6afbd48cb26b5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06fbwha2qkigss5r7r5vmgnr3c64cxy3njdp2qlbsxgm0c07xy9q",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
+  },
+  "hardware/qcom/sm7150/gps": {
+    "dateTime": 1617152862,
+    "groups": [
+      "qcom_sm7150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "db9226c3844f938352be3960c16de7c3d3baed75",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ilgf2rdxniq5b63an8asrbdir2f82yj05qcq8pg51gmkm2550nh",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7150/gps"
+  },
+  "hardware/qcom/sm7250/display": {
+    "dateTime": 1624497194,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "5cfde69f4324653992d2453983bd38b0586d2d59",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vha4cs3p8zy3b8m1di92wgypi8blsgl8a8aw997j9p4rg9pvm29",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/display"
+  },
+  "hardware/qcom/sm7250/gps": {
+    "dateTime": 1631322443,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7250/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7250/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "366e0e299aa79a24e797e977151e2fc65f2a37b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0a4d7vqlj666q8sw6548fli1hcmviqaqv9xhay4a3l3g4ppgylxp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/gps"
+  },
+  "hardware/qcom/sm7250/media": {
+    "dateTime": 1624497195,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "83311baec09683e9861ffb467eee8bb15059ad7e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mxv8v1fnxr4gmjc92l16zmzxbiyppppszmjyjc61rkj3z92vdk7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/media"
+  },
+  "hardware/qcom/sm8150/data/ipacfg-mgr": {
+    "dateTime": 1624583468,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "8e1dbfc8ea45956afffde6d0ffde2d98601a80a4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nl5wgfh2fnwh6ypyb7c4fga6q434b1nzfl4ha9l0qm24b5zw6vz",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sm8150/display": {
+    "dateTime": 1630112862,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "d4b668ab7444574fc9c9688ee05ff54e17fe15ce",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03hw9zi4rh43crmxafd1jnjbd9fpzln0mrd6rzc00lyb9hk5if10",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/display"
+  },
+  "hardware/qcom/sm8150/gps": {
+    "dateTime": 1634857692,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "4edbd532c885e087884053dc9921af7ebcedc5e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yhdc4qj2xjm4n6ym6yfldrrpbl263cj81n8fz08l6p4v3qfkc7z",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
+  },
+  "hardware/qcom/sm8150/media": {
+    "dateTime": 1624640114,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "47bfc4c027d8843898c8b33c7c655b1052ed8e2f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07ghzjg7k8jydqg46w8s5w3ngjx0y533xyx8aigji399f1jdj9fd",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/media"
+  },
+  "hardware/qcom/sm8150/thermal": {
+    "dateTime": 1613866058,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "c79f2f3e111cab812950b319b16407c1aa170641",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "068aa9jpgn5b8gdy62jz74hhik1dh4yjgliaavfhvqmg1mbgn7d5",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
+  },
+  "hardware/qcom/sm8150/vr": {
+    "dateTime": 1612577287,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "61c9b3474582b3a689557f168f4fbf79173d7bb4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k4dfzb7l3pk0zdxzad6y20kckyac5dl5i26b6rg03ip940ij7dj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
+  },
+  "hardware/qcom/sm8150p/gps": {
+    "dateTime": 1617152867,
+    "groups": [
+      "qcom_sm8150p"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150p/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150p/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "3a45e15e57b38026d127e26e7aad73c69006926e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m43j0m0cdjn7xn81n1a9h9v2b3846vixqffamajb8qrfp25yvzr",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150p/gps"
+  },
+  "hardware/qcom/wlan": {
+    "dateTime": 1637798881,
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "1fd28e3120432b47eb7d40bb58cd17bdfca4f0fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00y8hnmjl0a3g311w28iq208hx9spgchl9qz5psj1nl0zaqfrgnl",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/wlan"
+  },
+  "hardware/ril": {
+    "dateTime": 1622768904,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "40f0d25ae27b505a11a55b7dedb31ddf174d60e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13r4911z64whzp7q6sm9153xqj9frzmyq95q6dgfx2z6826gxcxn",
+    "url": "https://android.googlesource.com/platform/hardware/ril"
+  },
+  "hardware/samsung/nfc": {
+    "dateTime": 1621048115,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c2cac11b183ce464d1351a8d73e551b40df3f89f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mcsnjjngc7v1rb0pdf9fkjz5ww7smpdyxvll32yayx27nfmnsdq",
+    "url": "https://android.googlesource.com/platform/hardware/samsung/nfc"
+  },
+  "hardware/st/nfc": {
+    "dateTime": 1633043693,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "67b00af0be464f4067285c29f8acc831290e4fdf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18g57s4cfv0wamfn78nwd8hr66vn4b27swnlhllc69psnklql39y",
+    "url": "https://android.googlesource.com/platform/hardware/st/nfc"
+  },
+  "hardware/st/secure_element": {
+    "dateTime": 1621048114,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25c87bcbf8de900d75b69665a3b492753297165c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "043ca4c21n7jrrckdd2b6j9p1prg4y08k8giw7r90q8kk2bf4cwl",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
+  },
+  "hardware/st/secure_element2": {
+    "dateTime": 1621048115,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "021c915fcd963793017a1e5a608a34a2468c578d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "183k0fmav5ndrkxkl7bnkm5mqyq0ddjjw6iilnl5y8122cg8phqn",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element2"
+  },
+  "hardware/ti/am57x": {
+    "dateTime": 1613866062,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cacfa00fe254aaa7e0e90d5aca4a3141b4ddb0cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gqn5lsyf7s420cdiga57w2c6g03zj048i5qq9r4904abcn9w1bm",
+    "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
+  },
+  "kernel/configs": {
+    "dateTime": 1633208857,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "2806ab97483eac9f09b6cb3291a5a59cfefce997",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08w0m10d9ni4wazdr78gf1yzzihafqbzg4yxxjzpw1gwrv6qm402",
+    "url": "https://android.googlesource.com/kernel/configs"
+  },
+  "kernel/prebuilts/4.19/arm64": {
+    "dateTime": 1641946103,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed14ef0826ee928621a9e86a1118bf9268831eff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "15x4kkyh0744hs3jl0acjmgdn2h2sqgnk5m38w2mz9m3wfkmks89",
+    "url": "https://android.googlesource.com/kernel/prebuilts/4.19/arm64"
+  },
+  "kernel/prebuilts/5.10/arm64": {
+    "dateTime": 1639440459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04d61ae1e8efa40ef6be54b3faa627a8df8da564",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16ia73462a37wpd5qar7rlb9kn9ns5a4j5i3xj3vp4dwawp3zpni",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/arm64"
+  },
+  "kernel/prebuilts/5.10/x86_64": {
+    "dateTime": 1639440459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f093f3cc891ba76db7ff553d5af7af048b28e562",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "17my5v5r8ix6jgsdkjp2905maqjrm2jflpbi4j3fxl9337jx20ca",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/x86-64"
+  },
+  "kernel/prebuilts/5.4/arm64": {
+    "dateTime": 1640131662,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e57fc2b3a3121001b26bafc33ff54dd93b183dd0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hkcaka6rhn8lqwl9pcvglvvj75ais01g0v1d22dx42x99x2cq4m",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/arm64"
+  },
+  "kernel/prebuilts/5.4/x86_64": {
+    "dateTime": 1640131662,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "017fd9e2d279e4fd67780f8dd2c772ef257bce38",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1czk73h8piwgiwrrnhb9qisb76h5s6ff5d42ydsxnqx6sri2xwzh",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/arm64": {
+    "dateTime": 1612209682,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a27394ab54f12eb282dd6bd736c98a6959447486",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/x86-64": {
+    "dateTime": 1612209835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4eb41847eca7ea51b6b8915c107c335695077e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/arm64": {
+    "dateTime": 1639440461,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f4de285e2a81bf9df0ea014846ecdbe85033f883",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01hwiswcsqyhf64hhvgqv6k3dpq6alyz9bm806iw2znyn1hdqzyc",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/x86-64": {
+    "dateTime": 1639440461,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43ebfeac3df659e07c1a7b53a9ebf63ab0abc3d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03b5vsyz9qldfmpmc3j48fsd6zqpxvh889fmjgnhl14jd2b1alag",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/arm64": {
+    "dateTime": 1640131666,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1265fc8605c9625dd6c4d7a8a965e1009175928",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "070812yxvcwspq412zx2bppyasaww00ax3qjpsnvhxxzrb4vvfi8",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/x86-64": {
+    "dateTime": 1640131666,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a16914e71780a4621ba03d34841644a18653134",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "044f032w1dmzc5xrpf77da0la1qhdsq8mgpqm2b62ww9hx75bkvm",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/arm64": {
+    "dateTime": 1612210495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0352b90e933810a8dc3f0f8dccb56095458a93ec",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/x86-64": {
+    "dateTime": 1612210658,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eeb17b3d2976ac350300491586cfb648a48b7d38",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/x86-64"
+  },
+  "kernel/prebuilts/mainline/arm64": {
+    "dateTime": 1623287375,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a62a13e8f266d9ca2c0f6a75257e829a42da59a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pw66qkkcil7wmfamvikdjsdmsr4vysb4f0aby02ygix2kdwfx6p",
+    "url": "https://android.googlesource.com/kernel/prebuilts/mainline/arm64"
+  },
+  "kernel/tests": {
+    "dateTime": 1624497210,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "47a1ab736b761cbc1ca79bc8793a913958715539",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xibcqrq89p12cng3qsg5hcc7lf2mdz90g5cbipz7rxwqpid2qc8",
+    "url": "https://android.googlesource.com/kernel/tests"
+  },
+  "libcore": {
+    "dateTime": 1641607644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "545a7618aaa2c7c8c21953b1532338abbde01218",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zi111nc4412xv5bj0j9hhgpdmdkcq7l5imk0jxsadw92y29z83s",
+    "url": "https://android.googlesource.com/platform/libcore"
+  },
+  "libnativehelper": {
+    "dateTime": 1625706908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21ec1f8735dcb57ced675a2c2affa6917200e060",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1509vfazmfy60ny84mljzf1iw0m5hswg922z4wm8ac79gw5wsrf2",
+    "url": "https://android.googlesource.com/platform/libnativehelper"
+  },
+  "packages/apps/BasicSmsReceiver": {
+    "dateTime": 1629414742,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "63b705208b050a219f044647b360e8dcacfdd78f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13a8aj0lxiz3xw69iq5mf3kyc99v400x64gk9x2pgb6sqwdb8mn9",
+    "url": "https://android.googlesource.com/platform/packages/apps/BasicSmsReceiver"
+  },
+  "packages/apps/Bluetooth": {
+    "dateTime": 1641607645,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5d8217a3b0e1a2761cad009daa97bc45f093ad40",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ijdsg8hrv3rll332fc5fs1rldda33pncxgc4834368c6adags34",
+    "url": "https://android.googlesource.com/platform/packages/apps/Bluetooth"
+  },
+  "packages/apps/Browser2": {
+    "dateTime": 1617066458,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5eb0c3ed5cd45c38ff3e3f209fb04481f386ec84",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1h9fvxivq1vg0mcwjvi4bzz37l8qimznybpljqin45smddavryd3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Browser2"
+  },
+  "packages/apps/Calendar": {
+    "dateTime": 1633043706,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ae23bc0d5a54b548d7119de7aa97f963ab9ede7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0kfvxpgm706p2yqm52m0c13zzsq7l93b318jinphqkc9pknb44az",
+    "url": "https://android.googlesource.com/platform/packages/apps/Calendar"
+  },
+  "packages/apps/Camera2": {
+    "dateTime": 1636675653,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7ea8f36c0d7eb7d9c449d2e2607f36ed1f1598d7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x01pphlnhqh4m2r6s9244fdsqzf1hymg6ha5f8qs7vwq4x2mz79",
+    "url": "https://android.googlesource.com/platform/packages/apps/Camera2"
+  },
+  "packages/apps/Car/Calendar": {
+    "dateTime": 1637280465,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "25dd3b56b3ea566d0d55d88f4acc15ff21d0f5f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jyh7kzzybk5d6g2j5ji05x1z773r4dkvvkr8wnlq5y7i3l9g1nj",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Calendar"
+  },
+  "packages/apps/Car/Cluster": {
+    "dateTime": 1636675654,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "341f23745bd29323c43f8168b7145812f0f5cf2e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1l8b4nm4zf1vnrghy1jhb0zyhqvxw3wzp8dpkjj3r3pnhdlfsb2n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
+  },
+  "packages/apps/Car/DebuggingRestrictionController": {
+    "dateTime": 1628125955,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5e10d9971c4f9e6b1a62c5adb70d5fca72ce7c46",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hl1gyk1x3if9vbbd57qi69xrkzlbazfd71cvna9my33aazlz22n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/DebuggingRestrictionController"
+  },
+  "packages/apps/Car/Dialer": {
+    "dateTime": 1642212466,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "28246113531641cc5dbc859bd46c3c8371572059",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qs256h0rpk71a3ksid6i0hvazrd36ysiffjb04xmfrq30iv9r5l",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
+  },
+  "packages/apps/Car/Hvac": {
+    "dateTime": 1612577306,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "aa4cdda8422122d972db7073def3a42d5dedf244",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1d2hqs0qqjihdjsqcpa1sg1k54rzdnzgj1y045mmxjp3sywd4lny",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
+  },
+  "packages/apps/Car/LatinIME": {
+    "dateTime": 1613866076,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "66f577b59cae8fb9c453d639523ab4afb2b13648",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0386ikmn57maxfr4brily6klk0996d93yw6fahk0h1vlh1bhqgma",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
+  },
+  "packages/apps/Car/Launcher": {
+    "dateTime": 1640304453,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "db368faaaa512f2651698fdcfde21a6aea704af7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hpmc21rim77gm10dnzddpxssas7kdfb1qawwjh2d1xfkkdvmh0r",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
+  },
+  "packages/apps/Car/LinkViewer": {
+    "dateTime": 1621048131,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bce3a9ce8514f739679e36119471275d64d726b8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z34jrm6jwb5wpvia998h5izbmx7s80k3vgk43kmizkpfkd99n9p",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
+  },
+  "packages/apps/Car/LocalMediaPlayer": {
+    "dateTime": 1625015338,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8d5500fae2028481824226b00c7910efac6d6c41",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1q5kbq8p08vscikaqjhkx2dq4cv7i7q3x4ga9fvjfgjnpvvwcgla",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
+  },
+  "packages/apps/Car/Media": {
+    "dateTime": 1641766157,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "de96ca46d166ba6de30695c46ac8c6c812cd04a3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "124ygd7qblxq1x8w07cqkmjgn14fpr3l8wpy4fasjmladqsbfy3y",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
+  },
+  "packages/apps/Car/Messenger": {
+    "dateTime": 1637280470,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "993e5fa29cf3bfbb9cd6be9ea5c1f06239f7eb1a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0pba04pkx6qvcni9hhshqazxwrk1ny43bklb162jah987kiafjkq",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
+  },
+  "packages/apps/Car/Notification": {
+    "dateTime": 1639699713,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "59262183c3c824121d887cbf861f8bc0f03a0a8e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ada9nc3rzmqs1mfjj16sqsbsjdwb9w108sqxyfg8n9gfnm5g57f",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
+  },
+  "packages/apps/Car/Provision": {
+    "dateTime": 1634951280,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e3d44e4e34e1daf191098604f37e8f2dacb58ad7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nlc27pgdc5qr5w8fvdvzxm8sn90cairqs9bh8msk48n5igkfd06",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Provision"
+  },
+  "packages/apps/Car/Radio": {
+    "dateTime": 1639260470,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9e99245c6b248411008cbde78bcc4bad0d893200",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07r9i8cq3sas1qkmzvk2c9z2rk6z5k6x10bl53dyqmskl4c9r3qd",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
+  },
+  "packages/apps/Car/RotaryController": {
+    "dateTime": 1637798903,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e440764910cd605b3df3fb56068bf5235c1d5cb7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zcyfwbwmd37yzvyllmh4hf39f8mz6q1ingz30izd4mw2mn0s9jl",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/RotaryController"
+  },
+  "packages/apps/Car/Settings": {
+    "dateTime": 1642212471,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "22e2bf91f61f081beb80af33671500279e1084ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hwkn8vpyblq4f54sjjih5k6r5ralkafdsjcr2kn6n3q79ci4081",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Settings"
+  },
+  "packages/apps/Car/SettingsIntelligence": {
+    "dateTime": 1632957134,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c1bac3d3801aa8c0999e4e8797340c444dd56055",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f22j3sdh649nv3mywn29hpw9rgbl3p1ad3i22dbfxy1ghyl4ryw",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SettingsIntelligence"
+  },
+  "packages/apps/Car/SystemUI": {
+    "dateTime": 1640304450,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6580d56344b4941a668af74e451b3ce3825025ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12pm6fx1snsdnc6lxpilzqljbbs4ns8h5f4di67s5mfd2zsyxf6h",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUI"
+  },
+  "packages/apps/Car/SystemUpdater": {
+    "dateTime": 1625015342,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1628866e42d51678cba3c8695bbe5803a81992fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c5i2y5p3y5gmbdi4fl3k6nrifr9kp1g15115i92fg3vh78f4g0x",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
+  },
+  "packages/apps/Car/libs": {
+    "dateTime": 1642370875,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "854b79ef65ffd62f1837b1ace4ec6d7ba0af243a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gikia1r6aaabsvigimb91jlxd15s3hil93lrfypfsgnbidwndqb",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
+  },
+  "packages/apps/Car/tests": {
+    "dateTime": 1634771332,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9b549eee45f38da82434a0826120686df739010b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06zmkfp6jfdqjwi10ph1zv52mjj8af8fcj7839gj3gccn0asdkii",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
+  },
+  "packages/apps/CarrierConfig": {
+    "dateTime": 1637021277,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "3f0af8495a8524d03963d2e6a3dfed86f2f7706b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13q1lpnynivdgigx28cl5rgi4hwyyvbnzgikhk52bcq4f1x1aqx0",
+    "url": "https://android.googlesource.com/platform/packages/apps/CarrierConfig"
+  },
+  "packages/apps/CellBroadcastReceiver": {
+    "dateTime": 1641859666,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cef4d04c11bc764a000274f8b5e78dbf93ed2c8a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "098iyr05n1hknvah3yz2rrnmq44r97ar6pfnlb3ija5i2sdhjd8z",
+    "url": "https://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver"
+  },
+  "packages/apps/CertInstaller": {
+    "dateTime": 1640304460,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "83d1316428e96cfb2aebd0e020b26f63350b0305",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ijdyzrn2dnzbap9q807p8b7vri65d6d37yvaxss1n9vfv9c7j8q",
+    "url": "https://android.googlesource.com/platform/packages/apps/CertInstaller"
+  },
+  "packages/apps/Contacts": {
+    "dateTime": 1642212475,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a17c4c40deba15652ef2ae0658cc6cc9efd9b00d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09qgcxnlhhmgr6yqm8yis0ps93hmky569178jg6wrrq7nwrr4vw6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Contacts"
+  },
+  "packages/apps/DeskClock": {
+    "dateTime": 1614996472,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0eb90726084570cbbb56a963d8bae1b4c61daf6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v7bkqlsi8q3djjbs6h449p3nw9mg0c120y6bj37nkmyci4lw9nm",
+    "url": "https://android.googlesource.com/platform/packages/apps/DeskClock"
+  },
+  "packages/apps/DevCamera": {
+    "dateTime": 1621048139,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ada16f0b2944ab7855e1bab22276b4bf04e5bc39",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10vv74hndkdq9281dxsv8jk8frfjjqkqw2h48wc63c762mvvfy5f",
+    "url": "https://android.googlesource.com/platform/packages/apps/DevCamera"
+  },
+  "packages/apps/Dialer": {
+    "dateTime": 1642032704,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "09b69470d5526e1db14e2508f5047da41a816916",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1k6225a3dyjxr6rz9rkir2grl621csx7lq74fk7z2ri068fzz6fv",
+    "url": "https://android.googlesource.com/platform/packages/apps/Dialer"
+  },
+  "packages/apps/DocumentsUI": {
+    "dateTime": 1640304462,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "613e06099c70d6d6d1694357da840f657e6139b6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gb14ib3lsyjvrw9fn15d27ps4aqpi2hsyyzq944snw65jpa2xvi",
+    "url": "https://android.googlesource.com/platform/packages/apps/DocumentsUI"
+  },
+  "packages/apps/EmergencyInfo": {
+    "dateTime": 1637374095,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f7327627eea33b81398687746421d19c24b8e2fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v1knymy2blg11ngp5ghs1kinsv6089zzwws831m9vc7f0mdn6bx",
+    "url": "https://android.googlesource.com/platform/packages/apps/EmergencyInfo"
+  },
+  "packages/apps/Gallery": {
+    "dateTime": 1613866087,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "87e41a1ce6c15b00b6257283c523a62ce7650fec",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jvm1nsp49a8bdzrykm2ywi5d8kp5s79ynxsaazr56xh88m63swx",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery"
+  },
+  "packages/apps/Gallery2": {
+    "dateTime": 1641514069,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b68037e72f0d44b0a57c2f9c17b23878d00498cf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0clkzqc5d3ws2znaag6ynwnavz3372limgvzygmphpk5wfcdgm3k",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery2"
+  },
+  "packages/apps/HTMLViewer": {
+    "dateTime": 1632957141,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "81b067b82c520a47a864eeca0aeae25cc85a5807",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lswma9bl2chznhblrfkg5vrj7h04yyz7vj1rpwvxasaa6agm9hd",
+    "url": "https://android.googlesource.com/platform/packages/apps/HTMLViewer"
+  },
+  "packages/apps/ImsServiceEntitlement": {
+    "dateTime": 1639188458,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "03b004ddb06d5b4480ee07dc0231d6e3e9f03dac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0aifd6g4fisbfjlzd98amlg23swdlrsx3n52nc4hn71195nrby07",
+    "url": "https://android.googlesource.com/platform/packages/apps/ImsServiceEntitlement"
+  },
+  "packages/apps/KeyChain": {
+    "dateTime": 1640304466,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a711d9a56750d53a5bff5bf9aa5b00bd9fe7fdbe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nfxygswbzbfmjj8zqkf8my4md2wmcqb6bhb9hqcigy9ggsw26ar",
+    "url": "https://android.googlesource.com/platform/packages/apps/KeyChain"
+  },
+  "packages/apps/Launcher3": {
+    "dateTime": 1642971428,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3714e88b982c5ea05c5853f4baa515e0aed79a02",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0l4w46z3rs423yv0s860962kdqyq121jvln1kqynacx87ykkbjrc",
+    "url": "https://android.googlesource.com/platform/packages/apps/Launcher3"
+  },
+  "packages/apps/LegacyCamera": {
+    "dateTime": 1613866089,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "dbd74e50d6b1214708afa02235cff572d30c3358",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xlgpy1lpcixp767g81kahhzid6g81qa4ghzk0q97jpqb9dp7fsy",
+    "url": "https://android.googlesource.com/platform/packages/apps/LegacyCamera"
+  },
+  "packages/apps/ManagedProvisioning": {
+    "dateTime": 1641766171,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7e216d969b95a225e53f3dc184ca92e092a9830a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07ink9vr79rvwz6v3cv9kv9alvall3mw8p2wchhqrny0ypz5qb0l",
+    "url": "https://android.googlesource.com/platform/packages/apps/ManagedProvisioning"
+  },
+  "packages/apps/Messaging": {
+    "dateTime": 1642032714,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7f6c46186b4ef75eb5212bf56a1cf8475d5223dc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x990xlwf9fj3y4zlwplxil2d9bjq2334nl135vn58vkbs0nal0z",
+    "url": "https://android.googlesource.com/platform/packages/apps/Messaging"
+  },
+  "packages/apps/Music": {
+    "dateTime": 1613866090,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "de78506ec2e5801780d35b413936268f619aa2dc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0as5xx38vj9lhkqx0vwd76sdn53cd3f3p2igb48lbx31d037q4c3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Music"
+  },
+  "packages/apps/MusicFX": {
+    "dateTime": 1639188461,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "74d07255cf7b5ea21fcc708d031d60304ff91f34",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rv1vgy29dal28480i15qndz2c2kbbp5fh7qbkxpvzclixbdc3b7",
+    "url": "https://android.googlesource.com/platform/packages/apps/MusicFX"
+  },
+  "packages/apps/Nfc": {
+    "dateTime": 1640398066,
+    "groups": [
+      "apps_nfc",
+      "pdk-fs"
+    ],
+    "rev": "5ad10c965db4a241152969a110b7a3885eabc065",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jvknf69yjldvypnrnsnrlib33s7llnsz5h5ml2r8aglf16qy9aw",
+    "url": "https://android.googlesource.com/platform/packages/apps/Nfc"
+  },
+  "packages/apps/OnDeviceAppPrediction": {
+    "dateTime": 1613952494,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "92ea1803d24c4f62461ea815547f1d46a916522d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fkf6vkd884q62xl21kayi6113ggay9yla8v89nq1dyp2k5w3dna",
+    "url": "https://android.googlesource.com/platform/packages/apps/OnDeviceAppPrediction"
+  },
+  "packages/apps/OneTimeInitializer": {
+    "dateTime": 1612577323,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "842d2c6632a8e1d009c8d9af5c1545a8c3c5e3c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1p5xhhljcd2bcpb57b22h65rgsv6k11l3xdi0bc4jaim9p12sikp",
+    "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
+  },
+  "packages/apps/PhoneCommon": {
+    "dateTime": 1640304470,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c881b16e3f7518df838075e595c73950abe2ba06",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nmrb5nw162jbk3sz8v1jip0gxb4fr83bgfq0x0wc793gh9x35nb",
+    "url": "https://android.googlesource.com/platform/packages/apps/PhoneCommon"
+  },
+  "packages/apps/Protips": {
+    "dateTime": 1613952496,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9e565b07f609b8a091ef764cf6ec79d2526e569e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0krih7himlvr4i051i1ccrr46pvz34nl7zabxq37i5902fg7ifn6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Protips"
+  },
+  "packages/apps/Provision": {
+    "dateTime": 1613866094,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5af43a4bb80b29ed642a79b4c7c3ad1a48a3b6f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1b52p9b9i19cg8pip9ykfj5finlvxxv9ikwjfjpk022pzg0p0zz2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Provision"
+  },
+  "packages/apps/QuickAccessWallet": {
+    "dateTime": 1632532089,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d0fabc650bff574a7058811218c9c3d34e15ee75",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z85rzf28s2f28jxpa89ja51yl8kf12z43a1k72lb7q7cgma6w9a",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickAccessWallet"
+  },
+  "packages/apps/QuickSearchBox": {
+    "dateTime": 1633043730,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e0a370222153e0e7533905413e3a4cf6627f8dac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "144xmkff19450fqiihysyma0n40jzsqgkrwxdgjq2ja6ipdq4ccl",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickSearchBox"
+  },
+  "packages/apps/RemoteProvisioner": {
+    "dateTime": 1639008638,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "391a009e1b33380eafe16191a9b7f21078dfbed1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1i0sl4y1f55g494p7kh0jn09lpbl24x5895hzgg8x10rzx72mjsp",
+    "url": "https://android.googlesource.com/platform/packages/apps/RemoteProvisioner"
+  },
+  "packages/apps/SafetyRegulatoryInfo": {
+    "dateTime": 1640131697,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "76d4a87ce9b54ef0c220c77c9b06280a696aecbd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "106dkkz5v20cdy9kfxifgwdswmpql1szhrmmfc9f8lhh8sq83r6b",
+    "url": "https://android.googlesource.com/platform/packages/apps/SafetyRegulatoryInfo"
+  },
+  "packages/apps/SampleLocationAttribution": {
+    "dateTime": 1621048150,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "92b723910761cc41dcb5134be21bec9181a40348",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rl5fafh4w2ly59yby031ag1h5b1i7fp01i89qlsc85x5c4k3ash",
+    "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
+  },
+  "packages/apps/SecureElement": {
+    "dateTime": 1621048151,
+    "groups": [
+      "apps_se",
+      "pdk-fs"
+    ],
+    "rev": "26d5713f6726abbfe41bef3757faf76de61fa462",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0csvapdfp737y40sywzxbk87bx20dn3j7ppalz6wigc25r2a5wz8",
+    "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
+  },
+  "packages/apps/Settings": {
+    "dateTime": 1642212490,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bea94ed42e5740d126a4e857b316143358342185",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h5ifzpd2s8377cways45dxdcxqfg4yig0aj1dph31a27635kjc2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Settings"
+  },
+  "packages/apps/SettingsIntelligence": {
+    "dateTime": 1637626079,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "740ef51f0e64c6e1af043d8c650d1427171db039",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mzczwh353ligq0fchwgcvvy8sy8riihq0rg3n8x7zcr23py4q9r",
+    "url": "https://android.googlesource.com/platform/packages/apps/SettingsIntelligence"
+  },
+  "packages/apps/SpareParts": {
+    "dateTime": 1612577328,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "81afd31cdde36cc3230e0ec4b946dd8df6a32af2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1maawjwjr5mcyh62h02fv6g0jhchfw653y89mmjr1wc9xf13ywvn",
+    "url": "https://android.googlesource.com/platform/packages/apps/SpareParts"
+  },
+  "packages/apps/Stk": {
+    "dateTime": 1631322490,
+    "groups": [
+      "apps_stk",
+      "pdk-fs"
+    ],
+    "rev": "34ef9987f7c14aa77f581951086a1f5d7cc5a2dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05fmh1jk7a0a36sfm0jkv4q1g5h1i02i01fmip2d3czq27xq3l6q",
+    "url": "https://android.googlesource.com/platform/packages/apps/Stk"
+  },
+  "packages/apps/StorageManager": {
+    "dateTime": 1635808092,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d5eeb0cba942fe1e55232824071f4332d914bdaa",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1496k7wchbxwnngb9sdl78ihgqw00lm2bdjcy8ybdzn3530r7rx7",
+    "url": "https://android.googlesource.com/platform/packages/apps/StorageManager"
+  },
+  "packages/apps/TV": {
+    "dateTime": 1621048156,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cccaf041f9bab291e717d5a3a1b50b4ea28f733c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qx3r6m8crigjdxyhxbbfvmrs6r9yjjsjkz5i6aclg2l02hmrqq8",
+    "url": "https://android.googlesource.com/platform/packages/apps/TV"
+  },
+  "packages/apps/Tag": {
+    "dateTime": 1636416540,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "89caaeae37af2a1f450bcbd679d2eddd9f22d144",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0889fsahy8yk9p97kwcpalw1bdnrvkrfsxlavdh4nl8af6phvj40",
+    "url": "https://android.googlesource.com/platform/packages/apps/Tag"
+  },
+  "packages/apps/Test/connectivity": {
+    "dateTime": 1613866100,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "134064dbb88279078bfa712277f7599dd4bc397f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10mb5gqc3lyi02r4i68yqhqxiwik1xdi87ik9s6lr9b04clf1fax",
+    "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
+  },
+  "packages/apps/ThemePicker": {
+    "dateTime": 1641766184,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6e5087bfb603b473185840f11ba1ba453873acad",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fbqp3vkiznls6g99cx96dkp526p91w5f0q42b0h9401k278bygc",
+    "url": "https://android.googlesource.com/platform/packages/apps/ThemePicker"
+  },
+  "packages/apps/TimeZoneData": {
+    "dateTime": 1621048154,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c577efb9a4f8384bdb9541c586a3e61c0d390bf8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07ap27ilgs63idvgw1lyzy64djz657ad4wz273y0pibgh3nm5fj9",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneData"
+  },
+  "packages/apps/TimeZoneUpdater": {
+    "dateTime": 1622862539,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "358e668cdc76380a30efc154c7b017bde748226c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12ir26ysn4n8q1mvyhxp0lmry7k51zam3n2pcdkg3v3g1s344g80",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneUpdater"
+  },
+  "packages/apps/Traceur": {
+    "dateTime": 1640218112,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "44ca502dee6402d9fcab2b2494b2ecb94aeb9581",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f55pivbxv9rjn8bah93bhcnhjvq3afv1f01ssihyqlxfck09xig",
+    "url": "https://android.googlesource.com/platform/packages/apps/Traceur"
+  },
+  "packages/apps/TvSettings": {
+    "dateTime": 1642370897,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bcbd14854de6e3f4ccdcfb958941983e3697550d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1q4fm8b38i871ypm5l70aabaw622k0d46mn8v7ypc5ms18h2l55h",
+    "url": "https://android.googlesource.com/platform/packages/apps/TvSettings"
+  },
+  "packages/apps/UniversalMediaPlayer": {
+    "dateTime": 1613952505,
+    "groups": [],
+    "rev": "a182ef24dc9dbd2c1d571043aabc4197a6e21ddf",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bzyk8zck067snc55bknnd4rsmsqkx3y41yg5w9lm410a7vr7bgz",
+    "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
+  },
+  "packages/apps/WallpaperPicker": {
+    "dateTime": 1612577334,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d8e6d4bb4ddfe0b888769d24aadf98fc39e6b3be",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1amwx8m2ckvx5clggdsnwas0ix9qnam2z9sfdwy9wys6rb9mf2qp",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker"
+  },
+  "packages/apps/WallpaperPicker2": {
+    "dateTime": 1641766186,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a2099d086bf59ba727ef0316f2d6bfc70a347ccd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lsz2p2yil09igrxmhq5g0ck8yxk1qiphn0d4srsx4415pwza3m7",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker2"
+  },
+  "packages/inputmethods/LatinIME": {
+    "dateTime": 1642118948,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "81893aae83145cb3760576c2767592000296d8d5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1835hvs1f77rz2hvdzdyll16x2wdaw2q5q80dkrimxalkjazak05",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LatinIME"
+  },
+  "packages/inputmethods/LeanbackIME": {
+    "dateTime": 1612577335,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1130d0a01ae3004f936f3a776da47d7a4b534490",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19wfvg8izsyvb2fwy1gl21vfk7v9c1icbpw542pqcjdyc6dyb672",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
+  },
+  "packages/modules/ArtPrebuilt": {
+    "dateTime": 1625533760,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cbe696113906f4167b2f781036018a8b63d0b9dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0i9lnw0byhqxwz242kbr5dhi8dg91grhkycp9jp5icdpza28l66b",
+    "url": "https://android.googlesource.com/platform/packages/modules/ArtPrebuilt"
+  },
+  "packages/modules/BootPrebuilt/5.10/arm64": {
+    "dateTime": 1610155294,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "590a426c042a8419848cfc5f14cdf5c2ef8a6756",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1n7apxd43m3i2sqgjcp80garn9zznfcsq67gnm0nywp0bbi7wd58",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.10/arm64"
+  },
+  "packages/modules/BootPrebuilt/5.4/arm64": {
+    "dateTime": 1613866106,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b8db92606c1e73d9d05e43e34afd7c7dbeeda961",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13gs7i4dcwmjwld93q0w47ar1gcah0kaqbkxacwlc404axfzqg72",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.4/arm64"
+  },
+  "packages/modules/CaptivePortalLogin": {
+    "dateTime": 1640304485,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e910ae4c63df772d13801855aa552d8753990f28",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "128407hvkascjjx4j707qc3lphi5j2jf762grc02jqhmd2xf3x35",
+    "url": "https://android.googlesource.com/platform/packages/modules/CaptivePortalLogin"
+  },
+  "packages/modules/CellBroadcastService": {
+    "dateTime": 1631322500,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "884714a63cf032dbf769d51b2874474aeec00f50",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0slndn640xczh9ry6lplyf9im6b26z9n6v4d367ihbv85kn3yhib",
+    "url": "https://android.googlesource.com/platform/packages/modules/CellBroadcastService"
+  },
+  "packages/modules/Connectivity": {
+    "dateTime": 1644453737,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b490c9284c0ae28dccd1e8455b52c5c5d516c1d6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "031i909n3nxl3q7drkr0j9kn7l4chz6ajign9myharixnvjwjkmx",
+    "url": "https://android.googlesource.com/platform/packages/modules/Connectivity"
+  },
+  "packages/modules/Cronet": {
+    "dateTime": 1625281904,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a2896cd4fe598d2aff1347c9e58c67308e82c67d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Cronet"
+  },
+  "packages/modules/DnsResolver": {
+    "dateTime": 1628305748,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8425e47799dffbe7af7002479a04828fca099460",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ckllgahhki8dcx3md37x6jcyjm5maxmh98l43d107h14h1bva10",
+    "url": "https://android.googlesource.com/platform/packages/modules/DnsResolver"
+  },
+  "packages/modules/ExtServices": {
+    "dateTime": 1634016992,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "86beb7d9322c5dd95253b76c8683f470e085f833",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "112sxv4lymh9sx4n1ai9hcxd56wpjc9fbll1ih6bvx2421y65ar6",
+    "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
+  },
+  "packages/modules/GeoTZ": {
+    "dateTime": 1624324321,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "aa86b5a71af2182ad8525dad073e92bf5c5ffbe5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xw9s4x82r3aa98wcr5cbmclcw2cmmc22palh14ylsypcvpb4zip",
+    "url": "https://android.googlesource.com/platform/packages/modules/GeoTZ"
+  },
+  "packages/modules/Gki": {
+    "dateTime": 1624324322,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4f716949d5688fa887b43892133ed15ddaf40f57",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1snci4l616cvznfbgw3xvmkvsa3i95q1v3fp882327wmv65nrqww",
+    "url": "https://android.googlesource.com/platform/packages/modules/Gki"
+  },
+  "packages/modules/IPsec": {
+    "dateTime": 1628975345,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21f3a3ff4e2a98a48de4c5b93f3ad66634260d6c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v2qw6hjafasjn9vby9wac9kp204nfn0y3j0abhz2i591jnbzkdl",
+    "url": "https://android.googlesource.com/platform/packages/modules/IPsec"
+  },
+  "packages/modules/ModuleMetadata": {
+    "dateTime": 1622164166,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cf3ff38b2eb99af261a0b92f54573d7e8ebaf447",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wl1mb6fmnym4yyi1w4fc0zni7awb50mh9w91a6plp5j1rmy3x87",
+    "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
+  },
+  "packages/modules/NetworkPermissionConfig": {
+    "dateTime": 1614132557,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "37ec720f947159e767653e12d41aeb669501d25e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nz2xs3rmpvbfwka7lxr87chqpchq57cc8r25qfgymbhnkkg61pl",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
+  },
+  "packages/modules/NetworkStack": {
+    "dateTime": 1637107684,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9719ccea5ae89f76e6a7286d1bb39af379269f69",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zyn71a8b1a95i2d03c7xgk1rklffa96vm7qphafixsp41hg5b5s",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkStack"
+  },
+  "packages/modules/NeuralNetworks": {
+    "dateTime": 1642118957,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9c79232c9423d75a3c6f0d41d50ffbc7b4966599",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1vmbfq7wi4lyam5ha6cs34xk1hy41p4lvbv4ri5hp2gb6bs5zaz8",
+    "url": "https://android.googlesource.com/platform/packages/modules/NeuralNetworks"
+  },
+  "packages/modules/Permission": {
+    "dateTime": 1641946246,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9dbe53f94b8dcf430254263ff15bfe97d354e2a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ns3gpabxqcykx3wwmmdaxpay7wjh8f9q98n7wh6cfz8dplm11w9",
+    "url": "https://android.googlesource.com/platform/packages/modules/Permission"
+  },
+  "packages/modules/RuntimeI18n": {
+    "dateTime": 1623892165,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f2404da7b4d6a8b22043b78181436dc44a29d21b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "016clxna7xjxwy42chxfdcp48ny0j3g4nyxg57zvqglgrlx8cqp2",
+    "url": "https://android.googlesource.com/platform/packages/modules/RuntimeI18n"
+  },
+  "packages/modules/Scheduling": {
+    "dateTime": 1641607692,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c9a3eac2fee8575a59e60d4db4217ab8aade8df2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hcyrwbd156cm8xmcqdlb3rcs5ijbmmrsv4r0vrvgygidwwyr9sw",
+    "url": "https://android.googlesource.com/platform/packages/modules/Scheduling"
+  },
+  "packages/modules/SdkExtensions": {
+    "dateTime": 1628305752,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "30867ef3d3eaf85792294ce487d6558071de5b86",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m4pl0v7f56g74ym76qrq198g6pnd93w8zh05bynvyvarwbajphd",
+    "url": "https://android.googlesource.com/platform/packages/modules/SdkExtensions"
+  },
+  "packages/modules/StatsD": {
+    "dateTime": 1641607693,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c3de2d98b844a919ef5c181f09641c08cd8a1dff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06fwxkjkk8rq23s9y7r8d5nyjkmyczq87p5jqw4m98wgczyfa6zw",
+    "url": "https://android.googlesource.com/platform/packages/modules/StatsD"
+  },
+  "packages/modules/TestModule": {
+    "dateTime": 1539195664,
+    "groups": [],
+    "rev": "d7abf445f3ab90927d36bae6d0720b2632fa6f53",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
+  },
+  "packages/modules/Virtualization": {
+    "dateTime": 1625706972,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6722948c25fefcb10d6edceaf21a77df288c33d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1i7h4ppc6clrz7q992fmq7wsw7pznpai9kinwb2w87b0m3yzplk5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Virtualization"
+  },
+  "packages/modules/Wifi": {
+    "dateTime": 1641859712,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "14f9fa31b3769fd42d81e7a8cebfa0ffcb94977f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11qj79m8lc7avkj32xa5n2csr1lfclcnsi18lf94hnpjrxrh8r2b",
+    "url": "https://android.googlesource.com/platform/packages/modules/Wifi"
+  },
+  "packages/modules/adb": {
+    "dateTime": 1642284497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0a2d8d82db8b619feea966c18af3023b00cca032",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "046m5xzffvnk088b6w15xjgfa256kmrv90755p3bbv4n5fi61qqg",
+    "url": "https://android.googlesource.com/platform/packages/modules/adb"
+  },
+  "packages/modules/common": {
+    "dateTime": 1632870541,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ceb6d1c7e02bc53b9c18068e7eccdb414cc845a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09fkff1dj3m77sw9z0s4ag6cjhdz9662rddydzq3xsrscdrs3aps",
+    "url": "https://android.googlesource.com/platform/packages/modules/common"
+  },
+  "packages/modules/vndk": {
+    "dateTime": 1631747375,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1bf62ff55a27779c067f142071ae12cf9cf5b62c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y89gdy14mlhrwhf39f3ibqg28ndf1bfkknhv8zxhm2xv28yz4wv",
+    "url": "https://android.googlesource.com/platform/packages/modules/vndk"
+  },
+  "packages/providers/BlockedNumberProvider": {
+    "dateTime": 1635808111,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bd5d9a9e205d1636436645d1678635afe4244976",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0w021wx0aj1r5bldfbb9mf1v98isgjcyp45d3h0aa3k77vbs8dal",
+    "url": "https://android.googlesource.com/platform/packages/providers/BlockedNumberProvider"
+  },
+  "packages/providers/BookmarkProvider": {
+    "dateTime": 1613952519,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0358b01faf5061ad127a98e9026f045e5a54f3c8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06p1pl2iq980hibsdal7jq7qnmvsr3w4zw88jvr53ifgjvaj7jyy",
+    "url": "https://android.googlesource.com/platform/packages/providers/BookmarkProvider"
+  },
+  "packages/providers/CalendarProvider": {
+    "dateTime": 1627348169,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1f58108bfca5f2be14cfbba38cf858c5a8aced10",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10g01wxvmkylh7r7kjq2analk29zfs2xqaql75h0rw5bnvxkmfdc",
+    "url": "https://android.googlesource.com/platform/packages/providers/CalendarProvider"
+  },
+  "packages/providers/CallLogProvider": {
+    "dateTime": 1621048172,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ff42bd9dc0c29dff3af04b7b23c8018cdbee16fb",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qxaag2rzr45ixnnmzl88xhssvvlaz6mijizj75jkrdslj61q2ha",
+    "url": "https://android.googlesource.com/platform/packages/providers/CallLogProvider"
+  },
+  "packages/providers/ContactsProvider": {
+    "dateTime": 1635808113,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d3e4aa04f8126f45744982e9b2cc561ef6e7a05f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nwxlf6wvv4pp5y4my9iv172gl4kp1ic9l1q24696p4bvga7wybp",
+    "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
+  },
+  "packages/providers/DownloadProvider": {
+    "dateTime": 1641946253,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c203f7d1b17758db97396a4febe5b95ea3b92676",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y4jl93wphpnlvkg9sxah2byrpcacc2y7si9fnk4g3j1kg61xbsa",
+    "url": "https://android.googlesource.com/platform/packages/providers/DownloadProvider"
+  },
+  "packages/providers/MediaProvider": {
+    "dateTime": 1641341319,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4a3bfabc9cc41ce80d46fd991462829a03089674",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0khckpmh46jkf74agp6s6cq4knl22khkgvmrkrkkfh33rf4bfv3j",
+    "url": "https://android.googlesource.com/platform/packages/providers/MediaProvider"
+  },
+  "packages/providers/PartnerBookmarksProvider": {
+    "dateTime": 1613952521,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "376cbfd3195b3bcb8bc0bee1b2a577eb2dc7cb3d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12s14vcmpypbk2h116n3spvqg4akj6xizjrw7vilab7ln8wp89i5",
+    "url": "https://android.googlesource.com/platform/packages/providers/PartnerBookmarksProvider"
+  },
+  "packages/providers/TelephonyProvider": {
+    "dateTime": 1637194356,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "969b60b083a7819df9f9ceb9aa0be213708fecb8",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "00p4mhh3d3jn023dl2pkvw6gz92mr79c6wc1742iimjpzkxzc058",
+    "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider"
+  },
+  "packages/providers/TvProvider": {
+    "dateTime": 1641766205,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "72beaa5d7a0bbd0d64ff9213dbfc0c1ba76ba0ae",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wq8rhwbfxh1aqdgr60r3vvyi1p566cr02nwslqx5fxw5xnbbgp2",
+    "url": "https://android.googlesource.com/platform/packages/providers/TvProvider"
+  },
+  "packages/providers/UserDictionaryProvider": {
+    "dateTime": 1624497274,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4719164c24f8e57d3da515269b5252cda1952356",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nkkxj3mm39lp6ga1icachqykkcarfslxi3jngxj8v1rriqa710w",
+    "url": "https://android.googlesource.com/platform/packages/providers/UserDictionaryProvider"
+  },
+  "packages/screensavers/Basic": {
+    "dateTime": 1622596190,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bec35058872569aee82427cdf05b4aa90c2a34af",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03wkn8gl92cdcqkykb1m5kpmmzmc46hlinz4gyprpacn8wgr6zqx",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/Basic"
+  },
+  "packages/screensavers/PhotoTable": {
+    "dateTime": 1637107695,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "701a5b4ae1d913d136086687fd128c25727c114c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c5dks82czxys3cnmi86rvrpwgc1xgghgvrg8mx3nzvx6b54yhb2",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/PhotoTable"
+  },
+  "packages/services/AlternativeNetworkAccess": {
+    "dateTime": 1630717700,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bdb0d148106a84d7ad0c6989ef8b408f341eac0a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16b84vhvra87k6ricz42wi0i3byvb3bz9ivn464fc486j5vkgs49",
+    "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
+  },
+  "packages/services/BuiltInPrintService": {
+    "dateTime": 1638403772,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "152024fb1d3372d39261e41bc1bcaeca223c6dc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1jv80fhb3dgmgrjwlq8lpd1mrif5dpx5gd8imn1m6avd6k854vcz",
+    "url": "https://android.googlesource.com/platform/packages/services/BuiltInPrintService"
+  },
+  "packages/services/Car": {
+    "dateTime": 1641946258,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c8f77d42d16bc3ae5e907e19b51f2d8622c1dd5f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "19cjhx5dsvqwvww3f7m1jxiw2vlv9r2z2z82a64xvz6jqifg2j42",
+    "url": "https://android.googlesource.com/platform/packages/services/Car"
+  },
+  "packages/services/Iwlan": {
+    "dateTime": 1635462547,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8ec91a3ba2452c1532e31486a1b4fafc197038be",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nvqkpryx3dhynckjrcdz9ayslh5ibixjv8caysw9k2mfrrnzljq",
+    "url": "https://android.googlesource.com/platform/packages/services/Iwlan"
+  },
+  "packages/services/Mms": {
+    "dateTime": 1621048178,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2c610441daddee63d1a0d84ed9d31503ec099d84",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "192dhws43zp66czpx42kciwggd1p21mp34if3hkkcv8gqb5vkxsg",
+    "url": "https://android.googlesource.com/platform/packages/services/Mms"
+  },
+  "packages/services/Mtp": {
+    "dateTime": 1624497278,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "109c02897525a00f134f89678e10f954730ac2cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0581pybyfy4npszpycjkkphir38nvj6b16zfl4ciz8fxg6dcwgqz",
+    "url": "https://android.googlesource.com/platform/packages/services/Mtp"
+  },
+  "packages/services/Telecomm": {
+    "dateTime": 1642118972,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1dc5e49ed6a37250e185e95654ff2d0767278bb1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "059x87p8x7bfk75jzjc9jjsvwb7wpy6cmdqzhv06xicvqxh7q2l0",
+    "url": "https://android.googlesource.com/platform/packages/services/Telecomm"
+  },
+  "packages/services/Telephony": {
+    "dateTime": 1642639636,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "170562b96deb720d7b8a8b62543005b59b3e0b77",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1xh7nkv4wg408i910javcxgccp6l75z87yhrgwiaalp79v730jbx",
+    "url": "https://android.googlesource.com/platform/packages/services/Telephony"
+  },
+  "packages/wallpapers/ImageWallpaper": {
+    "dateTime": 1571790197,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0b9f93e806c51554b92d61a30394ceab63ee6089",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/ImageWallpaper"
+  },
+  "packages/wallpapers/LivePicker": {
+    "dateTime": 1639699769,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "372e8f5afc0a627a934a89144f20463ae4931221",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1iadl9j4xcf5m41w5yjnznp88jx7884riw3qd7pqdbrs7lnh3b1n",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/LivePicker"
+  },
+  "pdk": {
+    "dateTime": 1621048181,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de6f5f9d76c60dd6e5391ba4d9f7dc586366f2ba",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zxgc4qgxsz4vn8qyzmp8m4zqy98fcsgjsn6abhlagp3ihjh27hv",
+    "url": "https://android.googlesource.com/platform/pdk"
+  },
+  "platform_testing": {
+    "dateTime": 1642032791,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "42569611853e6daaa985de8da7e10152bbf60a53",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c56gywz1bz21zlp7k4xsqxsn9yrfviif9i4lzgjn84igpb7bn3s",
+    "url": "https://android.googlesource.com/platform/platform_testing"
+  },
+  "prebuilts/abi-dumps/ndk": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3abee5ef84697e13e34e6c045e2cb7cc88472370",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wv5rriip397yywjswk6d6ayp359kjw27mr5yd25vdv8p793pzja",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
+  },
+  "prebuilts/abi-dumps/platform": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0437426cc968a7c3fef54f68751fceb3e6d1e824",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bddynkzc67y3qbfhh9g7cn645027068g8x3503szglwzjdy83wj",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/platform"
+  },
+  "prebuilts/abi-dumps/vndk": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e2e2bc01a39e35d6d6ace16c93b4c2c0c5789142",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cpdayr5gi05vk1mfsijcc9kvb8ir7xxnrxbl5mnfgr7szdhn65s",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
+  },
+  "prebuilts/android-emulator": {
+    "dateTime": 1629508120,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8e521569e8f62db09a99d7707e86267f16ba7e22",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18s3ns14ar9zg89ydis0hyif9djjhngm29i4zxpac79b144iywj3",
+    "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
+  },
+  "prebuilts/asuite": {
+    "dateTime": 1628126016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3699ee3e2cd685030c3d756ac0bcd1f281a63b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "012s3a4fb2gsd7rwn8vzf3b7k38zk1kl6i80r2d4cys5a9vmadxy",
+    "url": "https://android.googlesource.com/platform/prebuilts/asuite"
+  },
+  "prebuilts/bazel/darwin-x86_64": {
+    "dateTime": 1615601352,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "53c93525ef2b067449d4d6b97163a464a0719108",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wcwyr0n9m0v9mfyjb8f3ljck0w3payq39iv33f2w7n0kihqalgk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/darwin-x86_64"
+  },
+  "prebuilts/bazel/linux-x86_64": {
+    "dateTime": 1615601352,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "e9f805189e91a1348e3a906768aca55822c9531e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mf45cyj47xqfpxp3cvdibwbxjswb2n10gpdydvyb5aynpwg492g",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/linux-x86_64"
+  },
+  "prebuilts/build-tools": {
+    "dateTime": 1621386600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6aa1e4fb40d4d482ed158fcc07212bdff0815440",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wph12829w8mj7ddrp9ml33igyg8qvw13hvjsv0jcl708pqnbnzf",
+    "url": "https://android.googlesource.com/platform/prebuilts/build-tools"
+  },
+  "prebuilts/bundletool": {
+    "dateTime": 1628809743,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c7dcc23e79bd55c5a6b52fa954bf9eb44e6c61f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zahhs55ba5zx98jf7vbcv8cas4fkqfp4a6inmci86rfj88rwvif",
+    "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
+  },
+  "prebuilts/checkcolor": {
+    "dateTime": 1586493700,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed1321c7b0b257c7e9f5170e68703c477c520778",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zaw6nl6k2l1d9g7rz45vybgi6yjmbxzfzz7kwrsgaymc27b060r",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
+  },
+  "prebuilts/checkstyle": {
+    "dateTime": 1621048187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8464bd4ea76bd5ad64cbb48b299b28c486058b71",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j0apf2ddqkxi2v3qqsbjbk9w5b6i7frjfyashymzcwvaz474p50",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
+  },
+  "prebuilts/clang-tools": {
+    "dateTime": 1613866135,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "390e091db6177cb3d7734fdeed338f61a1384c4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18l1ppiv14asv6bv2ivshdwmcgx6r100jjyrxjzl5hpi8zwm6wlm",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
+  },
+  "prebuilts/clang/host/darwin-x86": {
+    "dateTime": 1624640195,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "e39d536c3d769ea01f4f2b4ca0ec646bab7a6967",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ks4mbdskbwr2r8mxk3ymx68709ccm96j06hgq2wvmc4bb9ajyx0",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
+  },
+  "prebuilts/clang/host/linux-x86": {
+    "dateTime": 1632352353,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aeac9480e90fff0f6a0a8b808a606d0665146adc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0a8dbqq3qlsvsdrgymjk636rlv8zspfmqzrddx9nsysvkw5wmgsd",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
+  },
+  "prebuilts/cmdline-tools": {
+    "dateTime": 1617930584,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6b7d986ef06acc129a696313b53b603bef31e7df",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1h7r0mi51dgsgz61d3gmh0364zw8a3fgrg46fv26vwg2vj4dcp5q",
+    "url": "https://android.googlesource.com/platform/prebuilts/cmdline-tools"
+  },
+  "prebuilts/devtools": {
+    "dateTime": 1561663933,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "d380e8500e3fa4d3d769b8ad1d3209ee07464c12",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yr6acnwdmwygnvd1kljs27pnhwywgm8gv7qp1m6ir23axwydx0s",
+    "url": "https://android.googlesource.com/platform/prebuilts/devtools"
+  },
+  "prebuilts/fuchsia_sdk": {
+    "dateTime": 1604451501,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "70d0257c244e2e6a9372cc85c8491f9a1f299be9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0j1rnznlk5z0c985xb1fl8mxk52kwjl0c0vask9hka2bqwxcj7xw",
+    "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
+  },
+  "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493704,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "3c4592ad3343990f6076b318a7db8d5eaadb38a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0svy6bm57kq0zkcmc1747x46b77jh4l0rbs8415ka50kvmhwph7s",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586493701,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "62508997875785e6ad3da6c2b3fb6df43d81f7b6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wv4rh1y00w0mjp535arw85psjfbzc3gplczzdhpanr1g4im5vlp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "dateTime": 1578436765,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "f58c0f3d6a150d47c7f2629fe51187e6fb776c4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
+  },
+  "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586493704,
+    "groups": [
+      "darwin",
+      "pdk",
+      "x86"
+    ],
+    "rev": "53a83dd60d3cdfbd89ff34953ceafb9796cae94d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1526g7ybbd0l31bvqdpbarscjsnp1rajfnb9bwyjy8wq1p4q1pcp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493705,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "f04416b327a22f0b1e31dc1e04b4d1c578ffcf6b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0ag3hyvwi9sr0z95v09iwnx6n8wccxsga8z0gwgm286i0q5m4971",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586494587,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "9a12ac0d602b658134e0ce391e283a2f58d5b725",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1am7mjlf4vsybkzgvhhiak6j00awykncg0137wqagshyz5b0sp2h",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
+    "dateTime": 1621048193,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "a3c75f1dde3a3fa42d22a69ad7f8774ebf0b7f81",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bccbfl7imas5i47cnj5ms3lvsqkhp4nx37nbips3ia7d6fskjcs",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "dateTime": 1612577410,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "758e7982779b0a137b30c89c266e0f14dbe586b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1a0ls85jsic0xiyifqaxsp15s046j3a28p8c5mih8ya0hbw80x7l",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
+  },
+  "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586494589,
+    "groups": [
+      "linux",
+      "pdk",
+      "x86"
+    ],
+    "rev": "6256d95bc913b6443df08e86039b17ae653ec0fc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0sbw4b8f21cmhxnx6ad5ia5jz1fhv7834m8xskaw4ik5dxrarm11",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gdb/darwin-x86": {
+    "dateTime": 1575581434,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "f712b1af8c1bc77823f8116fae21b69da04f3ce5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0gs89dnw1xkpb94lism8s8arhlkyq52h7w1v530a3zdj656h7xrv",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
+  },
+  "prebuilts/gdb/linux-x86": {
+    "dateTime": 1575587382,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "358b3ffcee5b5c78b93a5fb0b31ef9ff0308fe02",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v8y9rdivi8ydrbcvxrkdlzc8snjpdjwgzra2s7qrjpd2qg4k4k2",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
+  },
+  "prebuilts/go/darwin-x86": {
+    "dateTime": 1614046184,
+    "groups": [
+      "darwin",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "6f0c58afff139e9874261ec88e33966136dd0be0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16hxbnamn9cayw4fv940m22k6k3yz4m9nf3liy89z7bwl008s2yk",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
+  },
+  "prebuilts/go/linux-x86": {
+    "dateTime": 1614046184,
+    "groups": [
+      "linux",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "41150f11c85aabd300f9c6d7bf5e9bf84aca225b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07dv2mwbxazin9kf32fv6s30ac28q4khswfavql8d78zcmacgw03",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
+  },
+  "prebuilts/gradle-plugin": {
+    "dateTime": 1618024161,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "8f778219fa46adb29e1b9f5992b8e8f6669b71b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sap095xg08fz10f6rxhnnd0c5d2xlld1zphp41hbdga5fhsn8gb",
+    "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
+  },
+  "prebuilts/jdk/jdk11": {
+    "dateTime": 1615428530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee8a422d2dcdf9b3af2a549ca19cffcca44705ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03wsqba6nzghhrqsvsi33rfjh8hdzx98vjkx2as0l601l21cks8n",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk11"
+  },
+  "prebuilts/jdk/jdk8": {
+    "dateTime": 1551002778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "348aefdc1d624104b8db3fc5f3e3f8667e27c959",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
+  },
+  "prebuilts/jdk/jdk9": {
+    "dateTime": 1600160960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d4a0a2114c710c4dbb455215f4963c2bf947b0b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0f7b8cydz6j6pvgxln6g0dp62qz0g1768zszdiwswk8zcvzk80l0",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
+  },
+  "prebuilts/ktlint": {
+    "dateTime": 1586494587,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "921bf61c90884ed0ecabfe2e8b84987735067116",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11rsh1vvx4k2wyn6cmhq7s5inrg0nrvavvdcx3jpkrvdh3lr1laj",
+    "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
+  },
+  "prebuilts/manifest-merger": {
+    "dateTime": 1613866147,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "91cfa76f6eecbbe4c5a93339208065c6ea7924fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0agc0j0mvr9fbi72x9dbf4dwsf9y8k4sniajzmdnkpyy5jlixd7d",
+    "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
+  },
+  "prebuilts/maven_repo/android": {
+    "dateTime": 1572476701,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5f3b5ed879e75fa533879c39cfea6a6829528ada",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
+  },
+  "prebuilts/maven_repo/bumptech": {
+    "dateTime": 1613866148,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0ff696cf8314a6e1b8ef22b4cf9c4ae467c1f3b4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03wzcxnixq9gfzciy09qjxw97d46zdhzihgx3g5lqv6403il1lf1",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
+  },
+  "prebuilts/misc": {
+    "dateTime": 1629508136,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6a9274e2bc25ecfdf3457ec79c535f78933463df",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q26ggqh11aa3878njn3sfbmr7g1wklbk1yrl7pzd12mjvpla3ji",
+    "url": "https://android.googlesource.com/platform/prebuilts/misc"
+  },
+  "prebuilts/module_sdk/Connectivity": {
+    "dateTime": 1643410235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51838f42b34c4e2269dca84dde7d24024a38fe00",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0140l9y2amfc36fz4g7k6cb3zhpqy7m7w0qpz9dh7kv1gvq0gfr7",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Connectivity"
+  },
+  "prebuilts/module_sdk/IPsec": {
+    "dateTime": 1643410236,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75e4fc687ef6f512b69d5507c2d9ad3100ad0c6d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09w9cmnlxxms4d52xbydz4c2gwxhdrv2yg354awg8iz6ri2s97yp",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/IPsec"
+  },
+  "prebuilts/module_sdk/Media": {
+    "dateTime": 1643410237,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "79895b3819d43e496e83a0fcd36ad25fbf617f04",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0dvbbpihyxrl1pvy61p9b2xqfadsvdcfd4v27nkr1n4pv50y0db6",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Media"
+  },
+  "prebuilts/module_sdk/MediaProvider": {
+    "dateTime": 1643410238,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0da7a97f46f6b55293e583bcd7a393bda26bbb58",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1nw30m4in5vy90aqy5dbg98x4lxsgayz8dnnp5fq1yakb5akb2d4",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/MediaProvider"
+  },
+  "prebuilts/module_sdk/Permission": {
+    "dateTime": 1643410238,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab5accf760f353f9bca3890e5e7be68586e9f206",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bnfh8yria5vlphm56pi5r5xsw3rchd2nalsw90fxw0cx4ji06zz",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Permission"
+  },
+  "prebuilts/module_sdk/Scheduling": {
+    "dateTime": 1638583751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9e14c1e884ceb84b43609fd6014093c05c8eacae",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1krvsxr582p3bqvgijpxzzx9nkwlbh02ib9yh6drn6srpbjlbr8m",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Scheduling"
+  },
+  "prebuilts/module_sdk/SdkExtensions": {
+    "dateTime": 1638583752,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72e09839d5e7e5472669da9d3abe558384d4da24",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1r6dvman8wgvgmy6kv2zr2vh1lwl3869b743dqmxsqc16wb2fwbk",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/SdkExtensions"
+  },
+  "prebuilts/module_sdk/StatsD": {
+    "dateTime": 1637885452,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "45b6074a5cd1e3ac8e30460f2157e3203cfcef66",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "037ik8d8qkfb9i46m7dkknxb0xr3pmpsfg1x7jfkdxk1rbp5j151",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/StatsD"
+  },
+  "prebuilts/module_sdk/Wifi": {
+    "dateTime": 1643410239,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c66b03b45c9aa8c39e6c3b430a8371654287a7b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11w5dxwa2sqf8sg2j78hr4ylp6sh1xip50cwzzf66b1c8lvcnhv6",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Wifi"
+  },
+  "prebuilts/module_sdk/art": {
+    "dateTime": 1643410240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba384683185ee9ba53ecbfb2772f3de862968761",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "132hdlcbfh0s5svs87b0hk1wgi3sym5pr1vni8jyspffk6gq09l2",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/art"
+  },
+  "prebuilts/module_sdk/conscrypt": {
+    "dateTime": 1638583750,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "991082adaf1188d5d8a856cdfb105bd4b85e44f9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zf61rlm3q2by6bi3bvfisw4f7xzb0j0jxjpk3i2v52ka4r0bsd7",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/conscrypt"
+  },
+  "prebuilts/ndk": {
+    "dateTime": 1617419323,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ef2a00486020670a7fefe2248dbd51d1a4a36c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "18g58y7abpi4kgc8zphv08yg89pcs6wazzm54v89lrbry6shhdp5",
+    "url": "https://android.googlesource.com/platform/prebuilts/ndk"
+  },
+  "prebuilts/python/darwin-x86/2.7.5": {
+    "dateTime": 1446753806,
+    "groups": [
+      "darwin",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "11b5cff5d042fe1ddbeb51f2c92b2f35bcdf5bc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
+  },
+  "prebuilts/python/linux-x86/2.7.5": {
+    "dateTime": 1551111763,
+    "groups": [
+      "linux",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1911b54ade8d6dfd6c167aa4c09679222f00cb7c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
+  },
+  "prebuilts/qemu-kernel": {
+    "dateTime": 1613866151,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "13df3a8b5beeb66255f40aa528ca43136a8aca2d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "174ffmr45kn5qkzbfc8a9irk8p2ksxzj5rylbbisswhlk7419rpq",
+    "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
+  },
+  "prebuilts/r8": {
+    "dateTime": 1636769352,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "970bbc7356f0fccff943afc0dcc117bdca37cf2a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zic971y9dyymxlm0p3s3jsv7gddvxacb57177s2v0wmkvg2yxyf",
+    "url": "https://android.googlesource.com/platform/prebuilts/r8"
+  },
+  "prebuilts/remoteexecution-client": {
+    "dateTime": 1635894568,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e308c056a3d660e647f774a1befcef204ca23d74",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0qjzgc0my99hgg1c82xikizs461sv04cxpvvcdrrq9748ac4ix8b",
+    "url": "https://android.googlesource.com/platform/prebuilts/remoteexecution-client"
+  },
+  "prebuilts/runtime": {
+    "dateTime": 1624929289,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc5ec4bc9bccf47922bca8c3026ddfec0530e461",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0yyl276b039qmbz3b7mqnl4h3mqk5ggv0yq07k2hli9v09w55dha",
+    "url": "https://android.googlesource.com/platform/prebuilts/runtime"
+  },
+  "prebuilts/rust": {
+    "dateTime": 1636160959,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9a07b16decca6df629117880185662534cdd725",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0cbms2bphjrijga9f9arndpxn1bsaps58k5gffxpvjvbcdczsc9c",
+    "url": "https://android.googlesource.com/platform/prebuilts/rust"
+  },
+  "prebuilts/sdk": {
+    "dateTime": 1638835811,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "420d5efdf7be6c685ac1a9a595f2ad0ddaf0f553",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "017cn9b1imrpj4h20xxbmi54ficqsnpd5yhr3x4fgmdmz53flarx",
+    "url": "https://android.googlesource.com/platform/prebuilts/sdk"
+  },
+  "prebuilts/tools": {
+    "dateTime": 1639793347,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "6ee707c86c5732a6d91218a65bea473a84cd56b4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h6rmmfspwk64cfw4hk50c54p5y8dm0i479zacxriwf8cipjaxsg",
+    "url": "https://android.googlesource.com/platform/prebuilts/tools"
+  },
+  "prebuilts/vndk/v28": {
+    "dateTime": 1636416602,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c49db363408176eb5b875b36ab0e7213baaaf446",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1m4zvl6v8lk0ap262bklnwfk8j3bkbwh10j4h0j7dhvmjz7bk58f",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
+  },
+  "prebuilts/vndk/v29": {
+    "dateTime": 1636416602,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a42ffdaec3136f99c99d51945e3ec314d77cc511",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zr93lpdcmjrphyvn9f7i5wwvs92ss0phxh0i429arahhg8qlq1s",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v29"
+  },
+  "prebuilts/vndk/v30": {
+    "dateTime": 1640045347,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20aac77ddc2c0daaed38f781c87d2bdaf09b7915",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sssg906bx2g43bcszi65jvg9kmvdgvwxq9bgz6daadfxxalrf64",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
+  },
+  "prebuilts/vndk/v31": {
+    "dateTime": 1637798988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3979b12be53e1cb99a65e1da6b8775d97cc9fb04",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1i8fw4r9yylq8ycwapj119cf2rk21i72rr7j1sd18h25f19vgg9q",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v31"
+  },
+  "sdk": {
+    "dateTime": 1613441354,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c1ee3c8d989a651d3df63ac71f047a19abf27500",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1x4v7n0i9pcz91q5ii4lpwrmqr9v0hpwjv86mcqjzjw22rzi5rxa",
+    "url": "https://android.googlesource.com/platform/sdk"
+  },
+  "system/apex": {
+    "dateTime": 1635980985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "288ca66c084ffed0392a1768150580804324321f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0m9zrsbc2z4fdg2l1drakgc5560m7vgr00zhvk0as2iyq2l4j8xk",
+    "url": "https://android.googlesource.com/platform/system/apex"
+  },
+  "system/bpf": {
+    "dateTime": 1625620193,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a24ec3fa8cfec4a40907c62095fe446acf91e515",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qp4zl4hzq1xdm7j6qd44bx2fb821j746vyxz9296zi6nwqaj0hf",
+    "url": "https://android.googlesource.com/platform/system/bpf"
+  },
+  "system/bpfprogs": {
+    "dateTime": 1613866159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc077250df5531c83469a216f51b19846314a924",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "059l6k1y7jpjbkfamq83pjj8nzmghc5pqkz1p53pn556w1hr34jk",
+    "url": "https://android.googlesource.com/platform/system/bpfprogs"
+  },
+  "system/bt": {
+    "dateTime": 1640736556,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5a1677b75359c428496d968c91ed3c542271e94",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "054mkfyz3m5nfwf76x7p6fr5jqjc8jc946fs1sm0llmc85p9rql4",
+    "url": "https://android.googlesource.com/platform/system/bt"
+  },
+  "system/ca-certificates": {
+    "dateTime": 1613866159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "77f86efbeaafb8c221768da70b479f0dfd9dca9b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1rz4x4mrsv112csx3bykgi78rrf1sc4g8p5yvma2yyrcn7j0vxq2",
+    "url": "https://android.googlesource.com/platform/system/ca-certificates"
+  },
+  "system/chre": {
+    "dateTime": 1638317414,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3d7b903537228b72ef53e233a163366157006d2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07nz1sk5wzsds5b0mcic7jj5y1lxvjxf7qhh6xl3b4lzkirrnyfs",
+    "url": "https://android.googlesource.com/platform/system/chre"
+  },
+  "system/connectivity/wificond": {
+    "dateTime": 1628903529,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf70586ae7ce5b4d027e9dc504adfb762cb76b6c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0lymnj2i95lcb3xmlawm1gpvrbr82y3kgggj1a71vcn4776bs7j3",
+    "url": "https://android.googlesource.com/platform/system/connectivity/wificond"
+  },
+  "system/core": {
+    "dateTime": 1643233201,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c2d454354056d641e123286cde159ec231a6d68b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1lfy6cmsmfpv3m274hnlz42n61hyx81kvmyp69fmw5psfqrbhjsg",
+    "url": "https://android.googlesource.com/platform/system/core"
+  },
+  "system/extras": {
+    "dateTime": 1639526967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2d8c4a8e97dd43aea381e6c1cfef7ba139a2af4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1sbpflpw3cb71w8v76ps177y7r9hvqc7l9w0l3yv20g6zw4hpnzd",
+    "url": "https://android.googlesource.com/platform/system/extras"
+  },
+  "system/gatekeeper": {
+    "dateTime": 1613532014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2a661295e0c4f846d1a42130777d69264770b4d2",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wxbr2nrgv2w9zwy8vf7pi4vnjcs6jrhg7p0psp36iqqpj46ncpc",
+    "url": "https://android.googlesource.com/platform/system/gatekeeper"
+  },
+  "system/gsid": {
+    "dateTime": 1625707065,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fcd14f4de09f9a6ab9f2dfac66f95a85089d511e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13xicpg8wk1y021a3lxlq49vr51v2nicfwn3zavvz0xgs065ygzs",
+    "url": "https://android.googlesource.com/platform/system/gsid"
+  },
+  "system/hardware/interfaces": {
+    "dateTime": 1630112978,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0cc52ec432c215ffb7ede5aebe729e5a7d44b91a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0nq5mdqq63ba26c1iy8hiy9d9mwzy3pjq9m2hh857j8rvhd1w3d8",
+    "url": "https://android.googlesource.com/platform/system/hardware/interfaces"
+  },
+  "system/hwservicemanager": {
+    "dateTime": 1622862604,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc264b01bd16b3f8cc99de1ddfba1b55a9b210f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03sg3s64q6iik4i0b8l57dz5m1xxk9dfyqirz72y61ycl4hnagmr",
+    "url": "https://android.googlesource.com/platform/system/hwservicemanager"
+  },
+  "system/incremental_delivery": {
+    "dateTime": 1635980990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36d693d0ed5c61ff5da5e67ba1f74f426635e5fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01qwp2nl3p7r01ksg6mjzw3ybzh2m246i0xr1fv2q0akm75bwgzr",
+    "url": "https://android.googlesource.com/platform/system/incremental_delivery"
+  },
+  "system/iorap": {
+    "dateTime": 1626225038,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec55326a6b71be5bbcbba316fd0804d1ad2dcc43",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0q3ip59rm8b3x3ralfn414bc0q51p42hxk2n2mr9pdd7d3vhmbpb",
+    "url": "https://android.googlesource.com/platform/system/iorap"
+  },
+  "system/keymaster": {
+    "dateTime": 1639188542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3034cf13a36d8aa04569c00a6f19c53a9b8ea6e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "114sjd25k4x60nzx866c46s9d52j0p2wdhi09bcdd9mq9nan586f",
+    "url": "https://android.googlesource.com/platform/system/keymaster"
+  },
+  "system/libartpalette": {
+    "dateTime": 1639440570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9901cd8c5229cbf77b55adff206325050da9e353",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0r9f816j292rqlz6r80mzyx05z1smrrypa0cz1pamx5s6j78ylpg",
+    "url": "https://android.googlesource.com/platform/system/libartpalette"
+  },
+  "system/libbase": {
+    "dateTime": 1621048222,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14576ff13cf5bce7d2ae0e8957178409ed3f68f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h5aw1r81ikh1y5723m8nzdl3z6f3fq7krrzjfrv80x8zwvgyml2",
+    "url": "https://android.googlesource.com/platform/system/libbase"
+  },
+  "system/libfmq": {
+    "dateTime": 1622077819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20bcc70d33bd5c42bd7459e553bc715989911bb9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gnrsz7k2ish726cdcysa2z0ai6npxnx9kpgpq65crakcnswkdgd",
+    "url": "https://android.googlesource.com/platform/system/libfmq"
+  },
+  "system/libhidl": {
+    "dateTime": 1625188413,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6442833159f482b429b402d560bc8cf599e9498c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1y1sw5p7dlal4b74r00jp6p0y5mjpablpli42cdcq5byhayz08r8",
+    "url": "https://android.googlesource.com/platform/system/libhidl"
+  },
+  "system/libhwbinder": {
+    "dateTime": 1622077820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20de08056006ed439232172118d568c304e4a8f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09nwism5hs2514pqccyh5nk558z2qrvrh2fhmqmfv3pm9sdd6bwj",
+    "url": "https://android.googlesource.com/platform/system/libhwbinder"
+  },
+  "system/libprocinfo": {
+    "dateTime": 1625707078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52fc8c8ca2dd437a40420f69746245021fb292d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "015y2lxpg1w3ijvlfridfwnbjvqd6gcsgya6fri8xn651m5bhdlz",
+    "url": "https://android.googlesource.com/platform/system/libprocinfo"
+  },
+  "system/libsysprop": {
+    "dateTime": 1621048224,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "232fa15531bbe903e4c721251512e9ebdad196e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0m6nk4r3rp267mlc7pi9cq19a2npb836cf5kv8k1xza1iqiaq0bj",
+    "url": "https://android.googlesource.com/platform/system/libsysprop"
+  },
+  "system/libufdt": {
+    "dateTime": 1621048225,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b24386ceb74592761771ef3f504d9d06b26ed43",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0lx95r91jpfcqhp9d91yvn6z5rdym4s4z2l3v2sa84dqpb72frpp",
+    "url": "https://android.googlesource.com/platform/system/libufdt"
+  },
+  "system/libvintf": {
+    "dateTime": 1621048225,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6cf1d21894c201bf828ff9c60e5237ae6f964963",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11rp914fxzapbdksjn6clmj40n9gmybgdqnngcppyqk4gs97bwz3",
+    "url": "https://android.googlesource.com/platform/system/libvintf"
+  },
+  "system/libziparchive": {
+    "dateTime": 1621048226,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6e8466542bd69b486724fcee424939089bc4666",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xhrhxj1f2cbknk5dgld8v9rhrzk22p2q6dzdhnlvyqgqzyf4rg0",
+    "url": "https://android.googlesource.com/platform/system/libziparchive"
+  },
+  "system/linkerconfig": {
+    "dateTime": 1633043813,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8836314ffdaad82e087adcd5c0bc0b0cc228d3f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0vai4jakxwblgrh33siaz6zhf77mr2nwk4f880jk64fd5pw1rg13",
+    "url": "https://android.googlesource.com/platform/system/linkerconfig"
+  },
+  "system/logging": {
+    "dateTime": 1628809784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "790e8672fcee6c0de3763f19e289cbddc1e183c9",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v7nk3yyllk4ah448kkjil1idv017h1zmi2qslp5zl19c9k1n495",
+    "url": "https://android.googlesource.com/platform/system/logging"
+  },
+  "system/media": {
+    "dateTime": 1639260571,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ae7ef19b39ffa3c99f12d12c1bf1c363317de4cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hrfaj6nydw6cc3wirhs67bs1ypicbx81l0r0h6rdyy0kqg59c3x",
+    "url": "https://android.googlesource.com/platform/system/media"
+  },
+  "system/memory/libdmabufheap": {
+    "dateTime": 1628975410,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b73d22667a3db115cf7422bbf4d72883871203a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "03l8sr6dmi8rnf9psclm0sg0pwqfnp7vknc6vydxgbz1gjxgdr34",
+    "url": "https://android.googlesource.com/platform/system/memory/libdmabufheap"
+  },
+  "system/memory/libion": {
+    "dateTime": 1613866169,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "51b722bc465018d63507619a1a22992978c700e6",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0jmb5lh6hgyzpsp711dd5igns56xls0crb2aqnzwqfyvn6dinbz3",
+    "url": "https://android.googlesource.com/platform/system/memory/libion"
+  },
+  "system/memory/libmeminfo": {
+    "dateTime": 1626491419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e337fdb7774eac5885b08570380cd44b9ba43f4c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hxknnvj22ap00v3nsh6867vi1bcb6dpsm90n223c7z0247kb5az",
+    "url": "https://android.googlesource.com/platform/system/memory/libmeminfo"
+  },
+  "system/memory/libmemtrack": {
+    "dateTime": 1617844202,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "633f6420e989482092ffb9f2da4b857cd81f644b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1v1zrkh94ynxgsi30s5i1ivahdabv10clysam1v1c762rczsgr8v",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemtrack"
+  },
+  "system/memory/libmemunreachable": {
+    "dateTime": 1623374605,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "844cc488b013621e50ffd56de98fbaedd514232e",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1hg82k95l8ph8phl9n982yxy016z68m4hbwjj5sdsnmi217v2cpy",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemunreachable"
+  },
+  "system/memory/lmkd": {
+    "dateTime": 1640304558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4279119947fece1ce141130137306b61de6e00a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zs9110x7g59rjxrqjri4xm1s751p3yj0xq9dsbbhyg492l40wd9",
+    "url": "https://android.googlesource.com/platform/system/memory/lmkd"
+  },
+  "system/netd": {
+    "dateTime": 1634346567,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "196067cf45e7bc2a0e64659734792bec85da1160",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "16ra9lzaac6rp1f2a57i6knjnrbhl226wjaf42bkdnw0zcj9gp64",
+    "url": "https://android.googlesource.com/platform/system/netd"
+  },
+  "system/nfc": {
+    "dateTime": 1639440580,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b152b990391e166ff07017991c11d3042ceec96d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0n6am97qcvl14dxr63pgvkay1iz8xhrjb7q18wch0i4f6srkbbrk",
+    "url": "https://android.googlesource.com/platform/system/nfc"
+  },
+  "system/nvram": {
+    "dateTime": 1612577449,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6a937062a33af781791a2726312897315c46c91",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "05xspxnd1366hmv4sjq2fmhbgjq4camppfnqpmakkydd4pw4qnn0",
+    "url": "https://android.googlesource.com/platform/system/nvram"
+  },
+  "system/security": {
+    "dateTime": 1641946314,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e4f1240fc28cb01bb0bc35fef87b5a135bf9165f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0xh4hsgvlxjcb5nb59za7xkzqcp7lwmnli84pwdm6cx073p7868f",
+    "url": "https://android.googlesource.com/platform/system/security"
+  },
+  "system/sepolicy": {
+    "dateTime": 1643410242,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6b08c0bc69743979eef2522d698f51b622e0a04",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04f3w7irs76zjq087j75i437ppparp2x7q0xkwy6qlzg06pgjbng",
+    "url": "https://android.googlesource.com/platform/system/sepolicy"
+  },
+  "system/server_configurable_flags": {
+    "dateTime": 1613866175,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e93b93740a25b02a2a1ff237e9518ce52a37e3af",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1ih665qh777kw9vyz8sgsbk3nm2bnhklir7v4df25j8wdr8kw4hv",
+    "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
+  },
+  "system/teeui": {
+    "dateTime": 1617066564,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6c40e913ed92417b87265bc21bc6cfb2e9a18e9c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1bicz4kmz79mifxfmzc2rzrgvp95zmcxm7giw8lqsigv32m55avl",
+    "url": "https://android.googlesource.com/platform/system/teeui"
+  },
+  "system/testing/gtest_extras": {
+    "dateTime": 1613866176,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "534c3e0166fafb93d8abead7be521aae4be6e0b4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v5ifyrq7wxsm0mh9843fidj4jmr2x10xqdvdwsshb1p17hxjyyp",
+    "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
+  },
+  "system/timezone": {
+    "dateTime": 1636769378,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2977ba4e7255fd87deaa66cfecab3a095dfa9691",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "08sn293cpbizif7ac3g77dj3dj8wpbcqxasca2xzhj0jxw3khd1c",
+    "url": "https://android.googlesource.com/platform/system/timezone"
+  },
+  "system/tools/aidl": {
+    "dateTime": 1639008755,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c08b0edf231c99b442f1594d2b8f32a4e16fe787",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0c2mfz16vc7ql3in0mqn11fqb1hdf3jfamh4gkdm1lgclr1f7qzb",
+    "url": "https://android.googlesource.com/platform/system/tools/aidl"
+  },
+  "system/tools/hidl": {
+    "dateTime": 1627701029,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81858d3cf9749548641468fc46741b09e71e23a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "14klv5dx95fcihfck1r41bz9nxgcblf838sj62mad685pjmah7fb",
+    "url": "https://android.googlesource.com/platform/system/tools/hidl"
+  },
+  "system/tools/mkbootimg": {
+    "dateTime": 1639188557,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4517784d8bbc6bc2771ba823583e5d72b181da0c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1crqv3dz191rwdwym9y5ssvvlb040ycwq2863y272iqywzparn0n",
+    "url": "https://android.googlesource.com/platform/system/tools/mkbootimg"
+  },
+  "system/tools/sysprop": {
+    "dateTime": 1616634570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e5992b1691189cb80bab88e54f14f2562b3c211",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hvq6n3kj0lyyx782wwy32q1m24qclkmas5jdb2wy5hxcrsqvwds",
+    "url": "https://android.googlesource.com/platform/system/tools/sysprop"
+  },
+  "system/tools/xsdc": {
+    "dateTime": 1624410644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d47d74f660813a12bf9cba225a2448a7c9187413",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "01kh80wg5r9b1csz23p7x0rqlpb26x5z4r4gi2y4ibisy5bva3w4",
+    "url": "https://android.googlesource.com/platform/system/tools/xsdc"
+  },
+  "system/unwinding": {
+    "dateTime": 1633208987,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "015601e6365ed95e98b6dd7ebf6538eeed4fbc90",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0iw26p7rx6r9j11r0bvds8idpl7kw6gja4d81wyyfq2j8a2q74ys",
+    "url": "https://android.googlesource.com/platform/system/unwinding"
+  },
+  "system/update_engine": {
+    "dateTime": 1631747446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "599ce0c950ac4c7fe5306b2994bab71c55596332",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0rz4d5aqxhvcj0c748sz8dls6dicsvia6skqp4ynm523qhlhjdi6",
+    "url": "https://android.googlesource.com/platform/system/update_engine"
+  },
+  "system/vold": {
+    "dateTime": 1636841376,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3cfd6469ad50e871203de100239c4fb7083eb4dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "14pwnbfznd99y1z95r52gqb9lf3gprjmiyznq79di0mapcp4wzp1",
+    "url": "https://android.googlesource.com/platform/system/vold"
+  },
+  "test/app_compat/csuite": {
+    "dateTime": 1621048240,
+    "groups": [],
+    "rev": "8e766acf9cd7ad5c1204e99c58956e10f0aa6a9c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "11h6hldlwrcfk314wn77a218384yh4kz4xz3nzvy3yqm99ywhz8n",
+    "url": "https://android.googlesource.com/platform/test/app_compat/csuite"
+  },
+  "test/catbox": {
+    "dateTime": 1639613597,
+    "groups": [],
+    "rev": "c0999ac016ecf520e3fb46552fcff5efc8ebde62",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1vvhs8zifbpg425gzykksvqjiv7rhbpk16w5vm78lbmxsl2p847h",
+    "url": "https://android.googlesource.com/platform/test/catbox"
+  },
+  "test/cts-root": {
+    "dateTime": 1624640246,
+    "groups": [],
+    "rev": "4829dc043d3b6449d9ff301f37f44fa50cd668dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1garbzndz4qsxmv6cys2zf3gwlsay5yw5svfbz770hhim4i037b6",
+    "url": "https://android.googlesource.com/platform/test/cts-root"
+  },
+  "test/framework": {
+    "dateTime": 1613866181,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "c28daa993ddc2d98562a74527c9847875a802c54",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1p4gak809gfak9r64pzrq708p53i7y7045x10q7ji16jycw123lv",
+    "url": "https://android.googlesource.com/platform/test/framework"
+  },
+  "test/mlts/benchmark": {
+    "dateTime": 1621048239,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da533a1680be892a29d42084d2073df556c5e0d4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0n5yjswf4lnshqg8y0lb2wi65gqqqa0xjfgffkif6m8ma6642mh5",
+    "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
+  },
+  "test/mlts/models": {
+    "dateTime": 1594388199,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5042637160d97b6233af2e0676248afc55404a88",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "136fcq4lmc69yp1gzlynvrv7126z91aw2l1y1gns0d69xk9hfbjf",
+    "url": "https://android.googlesource.com/platform/test/mlts/models"
+  },
+  "test/mts": {
+    "dateTime": 1629846580,
+    "groups": [],
+    "rev": "199ea18405bcac153b2af5a9566fc56b7d1cb8ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06k2xbcdlm0xckbnjgvybgzydk27grx7k5nkx5knxhhal76p5njk",
+    "url": "https://android.googlesource.com/platform/test/mts"
+  },
+  "test/vti/dashboard": {
+    "dateTime": 1551088143,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "56895ce046ced31a993946d0382ef3673a6939e3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
+    "url": "https://android.googlesource.com/platform/test/vti/dashboard"
+  },
+  "test/vti/fuzz_test_serving": {
+    "dateTime": 1551002920,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "af08632e12b97a4bc71bf9d6ee23c66335818d61",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
+    "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
+  },
+  "test/vti/test_serving": {
+    "dateTime": 1588777700,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "29102614a1d8a4c18923a84de97ad6460e26ea63",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12y5bwvhbj1yscbi87irp0xgwmb018fck905zf678aii8qckhp9l",
+    "url": "https://android.googlesource.com/platform/test/vti/test_serving"
+  },
+  "test/vts": {
+    "dateTime": 1641514179,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "f230e288e70551af530feb8ee396fb7223ed7289",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1wisf4kabifz94mf826jq7kmz4amy2pc5yvwidfvrkfjlmv8fyh0",
+    "url": "https://android.googlesource.com/platform/test/vts"
+  },
+  "test/vts-testcase/fuzz": {
+    "dateTime": 1613866187,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "6c371158144b465858fc8176c8849ee75151af4a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "106hmz81aaqpy3gq6apgz4a1j6nmvhzp8rbzpldqcl7ymn552h76",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
+  },
+  "test/vts-testcase/hal": {
+    "dateTime": 1640131798,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "ca85dda750c443bf88e7f1c7f195b6e42ce645e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13n1p4d3a832fns95npc1wiqq1jc6h3y432bkm36s7y10qhzd1wp",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
+  },
+  "test/vts-testcase/hal-trace": {
+    "dateTime": 1551088166,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "163ef9caa690b4580c9a1d1ebc9d800a0ca69a54",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
+  },
+  "test/vts-testcase/kernel": {
+    "dateTime": 1635894606,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "db1a3a907a32ec60a8f76745f39028bf38b98b1b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0hlbmm9ifx9a0bmfx1xhw4mx2y9vm5lc1xm43qwzmpdrj1larzk2",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
+  },
+  "test/vts-testcase/nbu": {
+    "dateTime": 1613866189,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "22d40c23594d685bdc3361422f546191ece120e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1h3vd99wax8n5ygs6cg15f0p8kj07kas75n72j7b20n4qdy2bflz",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
+  },
+  "test/vts-testcase/performance": {
+    "dateTime": 1613866189,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "f8f8dd61d6d55e0d734018023aff2c9ac950b470",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dh5n3pprrdb607f3jriz2madgq3ri8fv4c4mcmqld5fbc56w05b",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
+  },
+  "test/vts-testcase/security": {
+    "dateTime": 1636067570,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "7e87dc82d65cf906ac523d09979fc2140c06632d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "10ysras48ih7bka5c413a3mhjqryvsnz96g2rmdfw9xv2v8cb1bj",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
+  },
+  "test/vts-testcase/vndk": {
+    "dateTime": 1629846586,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "39547c0419ef7e2ec8b5e6bcb8bfe0ae83a00c44",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1l8r1qczbzaqvlq8cd4x1wvi2y2lh14m4fqcqypxlmvi3nl62pqx",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
+  },
+  "toolchain/benchmark": {
+    "dateTime": 1613866191,
+    "groups": [],
+    "rev": "f99cf13901314fadb26d078a6509b7f4250a72a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "04c2hzbgqxcim23z4brvq0px4cifmz52434lxacq741kqy8a3yn8",
+    "url": "https://android.googlesource.com/toolchain/benchmark"
+  },
+  "toolchain/pgo-profiles": {
+    "dateTime": 1626563655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "455edf58a2bcb5ab6da1ad710d2dbbd82258b3f0",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "023wq00bzc3lafcy4l4dwyhx0dxlpxikqr7wixj8jvz39n0hlq9g",
+    "url": "https://android.googlesource.com/toolchain/pgo-profiles"
+  },
+  "tools/aadevtools": {
+    "dateTime": 1621048250,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03f4f814d466b3fd64384c4c74a8dec90761b06f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1zb9yfwjj9f0hk75vi7qg9j3fllpk3n5mfhgky8z385bh2jmzk5v",
+    "url": "https://android.googlesource.com/platform/tools/aadevtools"
+  },
+  "tools/acloud": {
+    "dateTime": 1621048250,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "tools",
+      "tradefed",
+      "vts"
+    ],
+    "rev": "366f148faadd1dc900df70717ff487863ac2c66f",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "02svjyi2vj85r6yi6k5i0xffkxkkxh6iyf7bpf99aiwq80aw3hfq",
+    "url": "https://android.googlesource.com/platform/tools/acloud"
+  },
+  "tools/apifinder": {
+    "dateTime": 1623287516,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "c985d9637ba505ef3f2683c69267e2ecb50be74b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0bfac5abla83d56kz7hvwdb12h60h90lj9ahy7cgg75qfgjnj9ic",
+    "url": "https://android.googlesource.com/platform/tools/apifinder"
+  },
+  "tools/apksig": {
+    "dateTime": 1622257826,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "c52b0912b8f077e6443327a9448d131699686def",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1dl6k7qnk9kl26sdr3a6hy2mg9939a20bk7qp11jb3c5vnmarcsy",
+    "url": "https://android.googlesource.com/platform/tools/apksig"
+  },
+  "tools/apkzlib": {
+    "dateTime": 1621048253,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "2084ab37e773ee6fe5207353497bc201a32a5dc4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qbj6g2jivxjlxgm1z27anqgb0hh50fm3mqfpb4bd55mqn73csi8",
+    "url": "https://android.googlesource.com/platform/tools/apkzlib"
+  },
+  "tools/asuite": {
+    "dateTime": 1636161003,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b38f9132d6301a79c64baec7ae0227f66fadc824",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0lhpqxdbakqawxvkm8ad53m11yvcha5s75jzcqyni806wcspnc2w",
+    "url": "https://android.googlesource.com/platform/tools/asuite"
+  },
+  "tools/carrier_settings": {
+    "dateTime": 1621048255,
+    "groups": [
+      "tools"
+    ],
+    "rev": "5ef1ba9f0e42adbd2f76f5446df82c9d7704ba2d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1gcpddy94nmhqbmpr3y1s6b29w6zx3r5ixn53hd0s4y0rfw9ahj6",
+    "url": "https://android.googlesource.com/platform/tools/carrier_settings"
+  },
+  "tools/currysrc": {
+    "dateTime": 1611605421,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "116887283e39a50dce1b1703ba6845eeb6a8c9ff",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0h3smd8j3lrd8lnmzcpirn70k9q8l645sbgzfw6cxdrzbi7p2d1a",
+    "url": "https://android.googlesource.com/platform/tools/currysrc"
+  },
+  "tools/dexter": {
+    "dateTime": 1614996589,
+    "groups": [
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "7395ae4ca431d2603af6867741d2802e38bbd184",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1mmldb1h69bcxil78y708hfzr1v5s7y547j0v9cb2vgg48m109dg",
+    "url": "https://android.googlesource.com/platform/tools/dexter"
+  },
+  "tools/doc_generation": {
+    "dateTime": 1631747464,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "5bcdce9850e3b717ec3571d3f54933ba8c228ad4",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0wrhriszbxc58k6sqmv1lsipac7bi67q15yjg2clb6k5irp8rzkh",
+    "url": "https://android.googlesource.com/platform/tools/doc_generation"
+  },
+  "tools/external/fat32lib": {
+    "dateTime": 1613441394,
+    "groups": [
+      "tools"
+    ],
+    "rev": "028cd8502a3a55a1a5163399293553adea8da3c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0zx9wqm0l5w1ghcyj49bsfm39y8b97bckfmy9l5r62f6yx4hcgsh",
+    "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
+  },
+  "tools/external_updater": {
+    "dateTime": 1621048257,
+    "groups": [
+      "tools"
+    ],
+    "rev": "e03be8e2c5ca08196b10157e4aeb71844ad1b982",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0aa7dhk94wdc6qa45q2bhc8qc17x7f4n53gn8bqb06pdvwdiilmz",
+    "url": "https://android.googlesource.com/platform/tools/external_updater"
+  },
+  "tools/metalava": {
+    "dateTime": 1638583810,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "7a51ecdf012a09c687cedc06f9d3f7cfecc21422",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "06n81pbkibhn0bk0ap1g67nlzj4sq6iblqp2mqpcxr448xn44392",
+    "url": "https://android.googlesource.com/platform/tools/metalava"
+  },
+  "tools/ndkports": {
+    "dateTime": 1599773449,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6b43e0cbb3a6f8716bb2f14ac65ba8e7d8cd15b",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "13f0scvw1gkwjx24l6hqgk9v7q919zilas7v0b6h8pg2akiyd45h",
+    "url": "https://android.googlesource.com/platform/tools/ndkports"
+  },
+  "tools/platform-compat": {
+    "dateTime": 1633389022,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "74ba2cfc74d20dbbe64d79ce00ad083a7d240357",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "193lr1nxwghrz0ch9a2r744w108npnvr7rpzziy1h3wxgg8474qk",
+    "url": "https://android.googlesource.com/tools/platform-compat"
+  },
+  "tools/repohooks": {
+    "dateTime": 1634685007,
+    "groups": [
+      "adt-infra",
+      "cts",
+      "developers",
+      "motodev",
+      "pdk",
+      "tools",
+      "tradefed"
+    ],
+    "rev": "6be57e717cfa412bfffa56bfb6447c6808167150",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1yx3bwnpw5crc22v4sssy6vr55z2j1m9x4wa1gphix0lqy6n163j",
+    "url": "https://android.googlesource.com/platform/tools/repohooks"
+  },
+  "tools/security": {
+    "dateTime": 1634253180,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "a5608314399aeeb751e18fd2702b67fa060f9b90",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "09sk0fv0xghznv3hy3smxwgkgpg0a4ha516frfxjgxhc7rs0da17",
+    "url": "https://android.googlesource.com/platform/tools/security"
+  },
+  "tools/test/connectivity": {
+    "dateTime": 1641946376,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "927c52f3bb2fc9e7971dca461d53e11c5ee68103",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cp37j0j49ky6hfsjvkn3s69d300nrmkgffgba3lkpgxfpz84fdy",
+    "url": "https://android.googlesource.com/platform/tools/test/connectivity"
+  },
+  "tools/test/graphicsbenchmark": {
+    "dateTime": 1621048264,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e84a39466180015c88800b5a8ea4a73bdb3e106c",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "0v5b8p7lwcwrmd1sxc6axf7qkdqyq9p5dqcyazngr0amhdf2xg0j",
+    "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
+  },
+  "tools/test/openhst": {
+    "dateTime": 1613866206,
+    "groups": [
+      "tools"
+    ],
+    "rev": "7a744a9f9ba7c12ce42d72069dd6acae3671aa9a",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1qlnvcpsy11nd9cjjh6yy1bhcsikx3xg5rzkqbfhli0q0a5jwrpp",
+    "url": "https://android.googlesource.com/platform/tools/test/openhst"
+  },
+  "tools/tradefederation/prebuilts": {
+    "dateTime": 1642212609,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "760ec390d5298241fbdf5b47e04c96786efce022",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1z18jfsha5vb81kcv1rlsrn720g9a01vbgmvlz87r183lclgwh7a",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation/prebuilts"
+  },
+  "tools/treble": {
+    "dateTime": 1621048267,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "4beaadb00ee65c902959bf16f3709c2c05c1b707",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1cm4prh06srq421ibkac8s9kdjxvq6s0gy336sa92wc886hg8k2d",
+    "url": "https://android.googlesource.com/platform/tools/treble"
+  },
+  "tools/trebuchet": {
+    "dateTime": 1621048267,
+    "groups": [
+      "cts",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "e975b63017b913c9ef3a063ccd89ca7719cd6e0d",
+    "revisionExpr": "refs/tags/android-12.1.0_r1",
+    "sha256": "1i3iz9fyd0jbvmjawxy3w0qvf6ycnv6jvmxk6c7xm272ad43gxag",
+    "url": "https://android.googlesource.com/platform/tools/trebuchet"
+  }
+}

--- a/flavors/vanilla/12/repo-android-12.1.0_r2.json
+++ b/flavors/vanilla/12/repo-android-12.1.0_r2.json
@@ -1,0 +1,10897 @@
+{
+  "art": {
+    "dateTime": 1635375679,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b730ad8ad2d8d20364ae795050a748a3df50a32a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q5l3x7qdyz6a11pgqbfsjf7frfnhxrz5nms5rcijfg9swahrh2b",
+    "url": "https://android.googlesource.com/platform/art"
+  },
+  "bionic": {
+    "dateTime": 1637280060,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9969c4cbdbf365df0b5a6adb86bbf69ca8ef6cf3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rw2r4b9073hs773zn096fcjjyc87nr6hm6kyz22zvgqxr0viszz",
+    "url": "https://android.googlesource.com/platform/bionic"
+  },
+  "bootable/libbootloader": {
+    "dateTime": 1616547664,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "4cc0dc1b3b198518f2b6f21aea6b1b52eab38df6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1g10xsdj43z21cw7yl1mg70jdmgf27xqm713al4bvpqy7g3l177j",
+    "url": "https://android.googlesource.com/platform/bootable/libbootloader"
+  },
+  "bootable/recovery": {
+    "dateTime": 1639612859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d72c696642176e679b5bf59430b49c61127aa363",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fiwgp9zxnag49zjifili6nrcvbz3x10q64hwbyzgk76mdn6v54f",
+    "url": "https://android.googlesource.com/platform/bootable/recovery"
+  },
+  "build/bazel": {
+    "dateTime": 1621047725,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "WORKSPACE",
+        "src": "bazel.WORKSPACE"
+      },
+      {
+        "dest": "tools/bazel",
+        "src": "bazel.sh"
+      },
+      {
+        "dest": "BUILD",
+        "src": "bazel.BUILD"
+      }
+    ],
+    "rev": "ad40aa71d34789cd1a5aa5464a07383ea56cb941",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jsyl5fjbqna5vw2w3qqn6p9gr9rln6mkzisd0dqz1i8wh7nw1rf",
+    "url": "https://android.googlesource.com/platform/build/bazel"
+  },
+  "build/blueprint": {
+    "dateTime": 1621904550,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "86575de44b289dfcd3f49902f5e19f3e79ce910c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yi42fwvv679pfpr4vxy7vfrqr4la043a7s57rpbw2k5v7h6vm2y",
+    "url": "https://android.googlesource.com/platform/build/blueprint"
+  },
+  "build/make": {
+    "copyfiles": [
+      {
+        "dest": "Makefile",
+        "src": "core/root.mk"
+      }
+    ],
+    "dateTime": 1645936596,
+    "groups": [
+      "pdk"
+    ],
+    "linkfiles": [
+      {
+        "dest": "build/CleanSpec.mk",
+        "src": "CleanSpec.mk"
+      },
+      {
+        "dest": "build/buildspec.mk.default",
+        "src": "buildspec.mk.default"
+      },
+      {
+        "dest": "build/core",
+        "src": "core"
+      },
+      {
+        "dest": "build/envsetup.sh",
+        "src": "envsetup.sh"
+      },
+      {
+        "dest": "build/target",
+        "src": "target"
+      },
+      {
+        "dest": "build/tools",
+        "src": "tools"
+      }
+    ],
+    "rev": "fb0d971c8ed2c61155169e7edd0adba2bbbd3d4a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06xrw852sgy5k86ihf2jqjbgf53fvz7hkb4z824hsi5dbd1pd1gx",
+    "url": "https://android.googlesource.com/platform/build"
+  },
+  "build/pesto": {
+    "dateTime": 1621047726,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a37afa59ab7aade7251d4902a6800dd7fbc38b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cgw3nmazi87f7qam00szqzy37laz7lv5w9l5zagniv5z0kjl10j",
+    "url": "https://android.googlesource.com/platform/build/pesto"
+  },
+  "build/soong": {
+    "dateTime": 1642032097,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "linkfiles": [
+      {
+        "dest": "Android.bp",
+        "src": "root.bp"
+      },
+      {
+        "dest": "bootstrap.bash",
+        "src": "bootstrap.bash"
+      }
+    ],
+    "rev": "c1337a0d7ba8bdd642c4b44ce87d78929510a70a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pvywv5bhp2mmrfrai1w5nnj75dbyr81s3aa772r9z76x2ydgcqy",
+    "url": "https://android.googlesource.com/platform/build/soong"
+  },
+  "compatibility/cdd": {
+    "dateTime": 1621047729,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ce4adf58de6d6aedb58f246b5d6914f910e91bf7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04l9jdf0i7pf4lq3dxrik4gg3k00v2r3dr9mp6bznf6mm37cvzh9",
+    "url": "https://android.googlesource.com/platform/compatibility/cdd"
+  },
+  "cts": {
+    "dateTime": 1644645748,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d272fc14f4aaf59cdc3dc041ab8fb6a81532d249",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06b1aii0zab93ynrs53vvw4amqa2jlv4g3mckq1imqr3rpj3zpwl",
+    "url": "https://android.googlesource.com/platform/cts"
+  },
+  "dalvik": {
+    "dateTime": 1617930097,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0d796b1468b775e5b58e5536225087957be83f6f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18iw5p98mm7wnfjd0yhnb1fcrnjwrigp1apbz2lyizlm95hkgz2v",
+    "url": "https://android.googlesource.com/platform/dalvik"
+  },
+  "developers/build": {
+    "dateTime": 1613865703,
+    "groups": [
+      "developers",
+      "pdk"
+    ],
+    "rev": "d44ff7fd73b4fe736aa1b6488e45f51918e134ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pvgglif7iy8n6sx8xkxw7xf6gcv60lgfh4kbd4k1ry75rb1hfy3",
+    "url": "https://android.googlesource.com/platform/developers/build"
+  },
+  "developers/demos": {
+    "dateTime": 1496909782,
+    "groups": [
+      "developers"
+    ],
+    "rev": "96e109bb0e2da02139fd46f40f6f833d255d4de8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ciqaaj6jkykb6lkksqfka0077fhz1md6qiw5m337llyyiz29ywc",
+    "url": "https://android.googlesource.com/platform/developers/demos"
+  },
+  "developers/samples/android": {
+    "dateTime": 1621047731,
+    "groups": [
+      "developers"
+    ],
+    "rev": "77cd5e0001fda2d0a5cc08d977fe4fc908952d45",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1npnk3yyvchp4lh38aa7b31kly968h4j9af3x0ad894qigdmbk2g",
+    "url": "https://android.googlesource.com/platform/developers/samples/android"
+  },
+  "development": {
+    "dateTime": 1641945656,
+    "groups": [
+      "developers",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "740fda68eb56f88877cf05d0661f532fe8f8d364",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z6wkslcpw23g4dlm8glwwdpg6all0pr4wzdyr688gwsn8cy1592",
+    "url": "https://android.googlesource.com/platform/development"
+  },
+  "device/amlogic/yukawa": {
+    "dateTime": 1636322442,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "b88251d87e208ea4af89099038dc94f0953700bc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qk861pyigxp903dckyzls5lw8cz5vp4pzx0l0y1g5bvag84i65l",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa"
+  },
+  "device/amlogic/yukawa-kernel": {
+    "dateTime": 1617152484,
+    "groups": [
+      "device",
+      "pdk",
+      "yukawa"
+    ],
+    "rev": "b43593e4c7b007dd9a2b17eed58ed230ea232b6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hfm6i7s4jrhfkxggkdvi58bwkl0gs0zyhn0p2p4gkg4vn1xhzyi",
+    "url": "https://android.googlesource.com/device/amlogic/yukawa-kernel"
+  },
+  "device/common": {
+    "dateTime": 1630450866,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs"
+    ],
+    "rev": "ec79094f557486933db6ebbf840648e64fdd30b2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l39hk80ai2nsxjcbqg9kgf4xyb5s05kjijvswg2w055j0cmxsi9",
+    "url": "https://android.googlesource.com/device/common"
+  },
+  "device/generic/arm64": {
+    "dateTime": 1588703768,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b04a364b9fba5c1f28faf67eb553f175cf6e213",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l66va61ybzf224l9q2gq60i132ikb75k58h1za1faq18m8hwvyx",
+    "url": "https://android.googlesource.com/device/generic/arm64"
+  },
+  "device/generic/armv7-a-neon": {
+    "dateTime": 1615075279,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0de759cd4385fc008f641d8b0d84ab067f62656",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1986xyq0p2cqf4bgw3xf21qjszbidll8iwz2snzvffapybhr1213",
+    "url": "https://android.googlesource.com/device/generic/armv7-a-neon"
+  },
+  "device/generic/art": {
+    "dateTime": 1613865708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "74b75a59ab88c486507f5a6727187c826fe855ae",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ijzwbsqb7xhzlj1bc84mp6hx782q30cvdsk4z6m36yibwlmkd97",
+    "url": "https://android.googlesource.com/device/generic/art"
+  },
+  "device/generic/car": {
+    "dateTime": 1639188046,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1fe1c556e60e03755485485d6d6e94f81fb24c60",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11k274qmdw1n585z0ras57zwavzk2mdw19sg1q1xsj5plhn01psn",
+    "url": "https://android.googlesource.com/device/generic/car"
+  },
+  "device/generic/common": {
+    "dateTime": 1639188047,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f0b6ee279f9804d787a0dfc4ab57c4c955b5030",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1kv3h6c7bpxvlvjmxz19av9zsign6h690ab8h7sprwpwh8ra70zi",
+    "url": "https://android.googlesource.com/device/generic/common"
+  },
+  "device/generic/goldfish": {
+    "dateTime": 1637884862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b6d17faeabec179ac500708d1028e607909f0dc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "163rys1cm6rv390ix5qda0yj0n75gzzs4yiasfrbms27fsk4pamh",
+    "url": "https://android.googlesource.com/device/generic/goldfish"
+  },
+  "device/generic/goldfish-opengl": {
+    "dateTime": 1634252492,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a7b6e530150d1061573096f62f34d7a71c2918e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fb0p8cwr6zlz6vwvvd59hvawqsaqq9niy3c9l3rr0ff351djdxf",
+    "url": "https://android.googlesource.com/device/generic/goldfish-opengl"
+  },
+  "device/generic/mini-emulator-arm64": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6119f04bd2b445b779384b59ee6cfb3700a24b47",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-arm64"
+  },
+  "device/generic/mini-emulator-armv7-a-neon": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4951bcb5ade08f556e8c60c3ed558afd915181b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-armv7-a-neon"
+  },
+  "device/generic/mini-emulator-x86": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81d1932a1b592e75ae016b703acaa96844e85cee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86"
+  },
+  "device/generic/mini-emulator-x86_64": {
+    "dateTime": 1599966333,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "728c7cba358683fcda5950cfeb895656ceee38b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00ryrqgccb14b9plwp5xz969crisrjxij3izp26b3v9n01r5r24w",
+    "url": "https://android.googlesource.com/device/generic/mini-emulator-x86_64"
+  },
+  "device/generic/opengl-transport": {
+    "dateTime": 1613440905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd297c29f99c9a60e64553ad79b7c494772e58aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j6amjg99zbjsdg3xzgls29i0awz5rxdq8wklvkvrymhczk9ibr8",
+    "url": "https://android.googlesource.com/device/generic/opengl-transport"
+  },
+  "device/generic/qemu": {
+    "dateTime": 1599966332,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "02718c5980f2307321c458731b5c8fbfc03f34c6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/generic/qemu"
+  },
+  "device/generic/trusty": {
+    "dateTime": 1621047742,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dab117b1de3903c56d8e54842bd9906fa83ae039",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hj6w5lsdahw94dh8zgj2a6zs1vidcxdyi0wsxm7zwsvl1pwmrmr",
+    "url": "https://android.googlesource.com/device/generic/trusty"
+  },
+  "device/generic/uml": {
+    "dateTime": 1613865715,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "16c75d9d5dec48ed718fe7d55a3b12b7c0988569",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18ninwq7gwgxxkrf5pgqfd05n8wjfnl9wc2wmwrs9r4kzgawmhgs",
+    "url": "https://android.googlesource.com/device/generic/uml"
+  },
+  "device/generic/vulkan-cereal": {
+    "dateTime": 1639008078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76473a0e889538a68a1bb520be4f21cc13cd34bd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lx8pz8pcm26j2smb4ydg58wgfknjia9swz31p3dmak6h1q3j922",
+    "url": "https://android.googlesource.com/device/generic/vulkan-cereal"
+  },
+  "device/generic/x86": {
+    "dateTime": 1588705083,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3a5160c42742f335739222b0d399ffbaf5c3bde",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1msvricg8asj7vhkpfx4vd3jykdg3xqs0yhrvhj7m48lhsandfdz",
+    "url": "https://android.googlesource.com/device/generic/x86"
+  },
+  "device/generic/x86_64": {
+    "dateTime": 1588704382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b22474fb2f0d2750f43a10792409878dbd96fb83",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1w7b33sap7ym1y23435n3cjsbvl8ws49m46lk8h1kgy8apg08mkw",
+    "url": "https://android.googlesource.com/device/generic/x86_64"
+  },
+  "device/google/atv": {
+    "dateTime": 1641765684,
+    "groups": [
+      "broadcom_pdk",
+      "device",
+      "generic_fs",
+      "pdk"
+    ],
+    "rev": "16c26756bad8e65284f9f15b2e181c0e1eb0184f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1glsmdxc5a6hr1dl1x46dkxblrnsy1dzx9gwjd01sjiiikl9zi1m",
+    "url": "https://android.googlesource.com/device/google/atv"
+  },
+  "device/google/barbet": {
+    "dateTime": 1641945670,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "791679e8c75077b1acbb64d9c981bb02d86ade57",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19qrx0il7yk9mdcxpqd2h8s570dwq3ssw4vmrglgd7207mfxmkbd",
+    "url": "https://android.googlesource.com/device/google/barbet"
+  },
+  "device/google/barbet-kernel": {
+    "dateTime": 1642552796,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "074ae0b562f254560b4753a8859698ebdb6ca5a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05zrgqwadms899hm9rsq2mj5xa6736v0016mkxlfjnxdp3bj9pqv",
+    "url": "https://android.googlesource.com/device/google/barbet-kernel"
+  },
+  "device/google/barbet-sepolicy": {
+    "dateTime": 1626311159,
+    "groups": [
+      "barbet",
+      "device"
+    ],
+    "rev": "6f3c852f6849b2f5434e870be9056bd34a015f97",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lwjsrfcvdzj8lqkjy55y58bqmzirfg25zb19nhrp0bfnph3wlln",
+    "url": "https://android.googlesource.com/device/google/barbet-sepolicy"
+  },
+  "device/google/bonito": {
+    "dateTime": 1641945674,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "0bb6072fb5cb2668d3adc1c254567d9ca95185f9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "007dskcls76icdflzpvvj995p6bhmjfzw5cw81j4rqcn13ap52dq",
+    "url": "https://android.googlesource.com/device/google/bonito"
+  },
+  "device/google/bonito-kernel": {
+    "dateTime": 1642212074,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "f050775d922403632628a3b73f2197a3a7d7dea0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03rw9md6zwz5n315gyp2yb5a39hw7ycl1yf35pd1m2xps0ngylfv",
+    "url": "https://android.googlesource.com/device/google/bonito-kernel"
+  },
+  "device/google/bonito-sepolicy": {
+    "dateTime": 1637280083,
+    "groups": [
+      "bonito",
+      "device"
+    ],
+    "rev": "38a65e70530d0a050815273c522c79d2edbf9ded",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16m9crk2f4gazqjg4dwjn8ys99s3mcsp92ikfx5hyxd4zfcmb1r2",
+    "url": "https://android.googlesource.com/device/google/bonito-sepolicy"
+  },
+  "device/google/bramble": {
+    "dateTime": 1639612895,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "ccb084f3970ff6870c19949d1bb2c08b445d2075",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0dq4cy51r5my7j6zn6pj844rysc9psigflx8qwgnhwwvlp1gv9gg",
+    "url": "https://android.googlesource.com/device/google/bramble"
+  },
+  "device/google/bramble-sepolicy": {
+    "dateTime": 1621047749,
+    "groups": [
+      "bramble",
+      "device"
+    ],
+    "rev": "7685476a7a36f90ad73b9c7bf19f75b7b85cec27",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05f5cn22jkv4vjcdghy8j6g8g33yayrp4qk0bh289xri41l56yy2",
+    "url": "https://android.googlesource.com/device/google/bramble-sepolicy"
+  },
+  "device/google/contexthub": {
+    "dateTime": 1631998880,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "9b2c99922dec9f03c8283e1657667e29fe13fdfd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0b8a5fr7kdk156pwxahv7djm2m4l0bqhvsibf1ymlsan2h7z2kc8",
+    "url": "https://android.googlesource.com/device/google/contexthub"
+  },
+  "device/google/coral": {
+    "dateTime": 1641945677,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "fca00c2e62eba2d82ea15949932d7367a4f47a2f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10jbh8ad2ich65b2bp72v1n95awc71kmrhbf5j9i30aja6zlzyc5",
+    "url": "https://android.googlesource.com/device/google/coral"
+  },
+  "device/google/coral-kernel": {
+    "dateTime": 1643332816,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "59bc7d5b4dea751eac4ada83542cb44ab168e9d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10kb2fq5452wh40zjmxgd1bd0s96qrpd0cc8dimx4ra6rhy0n6vc",
+    "url": "https://android.googlesource.com/device/google/coral-kernel"
+  },
+  "device/google/coral-sepolicy": {
+    "dateTime": 1637280086,
+    "groups": [
+      "coral",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "1e90588953884c7bed9bb05a1f6a75366bf1921a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fllk0x7y2p97ka3ppvs1l9dkyc9y67qpb2rc2dy98mdn8md2ad2",
+    "url": "https://android.googlesource.com/device/google/coral-sepolicy"
+  },
+  "device/google/crosshatch": {
+    "dateTime": 1640304077,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "a5c727ade7aba1c87fe5fbcaf56f56207a05230b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0awadvz8zw7354capnc6psrbrc79xhyfvpi45wzy7zkrz8fmgq19",
+    "url": "https://android.googlesource.com/device/google/crosshatch"
+  },
+  "device/google/crosshatch-kernel": {
+    "dateTime": 1628305341,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "4558f84897de6432a8a6f558c9360c1b43d3ec4d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0y2984wgi8277hkalin5spnhkljdx9qx2s6pppxm0aalcxk34shj",
+    "url": "https://android.googlesource.com/device/google/crosshatch-kernel"
+  },
+  "device/google/crosshatch-sepolicy": {
+    "dateTime": 1637280095,
+    "groups": [
+      "crosshatch",
+      "device",
+      "generic_fs"
+    ],
+    "rev": "4c96160f0c826e51330d7b2f8bc0107a2761e07d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09laq8ckzgw28gv2hmy7f695z1zb5n8dfxigyqz6z3jmi75zyyji",
+    "url": "https://android.googlesource.com/device/google/crosshatch-sepolicy"
+  },
+  "device/google/cuttlefish": {
+    "dateTime": 1641945687,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "64e9eabda6fff25f9a869e741912c7fba52ae15c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0897jxvfbpb7kc7yqdp6nszrfbv1aqbv1nncavvipf610qk7kkxw",
+    "url": "https://android.googlesource.com/device/google/cuttlefish"
+  },
+  "device/google/cuttlefish_prebuilts": {
+    "dateTime": 1640131302,
+    "groups": [
+      "device",
+      "pdk"
+    ],
+    "rev": "e46e0fda78ef156094f019c1806d6b75a9c9a827",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sa42f1n396h12qk7sbppcay6k17rvr7wbyha7cflb3b21z25w8y",
+    "url": "https://android.googlesource.com/device/google/cuttlefish_prebuilts"
+  },
+  "device/google/fuchsia": {
+    "dateTime": 1613865735,
+    "groups": [
+      "device"
+    ],
+    "rev": "d9b0c8c280994a2a0d3fb64c501e37e01d5f164c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "131k68cyq4yl559hjy9qxll6smzavph9c2l39q5wwqxlb8w96gzp",
+    "url": "https://android.googlesource.com/device/google/fuchsia"
+  },
+  "device/google/gs-common": {
+    "dateTime": 1621363244,
+    "groups": [
+      "device",
+      "pdk-gs-arm",
+      "slider"
+    ],
+    "rev": "ee76efdfdaa6e33956866f0db257bd293aebc31f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/device/google/gs-common"
+  },
+  "device/google/gs101": {
+    "dateTime": 1642728541,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "b3c6f3bd692d213026011e7f319251edd6ee469c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pgmhkp9si7823pxq75hpb6jc75jirry7b0ngvrasqj72sbc6ljy",
+    "url": "https://android.googlesource.com/device/google/gs101"
+  },
+  "device/google/gs101-sepolicy": {
+    "dateTime": 1642118528,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "c4998d976580b33baefdcb1fefda8432c22428bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ck5spfrwdx4jv9dac9xn6xsfvb92hxw74rhxblwh3436rvq7qbs",
+    "url": "https://android.googlesource.com/device/google/gs101-sepolicy"
+  },
+  "device/google/raviole": {
+    "dateTime": 1645936589,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "ec56b4a14e1722578ab1153f45b8ee1dd8bd8de3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0s367y49isr8cq6y2cllhs11hmk13ma598w9zs9zd5g5w8m5c9kr",
+    "url": "https://android.googlesource.com/device/google/raviole"
+  },
+  "device/google/raviole-kernel": {
+    "dateTime": 1643332817,
+    "groups": [
+      "device",
+      "slider"
+    ],
+    "rev": "6724e08df4576c008371a49ff05d5cf053d51d21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j5jz7bwszspwdrhpa9d7m27v8a6l84l272mzcdy9lnamfki03zx",
+    "url": "https://android.googlesource.com/device/google/raviole-kernel"
+  },
+  "device/google/redbull": {
+    "dateTime": 1642212081,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "8aa514ea294998f0932fc33f6072bf13cafe0081",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hpa4l3m5lns2dqmv1844sz9linwfgqd2q1l38qv3p8nwbj8g52h",
+    "url": "https://android.googlesource.com/device/google/redbull"
+  },
+  "device/google/redbull-kernel": {
+    "dateTime": 1642552796,
+    "groups": [
+      "bramble",
+      "device",
+      "redfin"
+    ],
+    "rev": "a9343935287d22604c53d9de984fe81f91cc8d91",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04nnh5qrdwpx2alvsf438ihqbppwa7155zffwq16vvbqza7yh9f6",
+    "url": "https://android.googlesource.com/device/google/redbull-kernel"
+  },
+  "device/google/redbull-sepolicy": {
+    "dateTime": 1637280091,
+    "groups": [
+      "device",
+      "redbull"
+    ],
+    "rev": "5778df35d9d4e20db1da336b85e3b30c06c0a8a2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h75hq2nxy5g7sk2fgli04zkhhy0w6s297x6m0c5rr55ah8z9s8d",
+    "url": "https://android.googlesource.com/device/google/redbull-sepolicy"
+  },
+  "device/google/redfin": {
+    "dateTime": 1639612908,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "1c4d9529b933d71ea831de28ebc4d6b93376d209",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1740czypmzqiv20n1x0capch8f8k2n8q8bkqd4m4zhx2g13xzhcc",
+    "url": "https://android.googlesource.com/device/google/redfin"
+  },
+  "device/google/redfin-sepolicy": {
+    "dateTime": 1621047757,
+    "groups": [
+      "device",
+      "redfin"
+    ],
+    "rev": "0b9a8165e48e2b85f0368250f0257d8c1ae9115d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18ng4p4hgm1mcr9j7py85420hsdasv34hqbi3whg3kiynsbflj10",
+    "url": "https://android.googlesource.com/device/google/redfin-sepolicy"
+  },
+  "device/google/sunfish": {
+    "dateTime": 1642212084,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "93624cdc5e145af7aa424508cfe9928b220ae2d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fcb2wgwmj50kd5mb04b2n9gy14492gxhd0sk7z6drr5dzr5pg1f",
+    "url": "https://android.googlesource.com/device/google/sunfish"
+  },
+  "device/google/sunfish-kernel": {
+    "dateTime": 1642212085,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "964cc22be2e983d8a837ad7e784f938f673d10ad",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02f45bzzk6qhds7zqwnwrw08mjaqiiydk1ci0xdmwgbgdplq0v65",
+    "url": "https://android.googlesource.com/device/google/sunfish-kernel"
+  },
+  "device/google/sunfish-sepolicy": {
+    "dateTime": 1633388500,
+    "groups": [
+      "device",
+      "sunfish"
+    ],
+    "rev": "11f0ba5178b45db3ab7fb082b052315b2a366908",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zq45s6952q85g5s9dvs91y7f6h0s5hpma2g6fqfa0m5hydj8bzb",
+    "url": "https://android.googlesource.com/device/google/sunfish-sepolicy"
+  },
+  "device/google/trout": {
+    "dateTime": 1642212091,
+    "groups": [
+      "device",
+      "gull",
+      "pdk",
+      "trout"
+    ],
+    "rev": "cb26193b07e4ef2bf6ee074a477dd295b3f4d5a2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mda6q9fvfmgzq4mksxj75lg7733zjbnwkhqpq9mm6ca6qpk7fiz",
+    "url": "https://android.googlesource.com/device/google/trout"
+  },
+  "device/google/vrservices": {
+    "dateTime": 1613865737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b682108585d5a0c96abbaef95a36b805a2a79f3d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bqfiyv18g1il413rkmyhz4prkmq85ww4sh2d5i0rzpddc9rldjy",
+    "url": "https://android.googlesource.com/device/google/vrservices"
+  },
+  "device/google_car": {
+    "dateTime": 1636232492,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef7bc68830b5cf11dd62ed8b56bf79af4f65a9ee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "170jwa4p72l2vrxfyydv45ppwshs9480f4skaw5m4cb4dhzidwpr",
+    "url": "https://android.googlesource.com/device/google_car"
+  },
+  "device/linaro/dragonboard": {
+    "dateTime": 1624496815,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "57d717d79a7aab3f325eacf150b5d570346b47b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pb3mqvj4r549lgvqv53cd8x3qyx0byj9a87v5gl5q99lsrbjar9",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard"
+  },
+  "device/linaro/dragonboard-kernel": {
+    "dateTime": 1613865740,
+    "groups": [
+      "device",
+      "dragonboard",
+      "pdk"
+    ],
+    "rev": "ab1071c3e5ca439f61d4383f79a912670ce3543c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0prblxspjvp5nsz9ff236ia761539rbnn9wmna8za4k2qg4j26xk",
+    "url": "https://android.googlesource.com/device/linaro/dragonboard-kernel"
+  },
+  "device/linaro/hikey": {
+    "dateTime": 1621047770,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "2ada4127004b5db0b82fdc105801f6e8784ec6f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l5bkan588ig1g44bf1c5pwcd27i6wysh3i7sdfvlabkv6h0g86z",
+    "url": "https://android.googlesource.com/device/linaro/hikey"
+  },
+  "device/linaro/hikey-kernel": {
+    "dateTime": 1613865741,
+    "groups": [
+      "device",
+      "hikey",
+      "pdk"
+    ],
+    "rev": "16bc8c94ab239d5e3d32bddb7f2795c179eecfdc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r994z41qd5fq9vsg0360glrljrivkwa4wsms1amaw503vdxx2nn",
+    "url": "https://android.googlesource.com/device/linaro/hikey-kernel"
+  },
+  "device/linaro/poplar": {
+    "dateTime": 1621047771,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "05ab3e70836ef072dcf5bdafd6403728941bda7c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j921jkjwi0v7mhf6lybdlv2axyzlrhmyfkpdghmfyny9y1za7bz",
+    "url": "https://android.googlesource.com/device/linaro/poplar"
+  },
+  "device/linaro/poplar-kernel": {
+    "dateTime": 1558122724,
+    "groups": [
+      "device",
+      "pdk",
+      "poplar"
+    ],
+    "rev": "b557432b79572a33948610a82cb3321fe175c283",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0danmswzl4r3skm19gg0868p36fxlhd5vj793v4i5allqkqgnxin",
+    "url": "https://android.googlesource.com/device/linaro/poplar-kernel"
+  },
+  "device/mediatek/wembley-sepolicy": {
+    "dateTime": 1624639763,
+    "groups": [
+      "device"
+    ],
+    "rev": "bd1f94787d8d21e764585f51502dffc3b17cb95a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "184isr5327zlh5fjaqzcyanldbjxr7lp934141r80c2pydgfx765",
+    "url": "https://android.googlesource.com/device/mediatek/wembley-sepolicy"
+  },
+  "device/sample": {
+    "dateTime": 1621047780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41f6b1a4619dda186fb56a80b175da88889dd31c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "14iyki70hlnb95i416izsw29hiyfpj1dnfb2pxnrr82qy3xk6dr7",
+    "url": "https://android.googlesource.com/device/sample"
+  },
+  "device/ti/beagle_x15": {
+    "dateTime": 1617152532,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "5180fd73bf80ea3d732569c37dac10d8dd6be61f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vbknk4k3dx9gbmhnhgvaiinfmhk8s0f3j5hzihbbdljqp0j65mj",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15"
+  },
+  "device/ti/beagle_x15-kernel": {
+    "dateTime": 1554368860,
+    "groups": [
+      "beagle_x15",
+      "device",
+      "pdk"
+    ],
+    "rev": "56f98966a105e1a53783d3aa326fb96722aaad9e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ahsr4x06x982y975jizgy0k3jix70rd1ypzgg3v3k24wpifrnn3",
+    "url": "https://android.googlesource.com/device/ti/beagle-x15-kernel"
+  },
+  "external/ComputeLibrary": {
+    "dateTime": 1614823343,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "aa2e82c065b3f1c41881130aa7a832f4484654f0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k1ian6l5wkr2lgbn061rqggrv2k37z8x56jw2k005ga020qb71k",
+    "url": "https://android.googlesource.com/platform/external/ComputeLibrary"
+  },
+  "external/FP16": {
+    "dateTime": 1613786607,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6530ec1e33d2e3e0d5453badc078a9022f3d1c01",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13lwr9v1rhr35mlvhzvwhwx9zcsry9nmin57w8wy8f3jm3m65lsd",
+    "url": "https://android.googlesource.com/platform/external/FP16"
+  },
+  "external/FXdiv": {
+    "dateTime": 1613865798,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "300a361050850525e21434b86bbb0c217a44fdf6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1804qzjg3vn7crqfzb8qv4f8sz5gl09b6h1lsgdr2plz2iga6b6m",
+    "url": "https://android.googlesource.com/platform/external/FXdiv"
+  },
+  "external/ImageMagick": {
+    "dateTime": 1621047850,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04c3ea937c3074c913b6e43c6df1e174738cee3d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06ngnvlj2yd1n5r9d5jg914br23ynp0hjwqlvcp9kyb9wnz8n7ll",
+    "url": "https://android.googlesource.com/platform/external/ImageMagick"
+  },
+  "external/OpenCL-CTS": {
+    "dateTime": 1622077509,
+    "groups": [],
+    "rev": "f8e717e2f07d7212aaf4dd80c98c53fa5b230d99",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vs5jdpd0mxglmpcs0yjf778ink7mhkliahd7py6smw8mlram7kx",
+    "url": "https://android.googlesource.com/platform/external/OpenCL-CTS"
+  },
+  "external/OpenCSD": {
+    "dateTime": 1613865885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63bea741ba4717857e2b66146492b4431b7b2b81",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b3sn1yxyjl7ghzvgq2fk50q1q52s5wbwg7lgdd37kn0dfj8f7pw",
+    "url": "https://android.googlesource.com/platform/external/OpenCSD"
+  },
+  "external/Reactive-Extensions/RxCpp": {
+    "dateTime": 1613613913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f855f63cf6198c6c5960ebdf4ca8bed68e0929a4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ydkh937q0vss0y5zid0zfrhlvk0rib57g2cnylzl2f667svabr0",
+    "url": "https://android.googlesource.com/platform/external/Reactive-Extensions/RxCpp"
+  },
+  "external/TestParameterInjector": {
+    "dateTime": 1630969648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e40f0285454e0ce4b8a801be7ebc3d43a8f00e7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d1y4rr7xl4r9bb5v20jpskkgkgidb26vnkg4s1dq8fmsk2maliq",
+    "url": "https://android.googlesource.com/platform/external/TestParameterInjector"
+  },
+  "external/XNNPACK": {
+    "dateTime": 1616634395,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f26bdeccfa684df8d1d864fa8eea7f44d2885e0e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ps0gzf10n84ppcv23m03knwbllqd6x1skvn69sn6ssfiw12slwh",
+    "url": "https://android.googlesource.com/platform/external/XNNPACK"
+  },
+  "external/aac": {
+    "dateTime": 1621047782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2b05e1d57ba856cbcd4e6de3435ee4d1f2a599a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bg8wabf6snkr7fy3izis441jhqhag1gngi53dlzfk7g7ljiz3if",
+    "url": "https://android.googlesource.com/platform/external/aac"
+  },
+  "external/abseil-cpp": {
+    "dateTime": 1613531642,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e94aba65d5fdd3782e757dc43b1eae3d76648256",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "090a9pkyc3pxqz1pa42kmgqzqn3cs80f4arabm9sffnkxgds1254",
+    "url": "https://android.googlesource.com/platform/external/abseil-cpp"
+  },
+  "external/android-clat": {
+    "dateTime": 1622768575,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f10dac1d320e44c210bb3592dc96705414ce93b8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08bddsbl7za78ac6drf63pmpimyqcjkqp3xkjacqqppa16gk15f0",
+    "url": "https://android.googlesource.com/platform/external/android-clat"
+  },
+  "external/android-nn-driver": {
+    "dateTime": 1621652558,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "1ebec9ff1f72d4a4cd5150b50d8c0e7d5600d0a6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "060pv319qq0wdmy6xjbllc83mx5xkkz0jaanzbmgwiv2cq2xsc1h",
+    "url": "https://android.googlesource.com/platform/external/android-nn-driver"
+  },
+  "external/androidplot": {
+    "dateTime": 1621047784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b7b75472f3232a9e0d628b367aaaea619c72291",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dxx539y2fbys0v3108mvk6ac875rjz6sw552xa2mhdhj5hywx32",
+    "url": "https://android.googlesource.com/platform/external/androidplot"
+  },
+  "external/angle": {
+    "dateTime": 1631746982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "265d0e5e57bcdab2d6a0b7977a7492a85142d06f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sgr6i1qw61gi1brgqpxrcnnlp8ibq9ar8lzm577xxrjrivp3j21",
+    "url": "https://android.googlesource.com/platform/external/angle"
+  },
+  "external/ant-glob": {
+    "dateTime": 1613613773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d2901f52f975bbf848074eea518ff41e7be98e1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1kv13x3rrjv04fyipfjgdmvbj9c22wb4ws8xikp2byvqss5qfyfj",
+    "url": "https://android.googlesource.com/platform/external/ant-glob"
+  },
+  "external/antlr": {
+    "dateTime": 1613531645,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "85fcdaf6a76caaa4567a483e4874801270d59dc5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09m5na2mm1qbbffzvmyvkvvp48wcfyd2m90asg07adaf94pw7xkb",
+    "url": "https://android.googlesource.com/platform/external/antlr"
+  },
+  "external/apache-commons-bcel": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04277c08ba0e6724be73e049fac79ae7038aa5da",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wg1k32wz232b3d0iz8n0krpclz21l8jmmpd08ybgx410ga0nlwb",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-bcel"
+  },
+  "external/apache-commons-compress": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8208a598577cae6dc3eb7179964ada6e5023f9cb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mrr0ypp23pljll9i0xawar6h4snw52k10xnggmsrj638xi5bmms",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-compress"
+  },
+  "external/apache-commons-math": {
+    "dateTime": 1613531646,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d988a27249db24532edb4730887a214695840c11",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17f2wbjgrpyjbcxxmwyfyxfbr7ci4z14ry1vp7dac0hlzn57rpln",
+    "url": "https://android.googlesource.com/platform/external/apache-commons-math"
+  },
+  "external/apache-harmony": {
+    "dateTime": 1622077381,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "542986ebd3585ad0f48ce880f735955f7d41c353",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13j3zz0wjvyyy8i4n56039n96yrla6iqzng13fi02fia2wwv5vjb",
+    "url": "https://android.googlesource.com/platform/external/apache-harmony"
+  },
+  "external/apache-http": {
+    "dateTime": 1622934146,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "084077f8add55f7d1b320fd98123bf8a9be29789",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "180wkbj8pj021w6wizcjlnjl8giw3bs998jrxxpyrkpnjbf7nw2a",
+    "url": "https://android.googlesource.com/platform/external/apache-http"
+  },
+  "external/apache-xml": {
+    "dateTime": 1614909723,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4742f9255fd2b6388a8e65572f8ce454fb9071fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07p95202kf49p5wpg5fq9nc99hcjcphac903sbm8wlsvcvppw6hx",
+    "url": "https://android.googlesource.com/platform/external/apache-xml"
+  },
+  "external/arm-neon-tests": {
+    "dateTime": 1613531647,
+    "groups": [
+      "vendor"
+    ],
+    "rev": "e2bc156ddcea1978ce64f0e1c38dfc6923a0f026",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05q3rb390d3zdmva3br4r2njy8hwvnn3ny796dbbsy8fwyq6ijzg",
+    "url": "https://android.googlesource.com/platform/external/arm-neon-tests"
+  },
+  "external/arm-optimized-routines": {
+    "dateTime": 1621047790,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6eb72d47ab201d79808856f3e68119a43401a6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ag1zvd22685wxp2yk82vkwc246y2n1csqqjspx6zsbixgjrap5x",
+    "url": "https://android.googlesource.com/platform/external/arm-optimized-routines"
+  },
+  "external/arm-trusted-firmware": {
+    "dateTime": 1613531648,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccf7a910ce94210b438fec6ff0a8c46e4c35c614",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rdw9ffppv0lqb2gy6pljp9irrckg389afkb9m90nlx84cw4kg4j",
+    "url": "https://android.googlesource.com/platform/external/arm-trusted-firmware"
+  },
+  "external/armnn": {
+    "dateTime": 1616972522,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "4f943fe0a53fd9ad3f4dad65d541dfe91e522c19",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s30csg50az4hgmc0idc8ifnckw4rrjmhxlc3pl19kqywv1ng9m1",
+    "url": "https://android.googlesource.com/platform/external/armnn"
+  },
+  "external/auto": {
+    "dateTime": 1613865762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df28a77194f0ecb079ca7a95054e6ee1a9063fce",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02zs1cf9553f3wamv53sfxpphh2ss7l6lvww39f970zdpkkr1k85",
+    "url": "https://android.googlesource.com/platform/external/auto"
+  },
+  "external/autotest": {
+    "dateTime": 1613865762,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "695a4fd393e571b808fa719f623cfd96bae1c618",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wnd234ci6hwfflsdf248jvmwp8dd08hcka8nll3gh0wqmy9bizf",
+    "url": "https://android.googlesource.com/platform/external/autotest"
+  },
+  "external/avb": {
+    "dateTime": 1625706308,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b93c4fda2e511044499463f019ac3c48433ba3c4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s35d3zns4w00k7x2x2pvc4b2y4c8kd46rmi7x860kszkl02kvwx",
+    "url": "https://android.googlesource.com/platform/external/avb"
+  },
+  "external/bazelbuild-rules_android": {
+    "dateTime": 1616461328,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "286e717934d09c364bceb7c8589fadf91f957538",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mg4iyzaq22b9n07146vmq273vrk2f0hlyj7jm71s6vhmlqzvl3z",
+    "url": "https://android.googlesource.com/platform/external/bazelbuild-rules_android"
+  },
+  "external/bc": {
+    "dateTime": 1621047794,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16a2495baebe466e05306e829ae8d286eee894f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ijih5ka54195h55c019z9nq5hmb71f3smgkssnh0rmjry6h5dld",
+    "url": "https://android.googlesource.com/platform/external/bc"
+  },
+  "external/bcc": {
+    "dateTime": 1613865764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bcce0a3433f2f17784ffea3f7ed6757b45423459",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04kphwmxxnpv72ycsn8skhlc8hkmm01rb8w8x0jl0gcbcw28dbng",
+    "url": "https://android.googlesource.com/platform/external/bcc"
+  },
+  "external/blktrace": {
+    "dateTime": 1613952161,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "431adc1f0853088d8c091eeb4470fb17cba6e7a9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v4znxs40lqzd9k5qw5my887x3ybybdfhhcf7qi3y4v9p8wqk9mw",
+    "url": "https://android.googlesource.com/platform/external/blktrace"
+  },
+  "external/boringssl": {
+    "dateTime": 1621047796,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26614cdd3a55a81fc47ddd00fbb0399aed520c79",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zdzw01rab9qnsj9vn4ygk0x2i3bm2zjidl7fxwxf8z42h027bpx",
+    "url": "https://android.googlesource.com/platform/external/boringssl"
+  },
+  "external/bouncycastle": {
+    "dateTime": 1621047796,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a05f693caf937e28e25eb43fb9edfc004d705e6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0x4sy9406gffkglnkyg1pwpi66p1mhkrhh0p1245f2mbap6zbhx4",
+    "url": "https://android.googlesource.com/platform/external/bouncycastle"
+  },
+  "external/brotli": {
+    "dateTime": 1613865766,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3046ced842f41c7fa4c159c455d80d54a868ad54",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jjahi9515i5fchmym5rc9fk63hh8dmmbacpvf5q8bfb96vc52bg",
+    "url": "https://android.googlesource.com/platform/external/brotli"
+  },
+  "external/bsdiff": {
+    "dateTime": 1621047797,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8364bbb3ab75d44f62bb162675a5932d97cf776a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bvvbndadhzqsl8avqwzxag02i90zmplbzw5xfiprdrbzr3l07im",
+    "url": "https://android.googlesource.com/platform/external/bsdiff"
+  },
+  "external/bzip2": {
+    "dateTime": 1613865767,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a6d6b8ca1589a0fcb4de9b710d56e5a0101989a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vc2m1fz3dhypn771zbhfdf1my1lgm1naz08zyfcm62j6p0263sw",
+    "url": "https://android.googlesource.com/platform/external/bzip2"
+  },
+  "external/caliper": {
+    "dateTime": 1614308718,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20ca522be492a107fc954fffd70d75ea217d3f21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hg2c1b1vqrx3ky9s1s9bdalvpf47sgm2w2m3cwwc66p92x9sk8y",
+    "url": "https://android.googlesource.com/platform/external/caliper"
+  },
+  "external/capstone": {
+    "dateTime": 1613865769,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4fbe15dc97fb87aec1a47b6ad9fc86d63fea14b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "181svy2yh8400xdjbz09rfmkzbzic8i8zjpj3mmicpq3lrbp37lz",
+    "url": "https://android.googlesource.com/platform/external/capstone"
+  },
+  "external/catch2": {
+    "dateTime": 1613531655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "50bdff4f8bf2340c96507cc0466c8cf2a5a3bdaf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "121f7mvnhl9ss3ckwliiqfdkpi0c1siq7vy2ghd46lk17yc7lc7l",
+    "url": "https://android.googlesource.com/platform/external/catch2"
+  },
+  "external/cblas": {
+    "dateTime": 1613613786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a79c670143b8e5b44b4ead3323cfedb97907fff1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vs0bvv7jxg9v853ys0262523qw6f83vlyzkq8dfrsvnsycakzzf",
+    "url": "https://android.googlesource.com/platform/external/cblas"
+  },
+  "external/cbor-java": {
+    "dateTime": 1613531656,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "15cf0a1e4f431a0a2e0a7067365f6b6f6fe059cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18ycp109z76isyfi7pac2nd9idi23wpywkbndp9ki1h69mwr2zmm",
+    "url": "https://android.googlesource.com/platform/external/cbor-java"
+  },
+  "external/chromium-trace": {
+    "dateTime": 1621047801,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7087c32d84af1d9b43b689610d303a66d3dc8ada",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0alb6ykda1vi6n2g1cw3b3p871c9bpz4xgi163p7kz39hpwv4h5p",
+    "url": "https://android.googlesource.com/platform/external/chromium-trace"
+  },
+  "external/chromium-webview": {
+    "dateTime": 1642212129,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0da4e2114df5e74ee8a39c40a64e1d704cad912",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0dficsikbljkjnbfyq6p2hl52mb79wjzw01v8kyl7kldqjff7k5g",
+    "url": "https://android.googlesource.com/platform/external/chromium-webview"
+  },
+  "external/clang": {
+    "dateTime": 1613865771,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11044f7f3c2606f90c436d19a732fdaa2cdab214",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06jjzh7xg63a852m61x1dy5mk32g505srm9qax981y1fiqy4pr9b",
+    "url": "https://android.googlesource.com/platform/external/clang"
+  },
+  "external/cldr": {
+    "dateTime": 1636768923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "901df4c5ede73f5a4b9bbab800628fed87ac2066",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qgy41wyv39yx3ia6ysnwnc919xkxk0dh3wpzmzq962sm6k3b04g",
+    "url": "https://android.googlesource.com/platform/external/cldr"
+  },
+  "external/cn-cbor": {
+    "dateTime": 1613613788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8c4abe4e6201669973fad983c4023d271f24117c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gh910wa3zrdk8jaghbbrwhr5cwxj2jiji98b00i79vdndi9fkp4",
+    "url": "https://android.googlesource.com/platform/external/cn-cbor"
+  },
+  "external/compiler-rt": {
+    "dateTime": 1613865773,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb42c48f02e7ef0c8f99cb00534db785136cc7df",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sxxwngwcb9z6x3f9i7fw8j08h27wvzhdnmwxbrx2kz2zphm4gwn",
+    "url": "https://android.googlesource.com/platform/external/compiler-rt"
+  },
+  "external/connectedappssdk": {
+    "dateTime": 1634346131,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c836e53729e89182feeb0ad22c78b4aee116b77",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11qr5prfh22has9ay82flxs6wbhi7dviq4ac3hdvv1bbc64qimxc",
+    "url": "https://android.googlesource.com/platform/external/connectedappssdk"
+  },
+  "external/conscrypt": {
+    "dateTime": 1639440141,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5556862681ebe3cebac4cccc5b462552bb2ed5a0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0yzfqjv9kir19p3bkcq9gdwcplj028n7spxaippxhlrqzd7xba63",
+    "url": "https://android.googlesource.com/platform/external/conscrypt"
+  },
+  "external/cpu_features": {
+    "dateTime": 1614996141,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9078b25066d2fb9790ef6cf65dae77e1a3ec9351",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "078fa0lqhy0v8nhb81yr4r80lr6d24r0xayxwzvyz9f78phvypi5",
+    "url": "https://android.googlesource.com/platform/external/cpu_features"
+  },
+  "external/cpuinfo": {
+    "dateTime": 1613865775,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ea28f144a11c510f8a92eb5d5bb84d6241b6023f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0y7api7gknnfphvwz8fc751yzwj5vzzgm7zqdbrcf0r3m09my4yg",
+    "url": "https://android.googlesource.com/platform/external/cpuinfo"
+  },
+  "external/crcalc": {
+    "dateTime": 1613531661,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "906cdf950c73cb7cb1e12f9d55f91a92f3361bac",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nldnvwr197rpzigkxrdb1342vcnwh1mdazr831ynscqga55f7sc",
+    "url": "https://android.googlesource.com/platform/external/crcalc"
+  },
+  "external/cros/system_api": {
+    "dateTime": 1588165008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "521aabe8a3696d76f7b60bdb6077f9f8927eeff1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jr6jiz7qjgwfm8p15lq6qh18iy25qbyr1accj1mxy2xcp3lcvnl",
+    "url": "https://android.googlesource.com/platform/external/cros/system_api"
+  },
+  "external/crosvm": {
+    "dateTime": 1636160545,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61f34a3e9aced858166005992afd0893bf39f570",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19ilymnxcjfrgq5bgnlkcl4hn4wdky5rq0r377q344wd431i6ml9",
+    "url": "https://android.googlesource.com/platform/external/crosvm"
+  },
+  "external/curl": {
+    "dateTime": 1613865777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "104ec4426fff83ff8a4daf543f1d1fd2848a2862",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wfyfdkw212wlqdmxwwm985hdm6wwcgx3lagbl373h9f9d6j7y28",
+    "url": "https://android.googlesource.com/platform/external/curl"
+  },
+  "external/dagger2": {
+    "dateTime": 1621047808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "716049ac0972f3a765829b3c892a87b8c1f8ff91",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0aa3q04an07rmyf3fjjs797fpm49mq4fi1y0arqdk3jcn44ha8al",
+    "url": "https://android.googlesource.com/platform/external/dagger2"
+  },
+  "external/deqp": {
+    "dateTime": 1635375761,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "5e36d29c997d071d142633f0ff31413ab16dcd25",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16wwzkh068n4n6335r65cx3l24aapq05j9pbj3svpndgkzd28n6q",
+    "url": "https://android.googlesource.com/platform/external/deqp"
+  },
+  "external/deqp-deps/SPIRV-Headers": {
+    "dateTime": 1632870142,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "816c6f16faccf565e05c16697cf592b88507b94e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "197mx23883n4i2grsaaf7d09cbp70yajzd4ylwr186lg1q94j649",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Headers"
+  },
+  "external/deqp-deps/SPIRV-Tools": {
+    "dateTime": 1632870142,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c3f917f34b5a3a7a1924ab8b2fa9116bc7d7e4f6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n9i57smxsy1hrqa7i0as6ky0ggcyp3y104hgmxmgzmxsch6a4n4",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/SPIRV-Tools"
+  },
+  "external/deqp-deps/amber": {
+    "dateTime": 1616029365,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0284af9a3b09a6a769b076421521c69015caad90",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "012vrgcf5afz99avy1107z40ly4dbnvaldzmm60zm074ys2gpczv",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/amber"
+  },
+  "external/deqp-deps/glslang": {
+    "dateTime": 1616029365,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f93098378a66be83712da591c8c1e6498110e940",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0m4pvypx9l7d16pslkf8imqm3k21jap1vcb05pm6213rwrgl11im",
+    "url": "https://android.googlesource.com/platform/external/deqp-deps/glslang"
+  },
+  "external/desugar": {
+    "dateTime": 1613531665,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2490e4829b5dd5b0e24ad8d730b08182d2098cbf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l24kgg5lm93aawfknf9igbhcag5jlacs0v1h0b2cwk7ffq6igyv",
+    "url": "https://android.googlesource.com/platform/external/desugar"
+  },
+  "external/dexmaker": {
+    "dateTime": 1613865781,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aad7819e7cbd3f37a5ea1bae7246d887aca0465a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c47k9acimibwfm46zkhnwxr9ijjhz300w14dwzkirwk6hacsmy4",
+    "url": "https://android.googlesource.com/platform/external/dexmaker"
+  },
+  "external/dlmalloc": {
+    "dateTime": 1588119024,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec6795bcb56beb64962f39ae703321149b99cc71",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yz7c4y6jppq2gxgc7bnrhis4na6r96w3i9y7rqb32hyh971ym8h",
+    "url": "https://android.googlesource.com/platform/external/dlmalloc"
+  },
+  "external/dng_sdk": {
+    "dateTime": 1613865782,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93b70b5a1997376fe2a4e44308f545603ba73132",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n0kz9ffs327mwd06qj7msmfwrhyiabcvapxsr172az0skr9980p",
+    "url": "https://android.googlesource.com/platform/external/dng_sdk"
+  },
+  "external/dnsmasq": {
+    "dateTime": 1614909745,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1de5d4c49fe7beac12b5a1c06087cd55839b4bc8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06lwhhpprrsv7bz2jysf1wjx50zmck3q7wpmnci28lc2r2b39xv1",
+    "url": "https://android.googlesource.com/platform/external/dnsmasq"
+  },
+  "external/doclava": {
+    "dateTime": 1621047814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fcc4b7b628928776be56878fcc4245f65ad0f616",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1aa1aycv47aavy6j29wkivspdg6fxhrpzkb9fd7mpv7im2z134zi",
+    "url": "https://android.googlesource.com/platform/external/doclava"
+  },
+  "external/dokka": {
+    "dateTime": 1621047814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c753c61f945ea23bd0fd8c7901e64d65597aa57",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n9lbm134yr4gd9lddlc6kykh0f18q4s3jvp3y09xy6r8hbilxx8",
+    "url": "https://android.googlesource.com/platform/external/dokka"
+  },
+  "external/downloader": {
+    "dateTime": 1614650588,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6eaf0152dd81db93b9c1b4133f12b9799fc5c27",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1prbsya7mwnk2f6z7zmg4a62873kk5yfhjrki7dwb8rzwzq9mm5n",
+    "url": "https://android.googlesource.com/platform/external/downloader"
+  },
+  "external/drm_hwcomposer": {
+    "dateTime": 1634166161,
+    "groups": [
+      "drm_hwcomposer",
+      "pdk-fs"
+    ],
+    "rev": "12fb6943f04f528c47f29f0fd0511dfb5fd4f53c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18ma7x3pw5nq6l85whkr3m1nwd6hnjqxiqr3q0mbafi9hp8sfraq",
+    "url": "https://android.googlesource.com/platform/external/drm_hwcomposer"
+  },
+  "external/drrickorang": {
+    "dateTime": 1613865785,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0e40d3a0e1c1fec77bcacda7766e5ba04ad38b5b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c705icrhgcdkxlbz125yn61hglzbnyvmwj6prafs74l3jb9h2sf",
+    "url": "https://android.googlesource.com/platform/external/drrickorang"
+  },
+  "external/dtc": {
+    "dateTime": 1613865785,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ccf3f1d2999ce6005cd4ac92cdeaf8a31427cc1d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x6qsq1d8ay15is649cy900b6n4syl37m8705fk1x5972gm3s833",
+    "url": "https://android.googlesource.com/platform/external/dtc"
+  },
+  "external/dynamic_depth": {
+    "dateTime": 1617238941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "47a1cbbdfee473ca5e0491ead596ba12c3655c81",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11mw0dwirrrirgrap33k8dvngpilf6qdzwsz0phzbpr05900915j",
+    "url": "https://android.googlesource.com/platform/external/dynamic_depth"
+  },
+  "external/e2fsprogs": {
+    "dateTime": 1613865786,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9788feebe2c4be99d5e495e0d939340b414b6485",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00y5a8kkqiqwg8q3mgns7vph072s3jiv7ih6b43qbgha622d9xq5",
+    "url": "https://android.googlesource.com/platform/external/e2fsprogs"
+  },
+  "external/easymock": {
+    "dateTime": 1613952184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ee5c6b5588137f2e1641bcc4d3c9580fb706543",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13x8mwwilrqva7wknhcab80lhmh0j55mgdiha3w5v1crlk7nbgrz",
+    "url": "https://android.googlesource.com/platform/external/easymock"
+  },
+  "external/eigen": {
+    "dateTime": 1617238942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "434f649902d1845d3a9bb051626a8f16f363b2bc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mja982a49hx7mzplq5vb3igzkyv659032hfha4qhg83qc5svpm3",
+    "url": "https://android.googlesource.com/platform/external/eigen"
+  },
+  "external/elfutils": {
+    "dateTime": 1613865788,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "825f362ae0a46a6688e156f11d4db2da3127786e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1znxr9qbz5mgdl35g263c0n2k33siq2qhgdx0kilf566l9c7cjpp",
+    "url": "https://android.googlesource.com/platform/external/elfutils"
+  },
+  "external/emma": {
+    "dateTime": 1613613802,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a004c38a0155f376b5d5c4bf5e6c1f41cd0a1e9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q783p5xwhrw2hgq2lihxdz80n7gyw6pri9l8ryrzgdklxqgpdhy",
+    "url": "https://android.googlesource.com/platform/external/emma"
+  },
+  "external/erofs-utils": {
+    "dateTime": 1621047819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb02fb8d42b371cdda66db95f391bb16f2aec2f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jj89j02d66jzcf53yjvrv7rgbwcmfpbi8839ygab0m5zxjdlshv",
+    "url": "https://android.googlesource.com/platform/external/erofs-utils"
+  },
+  "external/error_prone": {
+    "dateTime": 1613865789,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5911048263ec9aea969ab29788887784ffb78a7e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x5ikif1igni9sh9fcl9ma0k670a8gykvjv8bxl745mhzfnyfwqb",
+    "url": "https://android.googlesource.com/platform/external/error_prone"
+  },
+  "external/escapevelocity": {
+    "dateTime": 1613952187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddff9fa649b2a80e9adc3f7b5e2524389b81c624",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12g3s6l40sncayrl9hvwkixb0diq5gkdf0i3j3llz8yi5i9bh1pp",
+    "url": "https://android.googlesource.com/platform/external/escapevelocity"
+  },
+  "external/ethtool": {
+    "dateTime": 1613613804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16884f5206cc9f217ff777aa64358a734f005ffd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17i4hhqfprqilra51s34l07rin3k32pzw36sb5xazmgr3g926giy",
+    "url": "https://android.googlesource.com/platform/external/ethtool"
+  },
+  "external/exoplayer": {
+    "dateTime": 1631228836,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e71d3e9bda8aad1c0b92f17e8725121a4e1122ce",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r3zdplwd1h8x1phqmkws4ismz92vnmvvw11s3jyjpay80maqgh4",
+    "url": "https://android.googlesource.com/platform/external/exoplayer"
+  },
+  "external/expat": {
+    "dateTime": 1617490956,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c59b852a775784da844581dea47bf4b6b1524b6d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1p1ckravpadk36lb04ahd40f2ivc921wrd21swq7n69c16g4a920",
+    "url": "https://android.googlesource.com/platform/external/expat"
+  },
+  "external/f2fs-tools": {
+    "dateTime": 1633043395,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34e1c3cf48b98a84d76c5048b60e34aa698b82e3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "062r7sgrg626wgg8wvzjimm5gd8pixd3ssm921zmw7ahfzfi9720",
+    "url": "https://android.googlesource.com/platform/external/f2fs-tools"
+  },
+  "external/fastrpc": {
+    "dateTime": 1587748082,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "576a336123e225bbdd1a373cd6b43d7ae3482a05",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mfid59pw4qkv4zdj86g8mm0gsrdqkpc8kcwx6xbq8l42k9br4jl",
+    "url": "https://android.googlesource.com/platform/external/fastrpc"
+  },
+  "external/fdlibm": {
+    "dateTime": 1614909756,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b29914775d117c4599777c0c98c7979de7464e2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cxx79d3l3w7p3b1pzlmnargzw8svaqx3jpl69a816ipq274y5kg",
+    "url": "https://android.googlesource.com/platform/external/fdlibm"
+  },
+  "external/fec": {
+    "dateTime": 1625706396,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "88f00a35b825af5fd0e1be1acd32e09345ad3000",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j0s8xhs6hgzjlybzks1brkjq7xlwlr17xkvay6lkjqb57cdsqxv",
+    "url": "https://android.googlesource.com/platform/external/fec"
+  },
+  "external/fft2d": {
+    "dateTime": 1616972553,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad3439a77c776970b0e3900ae8e336a85a451969",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "061p07mzli7srnhzvnz726j849446yyprlgxc300f5zwjla3cz3j",
+    "url": "https://android.googlesource.com/platform/external/fft2d"
+  },
+  "external/firebase-messaging": {
+    "dateTime": 1624928655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d76c42a4489ef1854a96cf54f94cd321e3ff080",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18c68j3cfc906x8glmlmcsxrbxfqy67dlim116grjmihv491zlsi",
+    "url": "https://android.googlesource.com/platform/external/firebase-messaging"
+  },
+  "external/flac": {
+    "dateTime": 1616814204,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "019b60576819ac5e92ccfb66614eac66eda388c5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bxl0m0kxfzwjk10nbm8i2fnsvn92d7793yv8bpwzqj4k7kcrg5m",
+    "url": "https://android.googlesource.com/platform/external/flac"
+  },
+  "external/flatbuffers": {
+    "dateTime": 1613865794,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2531304575c277495cae4c1dfa4c0bba7a6f6b5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0aqwlh168j42532l0klgx6gsbqw7lhj92l25b8b1380j2qgz23hs",
+    "url": "https://android.googlesource.com/platform/external/flatbuffers"
+  },
+  "external/fmtlib": {
+    "dateTime": 1613865795,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d4f07972a07256b829d49220d17c340b882343e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16x73827rr1sfvxpd4gg4rpx30vqfdp2r2md9ynmbl6lf2qwgqfg",
+    "url": "https://android.googlesource.com/platform/external/fmtlib"
+  },
+  "external/fonttools": {
+    "dateTime": 1617418946,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c11328baa47894287407971c1a62933a6d62ab9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "082gbxzxji2hssl0h25yxvs0caf8cyaisjd6k09s2wcgvnvvc7n7",
+    "url": "https://android.googlesource.com/platform/external/fonttools"
+  },
+  "external/freetype": {
+    "dateTime": 1621047828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86f030984ae203c286958c31f3334ef08cf3928d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1higwvkpvh6wz0ryjbq31v00fqxq14q9xrr3p7ww32q2nvkych80",
+    "url": "https://android.googlesource.com/platform/external/freetype"
+  },
+  "external/fsck_msdos": {
+    "dateTime": 1621047828,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "beade790a5badb4635e4560a5fc054c5cc465fc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08js9q4kzic0i6sj67cdppga0q818277a3wivp7dpaxvz4anc40s",
+    "url": "https://android.googlesource.com/platform/external/fsck_msdos"
+  },
+  "external/fsverity-utils": {
+    "dateTime": 1613865797,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "036ac78086fe598a4e85c2fb1fdf41dd497feca2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v541yjbvlkkddynwnwakrhj77jmawm1niz1nwbr2ish612v07p5",
+    "url": "https://android.googlesource.com/platform/external/fsverity-utils"
+  },
+  "external/gemmlowp": {
+    "dateTime": 1615600981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7224233763ae24f58ba2c14cc873f9d6b6fbe90e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dff6jrd314xnib7jhqwpfc4hyv6ycjgrmb92wwany30drmlnw9l",
+    "url": "https://android.googlesource.com/platform/external/gemmlowp"
+  },
+  "external/geojson-jackson": {
+    "dateTime": 1614736983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f1a107bbf9bc860e69e3672ddac246aef7a8b5c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qrp98sn4q997q5szpz37414hlm3yl6183r504sv14azfwm7ymyf",
+    "url": "https://android.googlesource.com/platform/external/geojson-jackson"
+  },
+  "external/geonames": {
+    "dateTime": 1605020923,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ef8440a65d84585c66467b8d51fcef819fe0f09",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xcdyb82cs40am7x477cavyczh1ijm5zx785fw2in1wkqah4zp0a",
+    "url": "https://android.googlesource.com/platform/external/geonames"
+  },
+  "external/gflags": {
+    "dateTime": 1613865800,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "360c9678b3686cbd6360bbc6ade5bfce521d799d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wyiic485x863sdm6834dsl3b4c40fqpagz529v091kribmmm8gz",
+    "url": "https://android.googlesource.com/platform/external/gflags"
+  },
+  "external/giflib": {
+    "dateTime": 1613613812,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "fb5ea64cffa714072aadacf93f53791155930977",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sibmcf4ld5cda63fyklr7bd0naydy5c39rszg0fp7iiivx3n8il",
+    "url": "https://android.googlesource.com/platform/external/giflib"
+  },
+  "external/glide": {
+    "dateTime": 1613531683,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0bfdd8a1811f422dab39836ce0ba982b13bd30d8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b38i7kvsivigic627hxi04k9sf5iq6ry176drcx9mr6wkbysbvf",
+    "url": "https://android.googlesource.com/platform/external/glide"
+  },
+  "external/golang-protobuf": {
+    "dateTime": 1613952198,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffdf1e98f88ca355c0e183cb9b1b0708568783c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1za35lgd4h3vfqhv0a9kjbi0arrq9k0phpks113mddzlfg7dxnbw",
+    "url": "https://android.googlesource.com/platform/external/golang-protobuf"
+  },
+  "external/google-benchmark": {
+    "dateTime": 1613865802,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "738576eff3e1bbc79af1a206621143be19d06581",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jnb9fbib4gp3w9smw5s1nvz2snbz414yxxa1xb58p5wjp7fqx4w",
+    "url": "https://android.googlesource.com/platform/external/google-benchmark"
+  },
+  "external/google-breakpad": {
+    "dateTime": 1614823373,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "90cc4ac63af74b7b37cfa397ecf7fe44d08977e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13l54qb6a8ba4g80h59mk1xxbdiqa0219h4p78rxzx1j75cx7m6h",
+    "url": "https://android.googlesource.com/platform/external/google-breakpad"
+  },
+  "external/google-fonts/arbutus-slab": {
+    "dateTime": 1613865803,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d087f6afbd5a4947a77f049302e38ddfdb0049db",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18g7n073qp1ii4gx11n6fpsv8si0ima4ldrx7mraca9mdq72w71m",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arbutus-slab"
+  },
+  "external/google-fonts/arvo": {
+    "dateTime": 1613865806,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1ea1b0a4dad5d7479d75bd3a1cc915e2995ceef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "144j3kjdp9gm5qi9x0j571m88vnqs1lwm8672qh9l3m7lxxsy0jl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/arvo"
+  },
+  "external/google-fonts/barlow": {
+    "dateTime": 1613865803,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ed35089cc29efe304b28cdf9c1b6a198b9eb98c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "029n04xijjbwwxmz8lbihwcl9a30bgy9czdzg82ybwylnwq9pfwm",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/barlow"
+  },
+  "external/google-fonts/big-shoulders-text": {
+    "dateTime": 1613865805,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "482c5b584a4e1b05a59a2de569e7d270a9f06733",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jpm0ld79d3g66iwiwmx4dn2gxdlrgwsblynf4zwcgcq7ydi4zb0",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/big-shoulders-text"
+  },
+  "external/google-fonts/carrois-gothic-sc": {
+    "dateTime": 1613613817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39d7801d9d191dbb5058337573209e4bcf9510c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "067xqhgd67ngvkr7frxdy1y774pfpzzkih3jjk7fj24wqnkc6d5j",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/carrois-gothic-sc"
+  },
+  "external/google-fonts/coming-soon": {
+    "dateTime": 1613613817,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "00af3f43e371cad1d205022464f087826a9207c5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wz6aji68kbhg58dbwn0zmjg2ywk6cfdq7j7awg38zl2q26nfmq9",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/coming-soon"
+  },
+  "external/google-fonts/cutive-mono": {
+    "dateTime": 1617238963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac548e79f151c51141098c21a2fdffa4cbcc8ec7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00wfjacl0sqncivpa3za9jmki9wva9q0vf85ads6g2rz4z6nkrff",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/cutive-mono"
+  },
+  "external/google-fonts/dancing-script": {
+    "dateTime": 1617238963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2747f5b03209398a405423f61b66a058eda1260",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hdp4a0gn23n88gzdi65dfqq3pmvw3nadf1p8xnqxan34yv8adyl",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/dancing-script"
+  },
+  "external/google-fonts/fraunces": {
+    "dateTime": 1613865805,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4c1d074a2f148fa5104fbe54893d7c8af4317b50",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gr0x87wrs8qh2ykpggcvxkxc1qmd6hw0xq6hn6p6s8078pw5b6w",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/fraunces"
+  },
+  "external/google-fonts/karla": {
+    "dateTime": 1613865804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e351d7cfd6a1026541418cdc69938af77b06e1a8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c8ny537pvhjfh0b87lfpc0aga4x0mlry203wkacgx2a1h00irhx",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/karla"
+  },
+  "external/google-fonts/lato": {
+    "dateTime": 1613865808,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09eaa1e45de495f133583324148d02fed38404f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hdy27r466jd7ik69257hiazjqsdzv0hbpzkmid6rq1gk2lkijgz",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lato"
+  },
+  "external/google-fonts/lustria": {
+    "dateTime": 1613865804,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8379de64cee1026e762064663cf61a7476a5148",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16i0vknh3z23mr79iilxyf6kqs5kqp198by9cx9rmzcg3phgx03y",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/lustria"
+  },
+  "external/google-fonts/rubik": {
+    "dateTime": 1613865809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08ccfffb059ed470655e8644e5827480a14d703d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10ap1n0s7qs742m3xzxrs91xyirp0280xvg4wz8hmpyip631h7f3",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/rubik"
+  },
+  "external/google-fonts/source-sans-pro": {
+    "dateTime": 1613865809,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d064759795649f3b5c5dfc0ef35b37144abba930",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nmdmb80pf2pzcdn369q5skspmlqv56sn9in0fcfhx14pib64w86",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/source-sans-pro"
+  },
+  "external/google-fonts/zilla-slab": {
+    "dateTime": 1613865810,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5b9fdf9831cdbcfdb2a40c48bc68dc401efcf88e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rm6wp6849wpw32ys5wbrx9836937j1zx310fdyyl07kqgx4vhmh",
+    "url": "https://android.googlesource.com/platform/external/google-fonts/zilla-slab"
+  },
+  "external/google-fruit": {
+    "dateTime": 1621047842,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c758911cecab67d2780de838d46ff8b1b552fb90",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wksa168xyk42yijf2idhpvzp8225ww165px3lc9ff9ph883g0ya",
+    "url": "https://android.googlesource.com/platform/external/google-fruit"
+  },
+  "external/google-java-format": {
+    "dateTime": 1613865811,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "53014b2e85ace8940cd7de19496383ece53b0a33",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0g1i78c3km8lly0rb3b6axma754vxl9s9s48jfa0n2l565h2zk0q",
+    "url": "https://android.googlesource.com/platform/external/google-java-format"
+  },
+  "external/google-styleguide": {
+    "dateTime": 1588028419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b0dae0a9d49cf1fe90c4104951df1f18a88ac49",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1krqv8srgkf85hrj0shwz9j4xs6nx4jbj8fzjsbwjg1f589dd8iy",
+    "url": "https://android.googlesource.com/platform/external/google-styleguide"
+  },
+  "external/googletest": {
+    "dateTime": 1625706431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c803e6f831675715340a0a225401d904cda37e21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hs29iy2v24vl66qqa85sdzvxlw7awjravhy53gjv9vnq2dzpb84",
+    "url": "https://android.googlesource.com/platform/external/googletest"
+  },
+  "external/gptfdisk": {
+    "dateTime": 1613865812,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe85b6e76494ef959306e4a8ee065c388b31159f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "062g4a8s71lwdh2rkqjcdklbxsb551334rd07hhipygjllwhixzy",
+    "url": "https://android.googlesource.com/platform/external/gptfdisk"
+  },
+  "external/grpc-grpc": {
+    "dateTime": 1616720576,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "c414653c770fb12633f403e32da529c6c7ad2629",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b8mdx9x08djdm8fss25r1dc2xbq1hb70zdm782k2rmbwp47axa8",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc"
+  },
+  "external/grpc-grpc-java": {
+    "dateTime": 1613865813,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "69e456917713c829b043e54e24f5a6c2f3961ecb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hwm7wb4zg81cx784piqc316ik0dihbm19iiyn3y22ahhkd3ma4r",
+    "url": "https://android.googlesource.com/platform/external/grpc-grpc-java"
+  },
+  "external/guava": {
+    "dateTime": 1613865814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8e1eb42a077bf64cb06888b5a5594673a4d903d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hdvqppxkyafrpkv9qzs5c7kab57vi4xhqacbqbwfr7dj0plca56",
+    "url": "https://android.googlesource.com/platform/external/guava"
+  },
+  "external/guice": {
+    "dateTime": 1613865814,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6727f95b7425b60734d7addfe7b362353a62216d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f9k7ribhyf0n7p9ff2jqk18qk1gim4vbln1bhiazdlfs3v5laws",
+    "url": "https://android.googlesource.com/platform/external/guice"
+  },
+  "external/gwp_asan": {
+    "dateTime": 1621047846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "feb3aa68761a0af68f7367a710ead3f63d9c6df0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k71w8a36dhr4l5r661rvnmj4bxz49is9md78hndks4jqcnzn036",
+    "url": "https://android.googlesource.com/platform/external/gwp_asan"
+  },
+  "external/hamcrest": {
+    "dateTime": 1613952212,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d819295bbb4e5442f9761f8a6547e7d3ccbe7121",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0i05qdmz9zd904apqxk6kdbffbydgj7k7n9yjvgrlw0m7xbynadj",
+    "url": "https://android.googlesource.com/platform/external/hamcrest"
+  },
+  "external/harfbuzz_ng": {
+    "dateTime": 1613865816,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "91971d3da3eac1e60290623f98b67dec95bb37a3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m7a4ln2v5dxy5dkcfdxyjsvsrsd3hjbxvmhb4gyx6am6lk6lca8",
+    "url": "https://android.googlesource.com/platform/external/harfbuzz_ng"
+  },
+  "external/hyphenation-patterns": {
+    "dateTime": 1588207981,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8554f7958e8c6fc3491682f40065258b34e5b7f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "184jm20gaz36kwskqkhax7n1allfjanax6rz3vqs70rjgsdvv5i4",
+    "url": "https://android.googlesource.com/platform/external/hyphenation-patterns"
+  },
+  "external/icing": {
+    "dateTime": 1630624039,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e9d7889e34175953406f6386702217f340e22652",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s4d26gpqhh1hzjknfxpjf3ch6qls9rvxbkfl0mwwkq6vzcvzss3",
+    "url": "https://android.googlesource.com/platform/external/icing"
+  },
+  "external/icu": {
+    "dateTime": 1641607364,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4c0cf81bb7813b4d6716e6a72ed729824926cd5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0skwlgyyb8a3r1n0a3v508k7bf9i5dc17yvic9a7rk8sy46fzdbz",
+    "url": "https://android.googlesource.com/platform/external/icu"
+  },
+  "external/igt-gpu-tools": {
+    "dateTime": 1617843819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6efcd7b5347a2cb65a95b72e85e0479b94e05f02",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c5cw7jgcfny776y5cqx7jcy8w4sqanx4b0qwrza6zqhgcc2cqhi",
+    "url": "https://android.googlesource.com/platform/external/igt-gpu-tools"
+  },
+  "external/image_io": {
+    "dateTime": 1613865819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b533862c7995b95287a75b12ef5ed62209ea3d5a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0257h57ygzpj2vknj5k8whkznrsmqd2fhzzb9gl3rys9qgljjmvx",
+    "url": "https://android.googlesource.com/platform/external/image_io"
+  },
+  "external/ims": {
+    "dateTime": 1621047851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7db06b958a74f421b27ed211aa2eba9141970f6b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1476c1dbyhsmvak2m5ffrgjxrf8ixigx5fsi5w805kfaifignmin",
+    "url": "https://android.googlesource.com/platform/external/ims"
+  },
+  "external/iperf3": {
+    "dateTime": 1613952217,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bee4961b9ffa007307846667a7e9ecfeb75e6402",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1malr0g6ha2s0qb6qrr4cly161vcj2d4xy5wbnxj43pnhg0k4gqb",
+    "url": "https://android.googlesource.com/platform/external/iperf3"
+  },
+  "external/iproute2": {
+    "dateTime": 1622768643,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d9ca4919acc6ffe5243fb0646dcc4d4e48ef18b5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1527d8lzl7px9b84fxm1742nvz6d4h0r8nwibjh0d18j62xhz1mg",
+    "url": "https://android.googlesource.com/platform/external/iproute2"
+  },
+  "external/ipsec-tools": {
+    "dateTime": 1613613830,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fdf95cfca2e7158b22bc9b43b3dbb4c340c0d2a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qz2058mcb75x22jarlls8ki6zhh9zd422nsn9wdzq29xk4a9cg1",
+    "url": "https://android.googlesource.com/platform/external/ipsec-tools"
+  },
+  "external/iptables": {
+    "dateTime": 1622768644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c674cefb721d1e3840de355173e02d0713991b43",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0d2vfhzixszwl3nwch9f996yx7kafr9rn7fni41hbzrh8nra476y",
+    "url": "https://android.googlesource.com/platform/external/iptables"
+  },
+  "external/iputils": {
+    "dateTime": 1613613831,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4896c2709c2d32e8f08f87e4bff726be1ccae39c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q24bn8swbjsaa19kc6jdk2fw93cbipi6xbdh95w07pdp3v1xazr",
+    "url": "https://android.googlesource.com/platform/external/iputils"
+  },
+  "external/iw": {
+    "dateTime": 1613531703,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5588f219e0de6b83b95cf14f7715d68067543d76",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01k08an490nvpzjyb7f6p8l67gxpkkg9fnc44f1lcc6ygb1rymsb",
+    "url": "https://android.googlesource.com/platform/external/iw"
+  },
+  "external/jackson-annotations": {
+    "dateTime": 1616972584,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2209255579c2a29b22048872db1982c2f55b428a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0apc5cffr02drfhfxri1fqs449i6bsk62a5kb0yfk73maya5wlw2",
+    "url": "https://android.googlesource.com/platform/external/jackson-annotations"
+  },
+  "external/jackson-core": {
+    "dateTime": 1616972585,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9870bc2326b0e2e656a9151f2cfdffb69024535d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c1amlrk7idijwhbhr2xvs822kc8cvfcmz2vxw9y03ylbicwnq42",
+    "url": "https://android.googlesource.com/platform/external/jackson-core"
+  },
+  "external/jackson-databind": {
+    "dateTime": 1616972585,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a3b4357d43cb7901cf594fc9fc2f83793dbeb32a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f4qf4dy0cyjv9cbmsvqawq0xp3r68snv5nidhj00jdnxcixh5zi",
+    "url": "https://android.googlesource.com/platform/external/jackson-databind"
+  },
+  "external/jacoco": {
+    "dateTime": 1639094606,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "698644047a03aee545abe6382b1cef004b3b163f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s5lr1q7ag4pv9s8nzfrgpwwmprw86c41b3605fvfz4sq2cfbs6i",
+    "url": "https://android.googlesource.com/platform/external/jacoco"
+  },
+  "external/jarjar": {
+    "dateTime": 1613531705,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df6eb497ee3b0a2b52e79929eb408ee073478f5b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vn1j4pmksskgdjak31yc2vc1l8ph4m3mw06nsm0ql7fhbmy00yg",
+    "url": "https://android.googlesource.com/platform/external/jarjar"
+  },
+  "external/javaparser": {
+    "dateTime": 1613531706,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "68f8bbeb8bba4d3f56b8c8d776cd7329574c7e81",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l5hikg3bhk5fasrbwgbiascl8jwimacmpj0if2yqmbzcr6bglzs",
+    "url": "https://android.googlesource.com/platform/external/javaparser"
+  },
+  "external/javapoet": {
+    "dateTime": 1613613838,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "25984244ccdd9d3ac4395702edfec3d4447479b0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kwklwk1xjnnvwblfb5hga4ks1p3jdmh9dc30c5mifksrp8fsyr6",
+    "url": "https://android.googlesource.com/platform/external/javapoet"
+  },
+  "external/javasqlite": {
+    "dateTime": 1613531706,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef9a0442a994de9d7248af776f46bb034354c587",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1801cchvl1nys58y41qxk9if6wamrakpvpq6c2k3fj65053kizi6",
+    "url": "https://android.googlesource.com/platform/external/javasqlite"
+  },
+  "external/javassist": {
+    "dateTime": 1616972587,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "601e30c1232c871cb3808f01db78c47b5fb13cda",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zfcnqlgyl59pv4h0s0nnc8lhgljpq5dq4p05anay43lnrszn3ca",
+    "url": "https://android.googlesource.com/platform/external/javassist"
+  },
+  "external/jcommander": {
+    "dateTime": 1613531707,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2710ee9cf5f125aa91a51b8c4704528ab47cc06",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m4a69hc9k4ixn8sah9rz9n10xgbz06swcfcsx96cjk0svpqyw4w",
+    "url": "https://android.googlesource.com/platform/external/jcommander"
+  },
+  "external/jdiff": {
+    "dateTime": 1613613840,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bfa09e233b949ec5998e8e05869c763a87ed8aaa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j5bnl4lmm2288dvbma7mxyx0x52d3jn5d9wpd6idg44ii9ra1ap",
+    "url": "https://android.googlesource.com/platform/external/jdiff"
+  },
+  "external/jemalloc_new": {
+    "dateTime": 1613865829,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "af268fd5b7cdc685dfe632d95debdee0aeca20e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xbgga8jnizv1588dh1bd2av005wfmc69xzh867269j0523djcdr",
+    "url": "https://android.googlesource.com/platform/external/jemalloc_new"
+  },
+  "external/jimfs": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f8907d0e4247fd231b3521acb34347c55e5ffee9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lgiryx40d8a5854yczzvm5x6fydncj06vaclq4hw07rlwh7kvn0",
+    "url": "https://android.googlesource.com/platform/external/jimfs"
+  },
+  "external/jline": {
+    "dateTime": 1621047861,
+    "groups": [
+      "pdk",
+      "pdk-fs",
+      "tradefed"
+    ],
+    "rev": "c8daa149b6cc634532baf704025d2d42bd2d4471",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qxn0vwnbz0sh9ax9ad52wg7373f48dcpq624bgfiypjgxfniqls",
+    "url": "https://android.googlesource.com/platform/external/jline"
+  },
+  "external/jsilver": {
+    "dateTime": 1613531709,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44ebc7d8e8c245b37df89e47cf5115e2ca10e744",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "198msf9yaqbjy52aj4wfshdnxy5nyf1jwn7p2l4gndn1212vkqa1",
+    "url": "https://android.googlesource.com/platform/external/jsilver"
+  },
+  "external/jsmn": {
+    "dateTime": 1613531710,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "664a4d61778b8f73fec86b37c91532b5e1f2995a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0czn4n8j87svwm1kgsnjd8qzyriygcjlkwskqj2w79v1s113rlb8",
+    "url": "https://android.googlesource.com/platform/external/jsmn"
+  },
+  "external/jsoncpp": {
+    "dateTime": 1615680206,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c03a583f234aeed2acf6e5f5a07546851ca32f54",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00985j9k2yspfp6vi5rhnb4pwbzig055l3p08mq8k1sqm3q47vqy",
+    "url": "https://android.googlesource.com/platform/external/jsoncpp"
+  },
+  "external/jsr305": {
+    "dateTime": 1613865832,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4bde6720d4d2b23a058273e76c16614e2bc2f56b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q8sc6rb67j35r6jk55ap37b9bbrgdca0a8dyyy04ipx07ccw05y",
+    "url": "https://android.googlesource.com/platform/external/jsr305"
+  },
+  "external/jsr330": {
+    "dateTime": 1613613844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ddf973b9670ac12c6fbc4c99d5a44d5075c73479",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s0jbmdd3vjaprwalf10i06n8sfmg1x356y5gz0jfimbsknva989",
+    "url": "https://android.googlesource.com/platform/external/jsr330"
+  },
+  "external/junit": {
+    "dateTime": 1615514583,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f8c1807be94017790e4a7437769aa8f84028cecb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n7rfvpi0pg1m6qjh6wza310gf01p2kv564bnkf3dfsjsczfs0nb",
+    "url": "https://android.googlesource.com/platform/external/junit"
+  },
+  "external/junit-params": {
+    "dateTime": 1614308875,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "591688af8afca1022a5933f7a13dcd119f528fa4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wda5sh5jy1ww8y50nfsw508ijw185h6g0mn5nba9iv95zs44zmq",
+    "url": "https://android.googlesource.com/platform/external/junit-params"
+  },
+  "external/kernel-headers": {
+    "dateTime": 1621047865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a62201a54ba8251ec5bc4233d1ec7d7dab0cb69c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vj1hy930nr1pxrc0jdm9j4fhxnlcr05lcg6700ai5qqgz9i06rw",
+    "url": "https://android.googlesource.com/platform/external/kernel-headers"
+  },
+  "external/kmod": {
+    "dateTime": 1613865835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7af39d081476661828eb198745c85a8e7228dee0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xv7xwkz8mhn41fq7jv5hq2fy9r2l4srnwkcf3xbaca2ai177g1m",
+    "url": "https://android.googlesource.com/platform/external/kmod"
+  },
+  "external/kotlinc": {
+    "dateTime": 1621047866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "31d70b4c0c2cfec8555445e36696fb433e9d1a21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0dzms659jz4zjm07pwissifi7v57xhmrlzkx7j63s9za6az63719",
+    "url": "https://android.googlesource.com/platform/external/kotlinc"
+  },
+  "external/kotlinx.atomicfu": {
+    "dateTime": 1621047866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "877f3972aed8259b7492f44f246f835cd183cb70",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "14zbi4fc70xnspx5kn6jdqq9yf8p177qmhx2bprsflrcdb1np9r5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.atomicfu"
+  },
+  "external/kotlinx.coroutines": {
+    "dateTime": 1621047867,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2e8b2e7e1732646a236701de78c5c29a2d8927a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xg0g0yn8qzk23p8vvh4laavmvinbmqch5ib1ca44g6fkf7f7df1",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.coroutines"
+  },
+  "external/kotlinx.metadata": {
+    "dateTime": 1621047867,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6dbe7680b54278b7924623fc2e1952a3369426d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0fz2mbsb51b6h5d8a1p099iccxi4ll2w4cnw3i8yikjmq5pl64k5",
+    "url": "https://android.googlesource.com/platform/external/kotlinx.metadata"
+  },
+  "external/ksoap2": {
+    "dateTime": 1613865837,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f844ed92d3d12895eed15e5c0c6d0e61d5404aa4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kvfan6g57xczcv075439zlqaw3rxmi5mdz7rrfjxv2qyh3sp2v2",
+    "url": "https://android.googlesource.com/platform/external/ksoap2"
+  },
+  "external/libabigail": {
+    "dateTime": 1617757431,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8c1daccf8d27980610cbb08a3e53809ac66047a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13rn7mvpwsvahryp1c8ka6rghblpa0vjsvrji3g86map3ij0shac",
+    "url": "https://android.googlesource.com/platform/external/libabigail"
+  },
+  "external/libaom": {
+    "dateTime": 1624410259,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "197f7fe04e6e486195bfefbf3422df79c9987c85",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01v88ya40i58w9fmwc0ak4rl9l2sc5rm9yyh7j8r388ynhy1rldb",
+    "url": "https://android.googlesource.com/platform/external/libaom"
+  },
+  "external/libavc": {
+    "dateTime": 1639094625,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3451a54cba662976a6bb0c194e4fe9a0d9c116e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c87xk9v7g7s1dylv7v8j53ma2h74mfxhbjcvzxcmg19pcf7qdxv",
+    "url": "https://android.googlesource.com/platform/external/libavc"
+  },
+  "external/libbackup": {
+    "dateTime": 1613865839,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "33d6cdc971334440991204e8754d28c32482def4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ll3ryrbrh2xz90b6r928jck1q0ghnq8wrn5zdy4y9w6naxjy8vc",
+    "url": "https://android.googlesource.com/platform/external/libbackup"
+  },
+  "external/libbrillo": {
+    "dateTime": 1621047871,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "597e0b3ab54abf51251f2bbbee96b8e13f52cc02",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0p9fnd8xjv5xf7jbkp7vmqzfmj0ip219lpmp4d291wxzc1jhy1cy",
+    "url": "https://android.googlesource.com/platform/external/libbrillo"
+  },
+  "external/libcap": {
+    "dateTime": 1625706470,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "edd7b1e0db714df9934899079be11d3f02a4d9e3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f4jkab7ws0sjzfgfvrf6mwrrl8q3ghnm885l8nkrlghqd7s3j9c",
+    "url": "https://android.googlesource.com/platform/external/libcap"
+  },
+  "external/libcap-ng": {
+    "dateTime": 1613531718,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "797713bae010faa75ada75611309f057581c2821",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dsr6r0s5m2aqm2wz9zq023abgvjxdrajjnsfrs8ssi30zxzrxyq",
+    "url": "https://android.googlesource.com/platform/external/libcap-ng"
+  },
+  "external/libchrome": {
+    "dateTime": 1625706474,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f08dca8e17e98f710272246a2ab85156b5d34d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mi55n6sb3wzc67a279cnabhx179s8dh4bh0j72ngwbaj9sln1fr",
+    "url": "https://android.googlesource.com/platform/external/libchrome"
+  },
+  "external/libchromeos-rs": {
+    "dateTime": 1613613852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "99c691bd3aa2acfab4fbddb73bdd2223575178c6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0lkwghnsaniv3v9lbc1r011ff4dk9d0ja9xzxxk4b58xds6zjpil",
+    "url": "https://android.googlesource.com/platform/external/libchromeos-rs"
+  },
+  "external/libcppbor": {
+    "dateTime": 1642032352,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1490d7459b73b720297562d72bd30670036d5deb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bsania9zv0raww5ki7b4sf8p63x15fng14zr2rx2wn4mwplkiaq",
+    "url": "https://android.googlesource.com/platform/external/libcppbor"
+  },
+  "external/libcups": {
+    "dateTime": 1613865843,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6e624fc8bf379a18f4dad458aabf14bf5c26fcee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1986mbxc28sxi377ydjj8b7mdhwwvsb1df4n3da1cf0m9rrh90vg",
+    "url": "https://android.googlesource.com/platform/external/libcups"
+  },
+  "external/libcxx": {
+    "dateTime": 1625706478,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4532a9738d78dbdc50dcc8e58beea17d8c51978b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qvz2zyl6j8pnwbjv1rb7kqvjgq13nmbym2zabb64nch2h0vfs4w",
+    "url": "https://android.googlesource.com/platform/external/libcxx"
+  },
+  "external/libcxxabi": {
+    "dateTime": 1617757437,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c8554c364b236d273e345b5c5ad6e69af18fd854",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11zz64d974bs5gm1b4vin5bjvq9a13h9gzjhk68lm4ksi1yaga96",
+    "url": "https://android.googlesource.com/platform/external/libcxxabi"
+  },
+  "external/libdivsufsort": {
+    "dateTime": 1613613854,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8b54e8bd278cd16b1dae67ac6da898f17ade0d81",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lh8s06r0fvkjsrdb0ns3iv0n97sibvbv3jy97c9s0zp29mfi3wg",
+    "url": "https://android.googlesource.com/platform/external/libdivsufsort"
+  },
+  "external/libdrm": {
+    "dateTime": 1624496922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "65ff18b4cd8c22fe7a21fc2a238f7a535a396a2e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v85xcr4k6vmdplnq3apm20yvd3jzwsv1rh570prrj15ba552alm",
+    "url": "https://android.googlesource.com/platform/external/libdrm"
+  },
+  "external/libepoxy": {
+    "dateTime": 1613865845,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a78a77c0421a8dce4baddb848ec639161d7c7fb5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wdjlwf9cvy1wz3xymrxmjxlqj1w7zxd2vxy0g90bnpslwcngc7l",
+    "url": "https://android.googlesource.com/platform/external/libepoxy"
+  },
+  "external/libese": {
+    "dateTime": 1613613855,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0661857c3e897d26079a815168903fa17b6db9d7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0g10bprh155ys18zvsxs0annjzh39cnyxfldy9zbxcpcj5dlvirl",
+    "url": "https://android.googlesource.com/platform/external/libese"
+  },
+  "external/libevent": {
+    "dateTime": 1625706494,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f1de461f0d58c2fe2101b3c197385960b062ed6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03gjyf91xycyd2g8nfkvvjg1kibvdm1dlzxn9x50sbhbig43i9gx",
+    "url": "https://android.googlesource.com/platform/external/libevent"
+  },
+  "external/libexif": {
+    "dateTime": 1639094630,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0c53511cde51b940c481d85c2f57bed66a60f04d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ppfmlnbh8vmhicdnvs4vfmsfg608pvmq60g8yylbr44c2bg208a",
+    "url": "https://android.googlesource.com/platform/external/libexif"
+  },
+  "external/libffi": {
+    "dateTime": 1613865847,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da1aa9f864d495ec9e185dfeced8a10c6f80e561",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1kfagm0922z80061324a4w74231aic3p9wsw6qi67nasf7f1fbjs",
+    "url": "https://android.googlesource.com/platform/external/libffi"
+  },
+  "external/libfuse": {
+    "dateTime": 1621047879,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3962a6dff300a615247caa8bbb361fa295a8a8aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10c514vzj2mihk97d69zxzdqgxc65fyqkllyx5glfsqhsr156lwy",
+    "url": "https://android.googlesource.com/platform/external/libfuse"
+  },
+  "external/libgav1": {
+    "dateTime": 1621047878,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3f976d7749d9aaae5bf7a1c92439f7fb99ccae45",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0w3rkagg3c83rf8j0i6409jxx0wya7yxyx5xx3kgq89axymlb7gx",
+    "url": "https://android.googlesource.com/platform/external/libgav1"
+  },
+  "external/libgsm": {
+    "dateTime": 1613865849,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9894dfa05710a31055767784795950443e86f9bc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13np111m5nqvzza0mllnvmm0frvazy1nmlhp6lfn31d00vdrn936",
+    "url": "https://android.googlesource.com/platform/external/libgsm"
+  },
+  "external/libhevc": {
+    "dateTime": 1625281482,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39f1fe7c17d76842611ce7426bcc1592b06c919e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pwsmr437jags5xyxpsdiqg4axjp3n9i5fpcfcp1d2mha3win6ry",
+    "url": "https://android.googlesource.com/platform/external/libhevc"
+  },
+  "external/libiio": {
+    "dateTime": 1613613859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "574778ea5f75a0a144b10e7edef8d50f54ab3770",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "049lcsyzmzympsk6s3rphcmql3y4rs2c1fsh6bfjpg4sdqjcf5w6",
+    "url": "https://android.googlesource.com/platform/external/libiio"
+  },
+  "external/libjpeg-turbo": {
+    "dateTime": 1621047881,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "79569ec533472c03e005a98063566cfec9e45180",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "003d689i5zbmfv9xqqi3bfc1fb0q9xl37x8k0lb5lv4pxr27i432",
+    "url": "https://android.googlesource.com/platform/external/libjpeg-turbo"
+  },
+  "external/libkmsxx": {
+    "dateTime": 1613865851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "86517feb632f51293f488b9baa697a7e61edbc59",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f3vr8khghmcw1pr9kn71ql7s1a0vwnclmqgm2dl27cbkfzf4qmx",
+    "url": "https://android.googlesource.com/platform/external/libkmsxx"
+  },
+  "external/libldac": {
+    "dateTime": 1613865851,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8ca9043823aeb7fca799122fda9417ec1ea7441",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wsy4g8bllsnhdca0s4kh7g986qixrqc3x4pn0jlwg8hnzdc26bg",
+    "url": "https://android.googlesource.com/platform/external/libldac"
+  },
+  "external/libmpeg2": {
+    "dateTime": 1615075457,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb1955916c805cd585085266b11f6695107d9ee0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04qb3lvjnizsyzs59zdxw1i9ng1dibnn3a15szzw8dmfrdwdfjv9",
+    "url": "https://android.googlesource.com/platform/external/libmpeg2"
+  },
+  "external/libnetfilter_conntrack": {
+    "dateTime": 1613531727,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d513c89dba4d997deb39883dd0cf36e687dbf223",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v6lpqqw7h19l9jzs43apw4kws39av9bhikarzlvym5xs3b6jhm6",
+    "url": "https://android.googlesource.com/platform/external/libnetfilter_conntrack"
+  },
+  "external/libnfnetlink": {
+    "dateTime": 1613531728,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1a5023413897685b476255b6152f19a6fdeb1c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c6w4mi3xc6gxly949fh30ni84yk5w0bwqmipv857hpbq4cl3p9n",
+    "url": "https://android.googlesource.com/platform/external/libnfnetlink"
+  },
+  "external/libnl": {
+    "dateTime": 1613865853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa95ef398e2e12601740749c84bd2f613ed34df7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f54wdvb46iwmm725yx2hj6nmfh6g3sfiar27m6qd2i01ah8fb8i",
+    "url": "https://android.googlesource.com/platform/external/libnl"
+  },
+  "external/libogg": {
+    "dateTime": 1613613863,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "765b87d4e71a207152e1cb27fc50e87517bbb7e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rdync9bnrw7gxwn69nkk1y8vn42il7145jlq9ry247qskd06hg9",
+    "url": "https://android.googlesource.com/platform/external/libogg"
+  },
+  "external/libopus": {
+    "dateTime": 1633043459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d4fc366a19ebc967ba009f8681e066bf128cb053",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0z39qr4nd2cgsckhzif4dbjchxqgq72xrql7ckjwyp769g599pz9",
+    "url": "https://android.googlesource.com/platform/external/libopus"
+  },
+  "external/libpcap": {
+    "dateTime": 1615075459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eeb22a7d4998b55dcf6ec7779a2f275315e6c3eb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16pjxifk3vmzkb66ga85ngcwmx555nzbms57fwm66k19v526m1m7",
+    "url": "https://android.googlesource.com/platform/external/libpcap"
+  },
+  "external/libphonenumber": {
+    "dateTime": 1613865855,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc65fb3fa2b64689c9f1a3e9317ab510c40ed34f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rn08wi8q4b6bb00rcchiv4zida0i7dz9vryfkadb15k4mqh79d4",
+    "url": "https://android.googlesource.com/platform/external/libphonenumber"
+  },
+  "external/libpng": {
+    "dateTime": 1616547824,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7be3bca7e950fc6b2d669e10e56ff92aeb378b87",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "177jf1vizmmkp7zx4kh99jp66zaqqxkcj6zgk3n080qc91jh3xbx",
+    "url": "https://android.googlesource.com/platform/external/libpng"
+  },
+  "external/libprotobuf-mutator": {
+    "dateTime": 1613865856,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b7373a355f408c8843a1705b71656a52db4b0a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qd6v41shmz918cv8h2jbgh3pvg65mk7c9m03afzz8gy26zl6rai",
+    "url": "https://android.googlesource.com/platform/external/libprotobuf-mutator"
+  },
+  "external/libsrtp2": {
+    "dateTime": 1613865857,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b07221b82e66410ccbe8d3834b6070305d70b04b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mr1gb60ryh71makvab277w1lrwlk7bv6alhh369jikm5sj78dyw",
+    "url": "https://android.googlesource.com/platform/external/libsrtp2"
+  },
+  "external/libtextclassifier": {
+    "dateTime": 1636416232,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f125410b69cf3d3424dbe70dafec810352a05dcc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ibclamamp6g4g8887sx45g42ms5xharrjiqxqq4wyv5zkqmgwm3",
+    "url": "https://android.googlesource.com/platform/external/libtextclassifier"
+  },
+  "external/libusb": {
+    "dateTime": 1613865859,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c503c79d576c2265e297463f1e05b12eca2d4c26",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v007hjbbbs07mq2y84511mv31b8h8hhac7hp2lqmrwp8f2jldxx",
+    "url": "https://android.googlesource.com/platform/external/libusb"
+  },
+  "external/libutf": {
+    "dateTime": 1624496935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "446dee5d25381753719ce28bc9fa093e2afaef7c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d0d5ljsb4amc6a8xwkx1hmzy712gww5vsh4fq0926nnl195vp8s",
+    "url": "https://android.googlesource.com/platform/external/libutf"
+  },
+  "external/libvpx": {
+    "dateTime": 1626224670,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17177b0e1dd1dbb380aa06fc2a4cbcdae1bdd84a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y883jrkywpy64xay77kxh1j2ijc77lmggyby8860y608a1227f4",
+    "url": "https://android.googlesource.com/platform/external/libvpx"
+  },
+  "external/libwebm": {
+    "dateTime": 1613865860,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ded23dfbd6d56861d4d34dd1a7ab80da8c671de",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kkb0mm6vqbv1ri6br6d4xisvbgx947r8d9vynbbw9bl03g2fbpp",
+    "url": "https://android.googlesource.com/platform/external/libwebm"
+  },
+  "external/libwebsockets": {
+    "dateTime": 1621047891,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3449f1c65afeee906d40ca4c77cef688b5f333f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "14l852ww7vwc5vpi0b5vdqall31afz743qyqs67kdy1xdzz906mq",
+    "url": "https://android.googlesource.com/platform/external/libwebsockets"
+  },
+  "external/libxaac": {
+    "dateTime": 1615075466,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "080975ab755e46f2158eebb2b172c7913e695f36",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k85nq28kwa9jhma9xypm9i3p1317njryhcsvmiqk0w3cn5xxlr5",
+    "url": "https://android.googlesource.com/platform/external/libxaac"
+  },
+  "external/libxkbcommon": {
+    "dateTime": 1613865862,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe63ae84eb8194fb8b0669116cd160501bf5eb20",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ffqp52cwhvb7kkkvr993sj0z63jk7cx0jkv4fb3apjczp8rlnlx",
+    "url": "https://android.googlesource.com/platform/external/libxkbcommon"
+  },
+  "external/libxml2": {
+    "dateTime": 1621047893,
+    "groups": [
+      "libxml2",
+      "pdk"
+    ],
+    "rev": "5155175af1510fcd85c7992e7c00ef1bfed7494c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kni8714vrwwrrbh3pg3fa5q7fillik22qzsrgy2i2d8y1jsbgp5",
+    "url": "https://android.googlesource.com/platform/external/libxml2"
+  },
+  "external/libyuv": {
+    "dateTime": 1613865863,
+    "groups": [
+      "libyuv",
+      "pdk"
+    ],
+    "rev": "17322c367e316c0f8756284b9f96526941028660",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wqd724hbmyk1nqyz2ixk14dq074897raqnb72h8zfbshkxrdvp4",
+    "url": "https://android.googlesource.com/platform/external/libyuv"
+  },
+  "external/linux-kselftest": {
+    "dateTime": 1621047895,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "6f54a9e58c87a0293b4d491c12f9f1d74b9f14cf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wfr5vcjbswirbk0dla14bkz7q34imxd7l7r311c82vqf4wdk04b",
+    "url": "https://android.googlesource.com/platform/external/linux-kselftest"
+  },
+  "external/llvm": {
+    "dateTime": 1613865865,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d018f4ac8fe5e12382ef9fa1a9f2ce7d57eec35",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vsbyazjkpdd4gpmr9cbj94bl4f3ddhqx56rz9apyd50bzbi8dnb",
+    "url": "https://android.googlesource.com/platform/external/llvm"
+  },
+  "external/llvm-project": {
+    "dateTime": 1607536677,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6378f248c747cdd3dbb12e08b5cabefcbc5897f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ikzmd238agp9ldng39y1yn4yj2nqah251h5nrsp3b97qvd05wk5",
+    "url": "https://android.googlesource.com/toolchain/llvm-project"
+  },
+  "external/lmfit": {
+    "dateTime": 1613531740,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "58858715d39a143447db5f494e29cdcae8426a6e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11nb4xcnbnqgq0b15hqdyppixhyri8kwymbvaznfi1y370jw66bp",
+    "url": "https://android.googlesource.com/platform/external/lmfit"
+  },
+  "external/lottie": {
+    "dateTime": 1623891890,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a3b42e44571690fb48a8ab82b321b7dc4005694",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xbfmzrpj7j32s4m7ygvhbx4x4s3gdvzqn07jkh2bmi7r3kws8nz",
+    "url": "https://android.googlesource.com/platform/external/lottie"
+  },
+  "external/ltp": {
+    "dateTime": 1628975035,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "ba4204ba0f1b4842bd197be49baaf5c3ff1409fc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mqyz806pbqm0m40p3lnxjnbnkh7y4rasymk1n8c2a48dm6crxdf",
+    "url": "https://android.googlesource.com/platform/external/ltp"
+  },
+  "external/lua": {
+    "dateTime": 1628903188,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3e21117b6daf2fd5dda92400aea03e3f9a58f774",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1anzd8bz8vm224z62km4v6i6jvqdys18kzrh0c6ss6gq6v85l1b5",
+    "url": "https://android.googlesource.com/platform/external/lua"
+  },
+  "external/lz4": {
+    "dateTime": 1613865866,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "daadd44d564849d558305d3d5cce4d10310f194e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z9qlmhzzd6zssc897sy2yz2iqpq812qfpyszxv5nsmj9ml48swq",
+    "url": "https://android.googlesource.com/platform/external/lz4"
+  },
+  "external/lzma": {
+    "dateTime": 1625706528,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ba5434b6d33e34dd546ba8d291d80edbb07e549",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08wi3bisnknkz26iw3r3lna9zxwnmbql6iz550793nbq8bnkvci3",
+    "url": "https://android.googlesource.com/platform/external/lzma"
+  },
+  "external/marisa-trie": {
+    "dateTime": 1613865868,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22b74355b45ec1a42f0eac469dadf9612e348c15",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "131spy2m80s752028pqqkhylnd2y8ibz1bajdssxjhw6ybhfh4yc",
+    "url": "https://android.googlesource.com/platform/external/marisa-trie"
+  },
+  "external/markdown": {
+    "dateTime": 1588189365,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6dd6ad75ec99b605ea34e5c9408d372f1a073b4b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1g8ziq2pf7gnyqcv6cbpigs7vaghd269lxzqvq3gkmqq5nvvp51k",
+    "url": "https://android.googlesource.com/platform/external/markdown"
+  },
+  "external/mdnsresponder": {
+    "dateTime": 1613865869,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "447bbc7ca162817b0d101559bab7b3ab84691560",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11fw71ghxij6q9zrn3bp7plz05yrw0a8w9yjkdcfjiicf4may28f",
+    "url": "https://android.googlesource.com/platform/external/mdnsresponder"
+  },
+  "external/mesa3d": {
+    "dateTime": 1621047900,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e64cecbdf52d2b558f94b6ed74bd5a2f36817092",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gj14c9wnhqpfpf3wkvfpf967rcsf151clamr6d1prf36m917a43",
+    "url": "https://android.googlesource.com/platform/external/mesa3d"
+  },
+  "external/mime-support": {
+    "dateTime": 1613531744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ffc71bf3afc7622f875b24ff45e17288e04cdcb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lkwshpnbp0hgz4azb63c83xdk8hrqywcbh501frjc8d5zgxvm6s",
+    "url": "https://android.googlesource.com/platform/external/mime-support"
+  },
+  "external/minigbm": {
+    "dateTime": 1639008299,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d902e16d121d3a02f54d4c86650c386e5c62175",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rk16cf47yc4mqdginjifshzxlmiknba3jckp9kkfx0n3kmilcvz",
+    "url": "https://android.googlesource.com/platform/external/minigbm"
+  },
+  "external/minijail": {
+    "dateTime": 1621047901,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ad4f1d809b395b1fbca7c6d5bc4e22bf73852fc6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18341lkx5k0svyj3z60cdv153h8aq0fvc00dssxm3rssim4ax3gl",
+    "url": "https://android.googlesource.com/platform/external/minijail"
+  },
+  "external/mksh": {
+    "dateTime": 1613865871,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef033dab82baf0004bc1b1dc24432e8d14b70722",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d8xqv9r3qa7vvwqs6ifpl77j5whvn67dk0b4xgfbsqf2rryrk71",
+    "url": "https://android.googlesource.com/platform/external/mksh"
+  },
+  "external/mockftpserver": {
+    "dateTime": 1639793023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe5f0c247ba66ce1c35069579c75be04ae665945",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13v4wf8ympfh18w233jzc9vy2sddh1qkrbkrwcmzs6smw84z5d4m",
+    "url": "https://android.googlesource.com/platform/external/mockftpserver"
+  },
+  "external/mockito": {
+    "dateTime": 1613865872,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b796eac84ce461e3b4e40342e4e7bf00f6979b6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0fvgaw450rhb5cmq2blh2y4zi86x23jjngrskprz9k4is3yw8zn9",
+    "url": "https://android.googlesource.com/platform/external/mockito"
+  },
+  "external/mockwebserver": {
+    "dateTime": 1613531747,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9f42638a9483e77547423cbaead63a8c36cad8c6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yxf1fgfkb7kgzz5pqac8171952gfviv2043njxnxbaysmy5sn1n",
+    "url": "https://android.googlesource.com/platform/external/mockwebserver"
+  },
+  "external/modp_b64": {
+    "dateTime": 1625706541,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "42bb4904173d8426f0f87fde206d8d68a0e13673",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l11d9qw0qlh6ab2ybwciscspqscdydj23q5998va4qxpapdcrjg",
+    "url": "https://android.googlesource.com/platform/external/modp_b64"
+  },
+  "external/mp4parser": {
+    "dateTime": 1613531748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "52585db8f3c349936676e3d09a43fb36e6a6991f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "167wv822ssx9n3z0bnbk72p532wy7ck7a0ayi0rrppz5whilg262",
+    "url": "https://android.googlesource.com/platform/external/mp4parser"
+  },
+  "external/ms-tpm-20-ref": {
+    "dateTime": 1613865874,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d77b09141e7e423793b581056a469c50d0fed5c9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j5gdirvbvqr3kw0d212s35awisanlmc1avyfk2ky7rqa82yqp85",
+    "url": "https://android.googlesource.com/platform/external/ms-tpm-20-ref"
+  },
+  "external/mtools": {
+    "dateTime": 1621047905,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cdb5eed6ebcca6d1fd92b33742a30912e53666f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0i0dbrkfj889qx63dz0iwvs6klablp5ydyria9s4j21bp3zmgzp4",
+    "url": "https://android.googlesource.com/platform/external/mtools"
+  },
+  "external/mtpd": {
+    "dateTime": 1622768696,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc4eff56cf88f852b887129707558a873e055979",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kgmcl1ll4mpzfwnl95y2qhv7d825s4i3rkd36wgvg5h6jkf9zjv",
+    "url": "https://android.googlesource.com/platform/external/mtpd"
+  },
+  "external/nanohttpd": {
+    "dateTime": 1613613882,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef845b076e67bf190c7886e4d692761bf0c522de",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gq2hhgy0rq5ws42vjkqjdawn6dns6kl8cb5h46lx8psvh7pdgz4",
+    "url": "https://android.googlesource.com/platform/external/nanohttpd"
+  },
+  "external/nanopb-c": {
+    "dateTime": 1639526642,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2db787ef809d8bc4354da4a4441234ff368feb78",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r2mnfxskl50figqqvas1zs0n4zd9hy5qa2g7jfnlm5q0pzwpyjr",
+    "url": "https://android.googlesource.com/platform/external/nanopb-c"
+  },
+  "external/naver-fonts": {
+    "dateTime": 1588181530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8e6a052e8cd2a21fb74fe33d6ef59626adaefadd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ihcg6mpzf8lnygnn82l5z8pv6m8iyw0mzsc76wmyn9j7wdyhg9s",
+    "url": "https://android.googlesource.com/platform/external/naver-fonts"
+  },
+  "external/neon_2_sse": {
+    "dateTime": 1588290974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "148469b41e9d27ae0f5b6fc604449d0ea9617963",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12ivga8rnf1ibchrwczfs38n8kpjrjkyrfn9hav2w8z3xdrhz8p2",
+    "url": "https://android.googlesource.com/platform/external/neon_2_sse"
+  },
+  "external/neven": {
+    "dateTime": 1613531751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e60bdb0647318b0b4535c0f186676028e5725541",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wl4zg5zkcgnrj9lzvm6l49awpar07hny1admj6hi06k0w2id3f9",
+    "url": "https://android.googlesource.com/platform/external/neven"
+  },
+  "external/newfs_msdos": {
+    "dateTime": 1613613884,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7afefc958e562a2ec6ee01d4be5ab4950da9bd37",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0shrw82gl4bsvsdyk21fwmjvdk9mjg24ylng2jbabki63xp4dmgw",
+    "url": "https://android.googlesource.com/platform/external/newfs_msdos"
+  },
+  "external/nist-pkits": {
+    "dateTime": 1613531751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ec89b1c33ec1aeeca3cd6157fa1809706a30111",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xdr99aqr4g7drh4gmr88ah0q2im8aq5cs8w834qanygpg694dr1",
+    "url": "https://android.googlesource.com/platform/external/nist-pkits"
+  },
+  "external/nist-sip": {
+    "dateTime": 1613613885,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3b5bf783df3517768697daf779ecdd2ff035ac57",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0k5qg8bbg2l6g3fv9x4bikpa7b0sf08lacayxgm3pnpyn2bmai43",
+    "url": "https://android.googlesource.com/platform/external/nist-sip"
+  },
+  "external/nos/host/generic": {
+    "dateTime": 1632604002,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a67fb520f7813486babf8d9c439bdc7de18f8890",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jwxahjz1qib7l5bsjzinjl0a1incqvns2msrl469gszdawvix7a",
+    "url": "https://android.googlesource.com/platform/external/nos/host/generic"
+  },
+  "external/noto-fonts": {
+    "dateTime": 1637373853,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17b82ae193957e9d5684416e1e3efce8b6bd5131",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1q470f9vdr3nrygwfggjdi7h7wc9g8h7alhc2cjvd5czmwzhwkqc",
+    "url": "https://android.googlesource.com/platform/external/noto-fonts"
+  },
+  "external/oauth": {
+    "dateTime": 1613531753,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e23d20118b112ba5f615d2e2bf45e224bb962724",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1iy7n0krrann5fkm46znlm1q598wzr4jlxv17d5xw4dwc5jp6p5n",
+    "url": "https://android.googlesource.com/platform/external/oauth"
+  },
+  "external/objenesis": {
+    "dateTime": 1613865881,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4308fd6b72e4801eba6e3f916e89463d05387114",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cvmp0wrf5lqag44wfjil3bdq4zkdc3dm4fr49g6qcchd7h65gmm",
+    "url": "https://android.googlesource.com/platform/external/objenesis"
+  },
+  "external/oboe": {
+    "dateTime": 1627002287,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16b5814fbb005de2f44277c9466fca045c84b69c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z95091yv1akx277a4fsy0hxdlav1b7kn969b6cn5z6cnzm66fyl",
+    "url": "https://android.googlesource.com/platform/external/oboe"
+  },
+  "external/oj-libjdwp": {
+    "dateTime": 1614909846,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "29dbc1766d1dbd5ca2a1f16c7ba8229d9726c7b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l4l046zxwqw991qadiawlwsrbv2chwh0rapbqry93l4ygikmbqf",
+    "url": "https://android.googlesource.com/platform/external/oj-libjdwp"
+  },
+  "external/okhttp": {
+    "dateTime": 1628975052,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8ea0c5d9656f08f6a67ec2eef226381db1b084b9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "097dqcz04kxb379dvrhzkgn7w3dm65lwpq0g9hadqaq6pv1ymf9r",
+    "url": "https://android.googlesource.com/platform/external/okhttp"
+  },
+  "external/okhttp4": {
+    "dateTime": 1612297295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da430a76a2790138192c1dd25675dab3a57ebaf2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/external/okhttp4"
+  },
+  "external/okio": {
+    "dateTime": 1621047914,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c833ac25ee8ae19a4a3241109e5f4244c2c25574",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ln8mr5cr324v8dzjk35hhy0333sa74j9ay3xns35yk7g2pprxbg",
+    "url": "https://android.googlesource.com/platform/external/okio"
+  },
+  "external/one-true-awk": {
+    "dateTime": 1617419034,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec4dcd846c3ef7a7211041023a559ed753bc0b80",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1g7v3ayb691jhr8fpcrdz5a5396qbilf9gkddx5wvl52cxrfd72j",
+    "url": "https://android.googlesource.com/platform/external/one-true-awk"
+  },
+  "external/opencensus-java": {
+    "dateTime": 1613865884,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "c3b6a808beedaf5f4e35c560eb60bf03a58a6f49",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1i22bm033fn223k4hjiqn55aj1xr3mvcgl6880cqhr2i8cnw7ij2",
+    "url": "https://android.googlesource.com/platform/external/opencensus-java"
+  },
+  "external/openscreen": {
+    "dateTime": 1617757480,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a93f6e226b68bc5688875cf4e2bec737c8c582d6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v1y1ar5ak3mn893gi7jxrfkly7wl45m84gyj33pspcni831bsfc",
+    "url": "https://android.googlesource.com/platform/external/openscreen"
+  },
+  "external/openssh": {
+    "dateTime": 1614045897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d18df9e11de6160bec3e04101343ef5c7083ae00",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ch7jqxxw4cv80w60k9nkfpxjp3i60xd575rchlyizvlxka6zwjq",
+    "url": "https://android.googlesource.com/platform/external/openssh"
+  },
+  "external/oss-fuzz": {
+    "dateTime": 1617419037,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1bcd81b724eba7d3681d2988958ecf87422d95d5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12ysv0nncqlx7gry6m10ac6x34y1kqs3y9jg5bzkb6dsb677mi6r",
+    "url": "https://android.googlesource.com/platform/external/oss-fuzz"
+  },
+  "external/owasp/sanitizer": {
+    "dateTime": 1613531759,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1b4ee6111bf49e33b83111636050374394e5f481",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bw90dnh8irryj7sn0n0swlx9vllvasxj8r01gh7prmawi97lh9r",
+    "url": "https://android.googlesource.com/platform/external/owasp/sanitizer"
+  },
+  "external/parameter-framework": {
+    "dateTime": 1613531760,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "17ed7eff362c4623b6ca349beaf9c754eb2f8352",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bf4fjy9p4fz7rp2plga2zam62s2k8jcwgn8mg0qka7jkddf1qrb",
+    "url": "https://android.googlesource.com/platform/external/parameter-framework"
+  },
+  "external/pcre": {
+    "dateTime": 1613865888,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f86434b83b5ecd86342778f8927a2b043926ccb4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dpm303wwx264bc6hxqlrfkfmavqwzb1k914gpxmdgfn0iv7hn2m",
+    "url": "https://android.googlesource.com/platform/external/pcre"
+  },
+  "external/pdfium": {
+    "dateTime": 1616461455,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e8e0d9e0a92ac33be356a816db7e2ee7dfe378e9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1g50kxs8y74bklsmnjzazd4nk8ajhksyapm5r0g2qidb3nmx3cl8",
+    "url": "https://android.googlesource.com/platform/external/pdfium"
+  },
+  "external/perfetto": {
+    "dateTime": 1642284248,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0f6b642287520ba48c5d47f2410fb9238fa93262",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f1dzp2vf3z0yjfvdnd7a5cadxwdrlfavaah5a8in34dn9imp7pm",
+    "url": "https://android.googlesource.com/platform/external/perfetto"
+  },
+  "external/pffft": {
+    "dateTime": 1613865887,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04815c2cf82dab38edf79e4cfe572e630e35f629",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qgf52lcq58ixhrhqnwcpixkkbrd586n23r14yikvbqhspdfar0s",
+    "url": "https://android.googlesource.com/platform/external/pffft"
+  },
+  "external/piex": {
+    "dateTime": 1613865890,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "be038a634e8b8c4d3fddd91be0da3a3f47c96182",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05lyk7vmhf7kq9bcwpg07nwvx1pdadjv1g3c1ny2wq2l2jchbps3",
+    "url": "https://android.googlesource.com/platform/external/piex"
+  },
+  "external/pigweed": {
+    "dateTime": 1621047922,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5989fa9a2e7899cdbfb25714c06694d0dc4b1f88",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zh25gjyykp19xpg9jh5xjqaz87j75nb5qzqg08gf7smspb34rvz",
+    "url": "https://android.googlesource.com/platform/external/pigweed"
+  },
+  "external/ply": {
+    "dateTime": 1613531762,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "77e56a6e8b6bfd3f887ed12ab55590bb8682754b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04ran6mcqvfm06d2pqw9x62vwdr782h14xmn9zw8c7pw0hqzkqfz",
+    "url": "https://android.googlesource.com/platform/external/ply"
+  },
+  "external/ppp": {
+    "dateTime": 1623114302,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2c9b143164562d033b4d4271ebabd983cd77e12",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x8kmf219svcclr8yv94f06y9m7i4hf1sshs4vw557l7g0c56rs5",
+    "url": "https://android.googlesource.com/platform/external/ppp"
+  },
+  "external/proguard": {
+    "dateTime": 1588698674,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2df85bfd8ac584e318f563b0d8d5e777c4c11a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0y15jn4kysl40rgbgh68z7gy9d1g5jjhkvms6gz1jz0vql7a0izc",
+    "url": "https://android.googlesource.com/platform/external/proguard"
+  },
+  "external/protobuf": {
+    "dateTime": 1625706616,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "759fae8663b32fb041f195391481f440c03f5a44",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ikjv3r0yg4iffq7s13l87va3f8hhhbinp4bb37kl26wb6wdjkzx",
+    "url": "https://android.googlesource.com/platform/external/protobuf"
+  },
+  "external/psimd": {
+    "dateTime": 1613531764,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "87337be2cd70b22552790590a9dbefec946daf0f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rq4alzwxxvls4pb4jb02sapag63jpvijjpjh2g2gb3rxnh9kg8q",
+    "url": "https://android.googlesource.com/platform/external/psimd"
+  },
+  "external/pthreadpool": {
+    "dateTime": 1613865893,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "78119410745719b99723794a10c8156a630e7483",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ixzpaa6335mcn3sd2kqxrbfr3835fxnfrz2afdyq17h65nvx3b2",
+    "url": "https://android.googlesource.com/platform/external/pthreadpool"
+  },
+  "external/puffin": {
+    "dateTime": 1613865894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bac9bf84fea247d6d3da89757748e06c63a8c8d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02jrnkqcr9jp2s6igb1nz3gbcr5zsb28x1983p5la5wq8cvykvf3",
+    "url": "https://android.googlesource.com/platform/external/puffin"
+  },
+  "external/python/apitools": {
+    "dateTime": 1613952290,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9169a57043ae2f9f4283d270e9fef70632116ffc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17caach33h2m4a25fwbdkfab2kmj8c5gbv3wf5zfzh84k27v18md",
+    "url": "https://android.googlesource.com/platform/external/python/apitools"
+  },
+  "external/python/asn1crypto": {
+    "dateTime": 1613865895,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0d647fd0bb93d3a8fe278f8a5f7898f4a4d1953b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00a85gygijpclgdcpp6ggr9zyamxval6k6pkq5ps97c88d2av40h",
+    "url": "https://android.googlesource.com/platform/external/python/asn1crypto"
+  },
+  "external/python/cffi": {
+    "dateTime": 1613952291,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72cf74668986d2a00b3b42e9fe5b6df8dd9ada68",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m4cr3zy22iahhiskp5vpn0b60rp08a368vkg4jzbkvwcap1z6ag",
+    "url": "https://android.googlesource.com/platform/external/python/cffi"
+  },
+  "external/python/cpython2": {
+    "dateTime": 1615264820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "133b790e2d63689bab91e3f81574bad4b828fc91",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jki6h7sgdaak46rff8iijzdcdf9phrdi5935j86595xk5a3d9vi",
+    "url": "https://android.googlesource.com/platform/external/python/cpython2"
+  },
+  "external/python/cpython3": {
+    "dateTime": 1615264820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2201d4bd23c909504e3456369235d8bd39437b47",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07asjr9d3wlbphfy1l55xbvkxdilc6wzm8fhjqkmha70a7bxj7vm",
+    "url": "https://android.googlesource.com/platform/external/python/cpython3"
+  },
+  "external/python/cryptography": {
+    "dateTime": 1613952293,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "272563a2ee2cec8b275fd866ada31693e67e4904",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10dgm0mh4ljqaj3b5wl39a2v0lgch1jcsrsxbjzx3n25alph1cpw",
+    "url": "https://android.googlesource.com/platform/external/python/cryptography"
+  },
+  "external/python/dateutil": {
+    "dateTime": 1613952293,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "465272357828aa32eae82593c9c94531a3b936ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pjs7hnd3yd3wqqacxis72jyzjcwd0f2bq967ysg8j18vzwjsx0q",
+    "url": "https://android.googlesource.com/platform/external/python/dateutil"
+  },
+  "external/python/enum34": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "a025dc9174888db76de1f8b5883bc814435b2a19",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xzl7iybydjfwj5wg6bmxzzmdxv6zpl6qn4w6aw0zws3mra6jhk4",
+    "url": "https://android.googlesource.com/platform/external/python/enum34"
+  },
+  "external/python/funcsigs": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1082ba7045264e07703ff3c2eb23514a281e7fb2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05v4kd9697gpxiyh83gsghh8c2vwc2gn9zlc9naj8k3apnc9k2j4",
+    "url": "https://android.googlesource.com/platform/external/python/funcsigs"
+  },
+  "external/python/futures": {
+    "dateTime": 1613613902,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "b5aa5f5539a1e2f5e72dfe5679993714eb15a4ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y2dviz6khx9as8kk3fq1dci62mi08yddpqfcsca79nqsfwf6rig",
+    "url": "https://android.googlesource.com/platform/external/python/futures"
+  },
+  "external/python/google-api-python-client": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "cd39112cf97b36e852912552e5b0cb9a5add3582",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hc7mrg2sjghznm5fysxqwq2rq8wy55rw1r66g57ripnzrn8xbqm",
+    "url": "https://android.googlesource.com/platform/external/python/google-api-python-client"
+  },
+  "external/python/httplib2": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "3a86850ec6eb5859809f1c61e51ee36cb16a6d1f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jfbxrd2prjm3nv3bmwlqqwgx6iqna777ydd430ljki9dymchj4h",
+    "url": "https://android.googlesource.com/platform/external/python/httplib2"
+  },
+  "external/python/ipaddress": {
+    "dateTime": 1613952295,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7354dd551da7c69448d2d9015931d88ff0042d97",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rvld36ky44qc8yz64a5k6g52qsss96dadvsdd8yqmrx8zincd0b",
+    "url": "https://android.googlesource.com/platform/external/python/ipaddress"
+  },
+  "external/python/jinja": {
+    "dateTime": 1614737089,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26bfd872498f742abe4efdae60505d5847f77418",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0syg2yndr59f4mf3hvw6vs43fx8hf60678ky4ha2liypymazf2kf",
+    "url": "https://android.googlesource.com/platform/external/python/jinja"
+  },
+  "external/python/markupsafe": {
+    "dateTime": 1614737089,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "544be55941920aff9eea37f9878350bb18c7645f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18qjh0xrnc59w7divzjrriz7ppclhhlisypzlgd8b8hbd4ali3rz",
+    "url": "https://android.googlesource.com/platform/external/python/markupsafe"
+  },
+  "external/python/mock": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "837706abbdd2e02b413dbd3e685ee878f949ee8c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1c8fbmxnl0h00dnwqywba008lm6bs8zrmvhagnp7gpr84if60gr7",
+    "url": "https://android.googlesource.com/platform/external/python/mock"
+  },
+  "external/python/oauth2client": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "a9519d8afa53d646e2127e11fe728ee43f9750f4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0snxs8dzmx5farizh7dk6kyw3pnw9dwq4lgjf55pz57zdw4w5h7c",
+    "url": "https://android.googlesource.com/platform/external/python/oauth2client"
+  },
+  "external/python/parse_type": {
+    "dateTime": 1613952297,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "a8344397517bcd1937b689cd3ca0a704f48c5b36",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jl9ij257zg68c3vbb8wnkpl9cqyr0k115374hh0xwl86cc38x5x",
+    "url": "https://android.googlesource.com/platform/external/python/parse_type"
+  },
+  "external/python/pyasn1": {
+    "dateTime": 1613952298,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "65cd5c55214837540ce03f0630d091780a68406d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0m5fjmifgskidmbvnnq4rvbqkwzkdmvhpi7pya6b58s3cwmrwc7x",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1"
+  },
+  "external/python/pyasn1-modules": {
+    "dateTime": 1613952298,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "49ad0363bc7a32a9478c0d67d5a6271b04c7b651",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0n7isv62gq7h7i605p3lpkp67hqdbmcnmzzv30jr2m0g8bb52fjr",
+    "url": "https://android.googlesource.com/platform/external/python/pyasn1-modules"
+  },
+  "external/python/pybind11": {
+    "dateTime": 1613613908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fae5938c85e5678dd15f5e9e058c792b84aae665",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r4s6cadrw8g60zhq9nh2cyzvbc52w1amj4ydp5apz2z4hz24fmf",
+    "url": "https://android.googlesource.com/platform/external/python/pybind11"
+  },
+  "external/python/pycparser": {
+    "dateTime": 1613613908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bccc56436e0f7b8a7896de5752e9deac6284354a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "120qdb67ag3yy0cgwdxijjc32s54irpvyid8dgmkd4jdl3jii7ry",
+    "url": "https://android.googlesource.com/platform/external/python/pycparser"
+  },
+  "external/python/pyfakefs": {
+    "dateTime": 1613952299,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d426185272e770a1d76cd083e2ef4eecbadb7c60",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jw07iqzrjac1p3vfs3r2g0lg4nsfqxxi6vkk67as939ggkas836",
+    "url": "https://android.googlesource.com/platform/external/python/pyfakefs"
+  },
+  "external/python/pyopenssl": {
+    "dateTime": 1613865906,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ce50258c4e9b5fc4c284e5993c9792e3a053322",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h50kdfwm9wp4c6vyhf34p3lirz0r69dckdm6hjw45h4piqafdwf",
+    "url": "https://android.googlesource.com/platform/external/python/pyopenssl"
+  },
+  "external/python/rsa": {
+    "dateTime": 1613952300,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "43204191142dd68efb68aacfe4f3c057161971ce",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x7jflip5dcbxd4z9ax3pzlqd0lw1dmgbjjffrrrjbq3ms5vg88v",
+    "url": "https://android.googlesource.com/platform/external/python/rsa"
+  },
+  "external/python/setuptools": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "07974c431dac6f2c6304fedcd4257bfbc4a291dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ypsmnmng16c8sqx8g3nsiybw7qfxyykpd74i1nqkx0x8qdfs9pi",
+    "url": "https://android.googlesource.com/platform/external/python/setuptools"
+  },
+  "external/python/six": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "32972688db26e939c722cb52fd0147dfac6e932f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j9sx6jph7hz7axrmrmd2wpyvlp8d1gn16ph94vnwcm3izx9a7vr",
+    "url": "https://android.googlesource.com/platform/external/python/six"
+  },
+  "external/python/uritemplates": {
+    "dateTime": 1613613910,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "3a1fae5ce3680e406cb25454ca65e95735aca3d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mzkgmy5lxgsbd1az98lvqz50z12l862zgqhrak5jvmgxy33asm5",
+    "url": "https://android.googlesource.com/platform/external/python/uritemplates"
+  },
+  "external/rappor": {
+    "dateTime": 1613613911,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9295e3a484a55bd9802ef1940a450b21392e6bf6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0k2pwhs721qh0h3x77z9jzl9vww7gvfdqf9ypxlgia2mha9m2y97",
+    "url": "https://android.googlesource.com/platform/external/rappor"
+  },
+  "external/replicaisland": {
+    "dateTime": 1613531780,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7ac59c370ec226f0631e90bc41a582b55e142404",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16bi4iv9ya7ylwhf4qm7rnymzzcl6wjl68rrrjqrsp9my28h4mrx",
+    "url": "https://android.googlesource.com/platform/external/replicaisland"
+  },
+  "external/rmi4utils": {
+    "dateTime": 1621047940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9bff4b6bb8654c6bc31f2591d90b6b3978c09037",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lwxkzw2xl6mssvzivzgrnn3wmxkpbm9r3hpd0iif8124ha02zq1",
+    "url": "https://android.googlesource.com/platform/external/rmi4utils"
+  },
+  "external/rnnoise": {
+    "dateTime": 1613865912,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7d5c2f6f188718f278e02be5ee08b9c12c553194",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1flgs86w4k7vrrq7mh962rf7y2vxnzfwsd12hpa44375rc06lrm1",
+    "url": "https://android.googlesource.com/platform/external/rnnoise"
+  },
+  "external/robolectric-shadows": {
+    "dateTime": 1639094700,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e332286a99959523ddd4aa61ca4b827ca9977289",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1la9xkbzd8x4djq6p7jlfd8jdbigv6q1sc84zh1x5p29mrfng6mq",
+    "url": "https://android.googlesource.com/platform/external/robolectric-shadows"
+  },
+  "external/roboto-fonts": {
+    "dateTime": 1623287184,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dfec14dcfcbf9bffa566d6dc1c99c8a61083ec4c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ygzmkkp1nj8c4spq3rgbdjx40vgmhkivkywikrab3wp3c469lw4",
+    "url": "https://android.googlesource.com/platform/external/roboto-fonts"
+  },
+  "external/rootdev": {
+    "dateTime": 1613613913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46d58905ccf30e28e77fb486f06eb7c61d034e01",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kyqrr4lavpbqz47ajvf03vylgxs72l1nhxkx93hpl52w1kyqih7",
+    "url": "https://android.googlesource.com/platform/external/rootdev"
+  },
+  "external/rust/crates/ahash": {
+    "dateTime": 1621047943,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b0eb64216de68cae89b255e96e3966e518c81bc4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hq34bv8dhqq4dh16bqlv49fsszfp1y08llsycpv8wwxhjwjbc1f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ahash"
+  },
+  "external/rust/crates/aho-corasick": {
+    "dateTime": 1613865913,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cac83ac7770e46ca4c207762c2ed994a77f43052",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pjnv2f5g34fd8qrzdkhqi9fz1x5mrcg4539gjrkr3kfrwbxsnb4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/aho-corasick"
+  },
+  "external/rust/crates/android_log-sys": {
+    "dateTime": 1621047945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92a7a0981e3fba6a1fb70a2f4f36209bf802073a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j5zn9ckhs1l9n8wgq1j5r4ahk7z5wny7idxqg5zlpf4nn0m6kr3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_log-sys"
+  },
+  "external/rust/crates/android_logger": {
+    "dateTime": 1621047945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7473861ef2e069d1fbeca2c1cbf3ef56538b1237",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xvwcn8dy0nas0kx33k8hhxvirkngyd8rn5d37bl07xr8lnqw82y",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/android_logger"
+  },
+  "external/rust/crates/anyhow": {
+    "dateTime": 1639094704,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "260c38bc9aed4f1a08b42d8b0bdb478031661286",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mpyq29wnw9wjv191hmilppxszg7rfl93flhf2476vkqiq1q85by",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/anyhow"
+  },
+  "external/rust/crates/arbitrary": {
+    "dateTime": 1617757509,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "276e74e25249cc974ba58b6f3dd0b2dd629f56bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zw3zrfzlwaidbzsl0d166jpmi2hywk1gfjrs2b9wr2dln61dg2k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/arbitrary"
+  },
+  "external/rust/crates/async-stream": {
+    "dateTime": 1614650720,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2788b2ee49ceeba2972e42155a2a9edf00f01234",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s0h4zsr8bkygz1d4i78cp5897yvm0bz5iaffbph53n1gryh8ddf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream"
+  },
+  "external/rust/crates/async-stream-impl": {
+    "dateTime": 1614650720,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f6eb8978c10aa6c9590c650ef92fcd9bc8a6cf2c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d30bmadkkr0hjly1033l7f3jr0bl1a30q8sdz1l58nx93c2sayp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-stream-impl"
+  },
+  "external/rust/crates/async-task": {
+    "dateTime": 1621119921,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "79bdc1b9ea2568c872f4de4395d2c7ebbd751a0d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1a0j7nxi30zng0i6q2dkqqkg70a8bxgbspl3pflv98bsxjhcnc19",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-task"
+  },
+  "external/rust/crates/async-trait": {
+    "dateTime": 1621047948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "00c3d162cdd0b47e3132f9e46dd5d9dc398e769b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rfbqsx81bhz1arfgzgql5kggqgfqq13yc65h69k44z91lq18227",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/async-trait"
+  },
+  "external/rust/crates/atty": {
+    "dateTime": 1616547886,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "22be54ef33515d31dc08d9cecc6b461728c0a4bd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ypvk3r03x00sq5qxd7c358049mzv2f0z364zkj2lr15yakp40f0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/atty"
+  },
+  "external/rust/crates/bencher": {
+    "dateTime": 1613613918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb82fe69e0d5d89ab0a2e6162c728bbe4e913ef1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d7skrpb2ipsqlcdsrl46cgdf8q7jf8bv5izmxd6cnw733zf5sv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bencher"
+  },
+  "external/rust/crates/bindgen": {
+    "dateTime": 1621047949,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "06641df2a813193dbd4c93deddd3eb01bc763f83",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "185wjwx64ldpyk4y3w67jjqd8q54pgy34pi0cif198zk6wjz0v11",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bindgen"
+  },
+  "external/rust/crates/bitflags": {
+    "dateTime": 1621047950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "281f2460b5702047a5a6bc3f7bd1700b03b07433",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ahjp9jmjwm6gm9wgfi4znwvpjpyfkyixk9pjrkx88v7d5c3jmdj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bitflags"
+  },
+  "external/rust/crates/bstr": {
+    "dateTime": 1617419069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d5e28d4dd67923a7ba461646734df4cb45a0ced",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sri0n70g1iak5831zqmkh00w90kk3g70cypy86g4zpzpafyl250",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bstr"
+  },
+  "external/rust/crates/byteorder": {
+    "dateTime": 1617419069,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61ee696ebcc059ad68f2b372b1e8832b00d691f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z56bdlmm8jf5bvb88ddk95b386xlc6hdaczm530jrzi07r77xjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/byteorder"
+  },
+  "external/rust/crates/bytes": {
+    "dateTime": 1621047951,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a30c7e667d68dad457fc15178f4a174f746f8862",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f7g96awyhi3sj71rbllbsq9c64j228r2g4wabnncrl99clma441",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/bytes"
+  },
+  "external/rust/crates/cast": {
+    "dateTime": 1616547889,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d618e3f90fe417651ea5f2f8e10f14f78136326f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17c2z30zxyfqni9b9j1778xxjc1lvrhafhzlaw6jajp9a6kwn61r",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cast"
+  },
+  "external/rust/crates/cexpr": {
+    "dateTime": 1613865919,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2f9e564778b37e4b332e4204df8dff525d7b30bd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xq9rrmn61yjwzjv61zad20b5irsznvz5w8c7pn5hnjw83aa64ac",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cexpr"
+  },
+  "external/rust/crates/cfg-if": {
+    "dateTime": 1621047953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d10de8fc3fd11294ade975b94548aac2a590fb50",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08666bjm2z2hagfmwbhy7nxa00fprq4dbv1si5slhi6mlkmhhxf3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/cfg-if"
+  },
+  "external/rust/crates/chrono": {
+    "dateTime": 1613613920,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5bbc83c61d85cdbd73e492061d495884a62c620c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x8si59fb4z6xpmn5kg48lamfx76s76vd443pl0qgc37jcdxx0wy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/chrono"
+  },
+  "external/rust/crates/clang-sys": {
+    "dateTime": 1614650725,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bf7bdf865b347325b1fa8a137c0aa13a21c3ed2e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15x52kc16ak83l3l08x0crp2rk5x594bj6jkqbjkkws4728d14xa",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clang-sys"
+  },
+  "external/rust/crates/clap": {
+    "dateTime": 1621047955,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bb797529b6743902acf3c271a7348aec664976b5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wwiss20xa3x2dxznfglzrkb36v0x38c651dbhl9h15swjirwqf4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/clap"
+  },
+  "external/rust/crates/codespan-reporting": {
+    "dateTime": 1617419074,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "054e7af1a86a08fb849f9d91123122546e308ac5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zsiq4anwyv212zznq8cm32rcigvf5xjvn817zav4pmwnq0gjqci",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/codespan-reporting"
+  },
+  "external/rust/crates/crc32fast": {
+    "dateTime": 1636160694,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b447815e6ef3172795511d7f7eb284dc1a711d2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bbyaqmiraqn9hkqhw9klah113w5jgxbapps7xh02qdm9kw2vjll",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crc32fast"
+  },
+  "external/rust/crates/criterion": {
+    "dateTime": 1618362312,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "336043bb8ee8d45f4e1a392e3e167da214767373",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rv1c32p524j7v0cn0lhin8g1qy0v8nnnn7670ak6w3vb3lvxb12",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion"
+  },
+  "external/rust/crates/criterion-plot": {
+    "dateTime": 1616547893,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "476218c9cd2e1d24db4de25d62be06b1ba92be00",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0a72appa3mnq7rjpv4q3kpnmrbmvv3hrk14yai12qbzw72v08syg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/criterion-plot"
+  },
+  "external/rust/crates/crossbeam-channel": {
+    "dateTime": 1616547894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f812b2de67de2d9806c7479aa9513190a2649f45",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nj6qicjbdkdrkycc43fgg0w7gyskmy3ahl6r9zhsb0dpqhys6c7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-channel"
+  },
+  "external/rust/crates/crossbeam-deque": {
+    "dateTime": 1616547894,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76bc6f9ba4be924b75ea57d04e4012c90b68de4e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q88z0w823ap29c1qv6fqy9bmgvb82zs836332hpka1lbrfw0c0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-deque"
+  },
+  "external/rust/crates/crossbeam-epoch": {
+    "dateTime": 1617930327,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "01aded036b0248ca3d30021c73068e07cc2f16e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gwdzc4f1p0ch46zbfdbmrk59mg9848nj1acas9x91xcrn447j77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-epoch"
+  },
+  "external/rust/crates/crossbeam-utils": {
+    "dateTime": 1621047958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "152dfa1c6c65ee96db86cc05aa16a24ba4414b95",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0n97x42nmc8mmwraz879ld6nqdgsq613wiahq066w5j8jvsn1ll6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/crossbeam-utils"
+  },
+  "external/rust/crates/csv": {
+    "dateTime": 1617419078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b498f0912d0c6e78e0e155a8a999cde441f3472a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10z3nh974sckbcfdxw8ah7h8mxvx1c6mfcjvcfr6pw8vzbq84mdc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv"
+  },
+  "external/rust/crates/csv-core": {
+    "dateTime": 1616547895,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "58aceee38f9c7f9b5f44f07c77c140cd4d1f6f7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y6kq025hkpl5yl4vakqd3h08ipbx15n2yayvw654k3vwl9290da",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/csv-core"
+  },
+  "external/rust/crates/derive_arbitrary": {
+    "dateTime": 1617419078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8868c5db41961fdca9a5c9b86d9855b2426647ff",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d83srj03644dvy59r5612779gcp8g9dj3r6c1gf7c03vlfpdm8k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/derive_arbitrary"
+  },
+  "external/rust/crates/downcast-rs": {
+    "dateTime": 1621047960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3914d8cb9e1250bdd94471b81344d8593e3be815",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1325khrkxyr04bzypvdf44azyq5fvbgf3rxxygyfwx8567vyjhcg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/downcast-rs"
+  },
+  "external/rust/crates/either": {
+    "dateTime": 1616547897,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "377f87bab32343a77ff905dc49a38b89138c4711",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jbnwc9iiiyyyf5pa425ysnjv14awhpzylc1f65xiw4zg16l8d6l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/either"
+  },
+  "external/rust/crates/env_logger": {
+    "dateTime": 1621047961,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dcf0c5a02aa863cf108c24821f807bd4e7cfbce0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j8s6pp9l87lpj5cx73cqkwsbxgza1hjv376h35sdf5zznv8gp1a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/env_logger"
+  },
+  "external/rust/crates/fallible-iterator": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4cc74f864664ecfde152e43eb7a6eb5d488ebc54",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wwq8gzcwmwn8nd25m0p7s165d2fpm3gd0bh5qvacca5krdwbapx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-iterator"
+  },
+  "external/rust/crates/fallible-streaming-iterator": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "55ff565bd3f6995b683a671e72935bf47be504bb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0934fiwj33yqkyya8fxlbkwncpm1p48xcvs4058nc8xz92jxms59",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fallible-streaming-iterator"
+  },
+  "external/rust/crates/flate2": {
+    "dateTime": 1621991189,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "53a9858c46fba1f2195bc2e3fc105b071ae97e18",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1j5kchixqzs9axz3k0k27mp7bwayjln4xks52r59rmzp1vxnld0q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/flate2"
+  },
+  "external/rust/crates/fnv": {
+    "dateTime": 1613865924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e12b53874342706c52a0cbda3cbd0b5db8ec726b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "176wqsijl9f64scdjgj92r1q4l9bb96s2wapsgj6ldg5d4sh04q7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/fnv"
+  },
+  "external/rust/crates/form_urlencoded": {
+    "dateTime": 1621047963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "253a2fa6aaf9ed7c6d7811f40e140ad95d169656",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bm74vin0rx5h0ihgzg258ihkxvmx2dsrac7wj76y8xgj99x2k0z",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/form_urlencoded"
+  },
+  "external/rust/crates/futures": {
+    "dateTime": 1621047964,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75fe13b6f38051a16e831376a2cfcd454d6f8faa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0d0w7s3rbb90x8y6sxzg22cqqlfy2zabcbbzyllq40dazg5f0rzi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures"
+  },
+  "external/rust/crates/futures-channel": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2011fa15354c33d36a1f5c43202fcbadb3e36dee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mjrc60cjhkfx1s4qzd7xjwb44wfff41p1vh1l2ibvmq3f80z15a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-channel"
+  },
+  "external/rust/crates/futures-core": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "91e97157d3b6c3f765eba86bee05847c0365ea68",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07fp7v1lcln8v4ajyafq71s80z0904i5xrmn5zqn4mv4q1az1r8v",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-core"
+  },
+  "external/rust/crates/futures-executor": {
+    "dateTime": 1621047965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d12778285194057f9ee359d1824ad6c4c6091bb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0myqw6i9ckl72hdb1yklxjn1ay4zs81pflshy5p8336lqfw7v7ly",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-executor"
+  },
+  "external/rust/crates/futures-io": {
+    "dateTime": 1621047966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43204e95bd9eb6a9cc00feb4d5e950b537b3bfd2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d573cpchcpahlcbgfjkmqj1mdlbn70p2yxhzzgnna6a931h358c",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-io"
+  },
+  "external/rust/crates/futures-macro": {
+    "dateTime": 1617419084,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3ce6eb4c1a47f84d9e9ef34c2f921400b09446c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1p5z0scaqqsngwgwgrmy1m1dzavalj8al9566q48pnrsj6xr8lbc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-macro"
+  },
+  "external/rust/crates/futures-sink": {
+    "dateTime": 1621047967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3d91a482cee5ccaa5ff30f3bdf59dd6b77d2430",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sm91gkcaif1qgalfv8pakak3jaf6x9ryy63w9hcb6vv1rj599k8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-sink"
+  },
+  "external/rust/crates/futures-task": {
+    "dateTime": 1621047968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8d68e22f5602022d9662b115e7de2a8eb46ac5a6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19p56hy20hrs8b1pd1ba6cpnhf3pcbpy1vz5hqsrnzhca1yb7mfr",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-task"
+  },
+  "external/rust/crates/futures-util": {
+    "dateTime": 1621047968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb596b174e57c6f5ae90bd01e79a0be081193828",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v5rpkakmi3yqakzwmyn3n9dvla3phwjq2y1h5rn7qm8ymvkfgk9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/futures-util"
+  },
+  "external/rust/crates/gdbstub": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "19472da78ceea5fd427bf0cb5718b0559fdb6d0e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09521zaxa0ijyhk3nbkh4y150cb5kxbr3nbkza82gspd4lagnby9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub"
+  },
+  "external/rust/crates/gdbstub_arch": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "53268edf3fddbf2b8aac5f204fcb46c13c8286f2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wsxbr0z5hxp8h4mgd6cb1kksgdkls01rfnaspyx1cshpxav0z0k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/gdbstub_arch"
+  },
+  "external/rust/crates/getrandom": {
+    "dateTime": 1636160708,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "63610492d58d561a82a8c012a56d61ca0b565204",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16simpsq12x6xq7l99pq62lag76svm5w0flsrnli9saj9mxrq7rw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/getrandom"
+  },
+  "external/rust/crates/glob": {
+    "dateTime": 1613865931,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "13df10bd4f1e81cea3c914c543b45662b1abe657",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sd6b3y7w2lhma4d0y4930sv3adi97pkyq6szd765mxzaxm5dh55",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/glob"
+  },
+  "external/rust/crates/grpcio": {
+    "dateTime": 1617419087,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "643ba3c6b3682aee224ec4f22a7477b4b16475f6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dc2x1jl20lb93833dkrjksszkqnjlwh9lzf2z34kjib5whxyicc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio"
+  },
+  "external/rust/crates/grpcio-compiler": {
+    "dateTime": 1617419087,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "994ea28aeb7c4021719b466f1d85180725f7e648",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xd739ka5f56zywd9xnm934z472c7drqiz6hqg64cw9qxgp96fyc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-compiler"
+  },
+  "external/rust/crates/grpcio-sys": {
+    "dateTime": 1621047971,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d18b1aa298c54b9ea5553490b8086d064213442f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hmydw85ih7cjdb3rdmpv1hmfqqb6wvz24z4ba9kwxn2y4vf2hnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/grpcio-sys"
+  },
+  "external/rust/crates/half": {
+    "dateTime": 1618276021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "986b8bb308ea5a5926e9d3ccc470932d93800cce",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08l0jgdfi6qmbqp5v2q8hjpf9rwqmampl9ki7qramhin3p6c620f",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/half"
+  },
+  "external/rust/crates/hashbrown": {
+    "dateTime": 1617671151,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1868f22b9863e0840e94f8c58794034d320b433",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0lkksfn0kqd6sqjlm35m4h6nv8bx78fw4c1dbkj2q82sqy63r88j",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashbrown"
+  },
+  "external/rust/crates/hashlink": {
+    "dateTime": 1613865933,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "032d02203fc3bf123951eafc9eb52766faf7877c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m1zxa9kcq561wckji7m2rsrp7h32zcsl67nz8sm3crmfiih89p4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/hashlink"
+  },
+  "external/rust/crates/heck": {
+    "dateTime": 1613865934,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "658719fff726a708d294c01091184236d3a23af3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0x4djw1sjsl4p906fpx8davjlrnxar843aiap7qph620fa8f5p92",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/heck"
+  },
+  "external/rust/crates/idna": {
+    "dateTime": 1621047974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e2dce5bb3d59adf157a58e2ab57e1f257845c046",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ymmrdxp31wpqwhfcaan2rjfhcj0gv7zigshhpcai1xv5zfb9ax2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/idna"
+  },
+  "external/rust/crates/instant": {
+    "dateTime": 1613865935,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7759821a1d41d71564a6ca02bb61321fb8cb003d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07w1pii8i6qkfnwvhsm4iivflxqq6hpbmiyq7jsw4qbigsrjjrc9",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/instant"
+  },
+  "external/rust/crates/intrusive-collections": {
+    "dateTime": 1621047974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ffb90c85db9d9a0d99a010d730226d3e3513d572",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06rv3d12ds3kdnsxlzv4318i1nykvsmh9hcvcapvhpxc8av9xj9q",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/intrusive-collections"
+  },
+  "external/rust/crates/itertools": {
+    "dateTime": 1617757538,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ebaed332a3273534fd098ade94452ccf4e5535d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0w0h9zdc938l057zjbsvai9s5mnhyx9nga55agwarflg39gr12xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itertools"
+  },
+  "external/rust/crates/itoa": {
+    "dateTime": 1621047975,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81fcd812450fb10843e421daaa31d40f384459cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rji01a0sfkfh18jx243hbm69mqjx9i013df0zwisnvq4680536i",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/itoa"
+  },
+  "external/rust/crates/lazy_static": {
+    "dateTime": 1621047976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "947e8aa046c69f1419dfb24aecfc62af7cb3dcc4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wbi944w289ihsvirwzy9y0casx6xfnyd6vlbrlp6mrly8i9f1n8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazy_static"
+  },
+  "external/rust/crates/lazycell": {
+    "dateTime": 1613865936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aea05f644cdc3b2fb2cfbbd0c69eb2106faabe50",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06di56bnsz4msyj77nwha4g1mi08k19ymh15isd79wc6x44z9h5h",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lazycell"
+  },
+  "external/rust/crates/libc": {
+    "dateTime": 1621047977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b3579dd2b8f18e7648737cab48150ebd7944e655",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zx4l0w87azhy1pc6mnvzw0ksbjbfrv6gvbvnn2d5g2plp3ssja0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libc"
+  },
+  "external/rust/crates/libfuzzer-sys": {
+    "dateTime": 1617671157,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "524a849edd4581df2023bf37c9bdd8efb926fe5b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f5a2zl26ydvffwzfw3yk2mfpy63qkhc97vbmg6nqp03jd3gxdhv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libfuzzer-sys"
+  },
+  "external/rust/crates/libloading": {
+    "dateTime": 1613865938,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8558dde305d36bfe447c2d65f4445d495dcec0ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "125hn4cvm7d73y1caagf2vm17qzrkl6hppw8icibiwzc3cvq509p",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libloading"
+  },
+  "external/rust/crates/libm": {
+    "dateTime": 1621047978,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08e1341a3ad93e00789f4b930afb325bcd1c627f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "111agfhx3rid2cgg0va4rblsdvr5xa0lpzwqbbk15nh184ckbn14",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libm"
+  },
+  "external/rust/crates/libsqlite3-sys": {
+    "dateTime": 1621047979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16be857cf361b6995747a44a31ce720fad233f88",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zw7ak9v8fayazqi33nvy6laysh2rxd424l2c8sxb5sshp9csp8m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libsqlite3-sys"
+  },
+  "external/rust/crates/libz-sys": {
+    "dateTime": 1613865939,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75fa83ec3375f6d90913d5e5660654f4b6878589",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1snrdfqxghyiwd3w7yxbp0vl0kpx6w1ciih3hhvwhfg83yh754h1",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/libz-sys"
+  },
+  "external/rust/crates/linked-hash-map": {
+    "dateTime": 1616547915,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3598416fc315b8d97547e4f9e2962d3136c14cc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10avx3pavwvc6w9pwwbkazahbrjffkq1bw4rd48fwbapsx2c1axj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/linked-hash-map"
+  },
+  "external/rust/crates/lock_api": {
+    "dateTime": 1613865940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "44a956688174defbf5aeced97d53c1ca6995122e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18m7p6hd57zbhc4nr0l63i38zk9riw8vkrs172j5zzwfc086v3vy",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lock_api"
+  },
+  "external/rust/crates/log": {
+    "dateTime": 1621047982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8858303249303ed4045316fbf987718d32b6ff61",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zzb335rk5bpi75jm4sb5pf8rmnpf6dznbd5n4nzl1i226zfqvz8",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/log"
+  },
+  "external/rust/crates/lru-cache": {
+    "dateTime": 1613865941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a6298987a37c68fa55b2673f683172e71f52c215",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cba2cgnkp681l5dhppipfidlj244mzzv0iwgi0qmaja99cdyzfz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/lru-cache"
+  },
+  "external/rust/crates/macaddr": {
+    "dateTime": 1616547917,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a4f63e4d779c84355694c06ef2ea20847bd6eaa8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ih34msm26vya16vkqxsvf0zrxxhbdgm3gbxb80md6wlv4vmskjm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/macaddr"
+  },
+  "external/rust/crates/managed": {
+    "dateTime": 1616547917,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c414f2435c846ec4a09b084b2e776f29000abc62",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05a90v3jq9yw5bj547qjx31l5fm6fafdl1mbngbkglmmw0i2bzmk",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/managed"
+  },
+  "external/rust/crates/matches": {
+    "dateTime": 1621047984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "72925e3431c8365aa0e35afa56f4a60d21386e39",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sp2ddidbl3h0hbrkbg194jpqpdb1l74pi8kdga3sxczp3dlmkyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/matches"
+  },
+  "external/rust/crates/memchr": {
+    "dateTime": 1621047984,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16fc021886188f5754b2f218b3debb910feaf364",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hwsviz4jz3c7n7lcf95m6brifngx1r6s3h57d1xkqqz6vz7y716",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memchr"
+  },
+  "external/rust/crates/memoffset": {
+    "dateTime": 1621047985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de6b308ff7f96321aa9b71891ae3dff068a022f1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1vkrp3y4l7vxcsbgf8wxfl1w9icwnikb69b2jjw77cy3r16c43qg",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/memoffset"
+  },
+  "external/rust/crates/mio": {
+    "dateTime": 1621047985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7eb01e84f5e79d38e13de4ecc1cb68911a860064",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jhji521v8686xn5zzl3myy4q6jdnsw8wn3bh6fa0cnyl60gmpb2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/mio"
+  },
+  "external/rust/crates/nix": {
+    "dateTime": 1621047986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9ad34ca2a7ecdeeb866c9c1adcfa06107b907712",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wvpj5950hvj55gajh3yp2pf514shscnp4z39h9md9rjzig9qwr7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nix"
+  },
+  "external/rust/crates/no-panic": {
+    "dateTime": 1613865944,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f95a9a278af7680084189d96f87de6b09a38e78",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cz0nj5d58s0p03pf4j3k14d9my2iss4gap87ln7fkx63kll7l9b",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/no-panic"
+  },
+  "external/rust/crates/nom": {
+    "dateTime": 1613865945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a73daa8f73ebc829af402b23068a4f0a9b275b3a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00iz5lgxgdlshwmsbppiw509y574dicmk3zfyba4xz0scd564xnv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/nom"
+  },
+  "external/rust/crates/num-derive": {
+    "dateTime": 1613865945,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4d536283b17ceaf78f06bba443ea908f56978f84",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07l72iv3aikhcfywfll8rjh7ylclndxr7cidcq6a8i0klxfibiv7",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-derive"
+  },
+  "external/rust/crates/num-integer": {
+    "dateTime": 1613613943,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0549f12c1bc331d85a89bac3ea14d436271b6f5f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b0i5j8vgn1xvp66dcwdvfcq8hymn7hx04411lrbcha9v1zrjl23",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-integer"
+  },
+  "external/rust/crates/num-traits": {
+    "dateTime": 1621047988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "312dd377909cb214d83a68be1767fa10fb55b736",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05ar1k2x8pqqr9hn4cchy5kbv5cg80aaxq0k6xp794m3cn7j275s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num-traits"
+  },
+  "external/rust/crates/num_cpus": {
+    "dateTime": 1621047989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d7bb6ae1bd1b3c41b24a94e25746288b2b76f5ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13l3ss2303qgx780ppsp7y8zkz5rh78mznml1mbnhk1j177zdjwp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/num_cpus"
+  },
+  "external/rust/crates/once_cell": {
+    "dateTime": 1621047989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04de0b0e68086f49b0e6f133dfd44c738f573ffa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pn4aj49f25r5jz4dm9wmdf1rmmghzff2yzplikbgkx4kl31q5zx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/once_cell"
+  },
+  "external/rust/crates/oorandom": {
+    "dateTime": 1616547924,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "df110e841b1ac754a22070f3310274c94e87294a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05xsrs0hvzh9z28lmfq3slmjzia6dg6nqlsx5qzwzn06qximykaf",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/oorandom"
+  },
+  "external/rust/crates/parking_lot": {
+    "dateTime": 1613865948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dad15a9fefd6f701e7a8fc58361953d24ff74d76",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lfv9la7lm4m8k5wln2xv4ghv1yv4z99mgzl2rx5hz1rfrgg38g4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot"
+  },
+  "external/rust/crates/parking_lot_core": {
+    "dateTime": 1613865948,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b13c02e5828c64b3a5040e19a72eb423a3d9aecc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rkzqb6is3c3s08m4gf16s17i6siy5xhcc77s25rwlvx6waq4k8d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/parking_lot_core"
+  },
+  "external/rust/crates/paste": {
+    "dateTime": 1617419107,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "70c6c1b386a15196fe4fd802416ec46a693d261c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vy1knxk1rckadyjyl72dcyqc6wz8dvq0c986z3652cl0g0q1pji",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/paste"
+  },
+  "external/rust/crates/peeking_take_while": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e57dcfb2031065e3755607e0ecd717f1da619b15",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12901vqlv7ciffpdq7bfdcfx2vpylwv16czvrm6174g7d9l68fv3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/peeking_take_while"
+  },
+  "external/rust/crates/percent-encoding": {
+    "dateTime": 1621047992,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d8cefaa7acc955d122e837b5d9f8033df47fb036",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vrdcvkv72306calx7q3hxmsk2b0kcac9hjn9s92l01am2svpa65",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/percent-encoding"
+  },
+  "external/rust/crates/pin-project": {
+    "dateTime": 1621047993,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7658bc99a331fc1507d55f46aa3cd71f9bd80424",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y0037f6zw4qyjjmb8qgxr15mdf8a36iym0r2in978bx6vickbyd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project"
+  },
+  "external/rust/crates/pin-project-internal": {
+    "dateTime": 1617419109,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b63bfebc8118cc01b78053cf12c1fa4bf008c724",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dyjczyl7rjyj3qlslhvks0cb5hfmiz98g6il06837sl7sa7r435",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-internal"
+  },
+  "external/rust/crates/pin-project-lite": {
+    "dateTime": 1621047994,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b94493a6b31106ad769b5d86f8bbceac84f17837",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19hx6g9vkwl07f5d65irylb82dj96w9sfcrpk2g5jnj4q35991di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-project-lite"
+  },
+  "external/rust/crates/pin-utils": {
+    "dateTime": 1621047994,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "34f4a652b144fe95057cfb80a0e6476a84a7e9cf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wc5x25b440l1qlfslhpvnm9yppwxjmx284wy7s0wz9jr9ikdn3k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/pin-utils"
+  },
+  "external/rust/crates/plotters": {
+    "dateTime": 1618362350,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a719b4c2ce507c0b15f19053639a754fad89897c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0w3hzsr0hz5zz7cyn9r6hscan9arf8nbiq6fbgjaw67vjzzgjamd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters"
+  },
+  "external/rust/crates/plotters-backend": {
+    "dateTime": 1618362350,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24dea44c57a1bb20df6c9eeffa6093b58d4ec80b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f6vxfgg2nb130cs0ykr4clhzwm9sd37hh87zk53v2yh1k2nsx63",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-backend"
+  },
+  "external/rust/crates/plotters-svg": {
+    "dateTime": 1617757558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "613cdd0611c0760576235aab50ff374e249cbe6c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0knjd1657r31h5djbkacpiapax09adk2ryf8izayli46ifyx11bz",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/plotters-svg"
+  },
+  "external/rust/crates/ppv-lite86": {
+    "dateTime": 1613865952,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2afa54124c888f26b2f580a1049b325627bac6dd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02gkxcgik9jaw36hm59bs2pkgirrgz71ngsmxdda98h1ydip7i04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ppv-lite86"
+  },
+  "external/rust/crates/proc-macro-error": {
+    "dateTime": 1613865953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75e1fc516c5d1bf126fe282ae77049dbb211853d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1knxgc7r9x289qmm38vmrh6sdyfp06i4n4ajlknyirb7gkqmw2br",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error"
+  },
+  "external/rust/crates/proc-macro-error-attr": {
+    "dateTime": 1613865953,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48229537bd8bb74f7690d5ac73f62c3c99eef3d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00zdh0yjlvp8lfc55a9vpf30b1q4m5cnyqdd1sfxxjlfv5fjbddc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-error-attr"
+  },
+  "external/rust/crates/proc-macro-hack": {
+    "dateTime": 1613865954,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d7da71cada868a4f231bb20ca58756f61a72bc88",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k1ljy6alvx8hq3ym48ajavdljr6199xfd75ql72926nwk9aszxv",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-hack"
+  },
+  "external/rust/crates/proc-macro-nested": {
+    "dateTime": 1621047998,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dd84b011bfd37752f4dae0d6ddaacc2227d34e44",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cm5csfpjbxbqs80javai4s0cdaz1d0a9i9mj45ck1dr1k9xzd5d",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro-nested"
+  },
+  "external/rust/crates/proc-macro2": {
+    "dateTime": 1621047999,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dcd6307d4e307046e5acd6ce052d3e5254b844ff",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01f5n87cdwhmw31b2433hv8fq9345haqhpg6k54as37g5pf4r052",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/proc-macro2"
+  },
+  "external/rust/crates/protobuf": {
+    "dateTime": 1621047999,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4b0e1034d4abb865d3a7453e05fdcd4204e85d7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v05llm5p3y1w36vnxlb58n0p5bdg5k2sr9vjrcq14biqapcm3di",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf"
+  },
+  "external/rust/crates/protobuf-codegen": {
+    "dateTime": 1618023958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e09498a7e6330c0cb38d6102be20760d1d592e46",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yp4dly0d57gcyh4jp76jkvwxrbnv5w8vdklfmdd2gnad3gg5qjp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/protobuf-codegen"
+  },
+  "external/rust/crates/quiche": {
+    "dateTime": 1621904896,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e03c02a516b421b02f23a5a6c2997b01370b3470",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09r61vnj962kpz4s4r47mj21823244lnm60j0vnf9gp6yr10xv6w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quiche"
+  },
+  "external/rust/crates/quote": {
+    "dateTime": 1613865957,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69fba7350abb79cea0e1f9000588bd8aa647d586",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lmnm2xvq7sqz0vqprqfgah04rwfgs3jga4za3ijpzmqr4bfqxbs",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/quote"
+  },
+  "external/rust/crates/rand": {
+    "dateTime": 1621048001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "668e5952a703ceecf97efcc2fba9e096113bc319",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1q0xgznpka23616c4c52jw87yf2yf1nqxk4nrbs37idvdax3370w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand"
+  },
+  "external/rust/crates/rand_chacha": {
+    "dateTime": 1613865958,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48396769be41b1fd959093b037c613420e0a725e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11nlq925r5jay7akqzimrk5lpr38cyi5izlpzmjqs73jv6j21n4l",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_chacha"
+  },
+  "external/rust/crates/rand_core": {
+    "dateTime": 1614470744,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a874ddce1cd69c5d939ab3facc194c0e0a1b4df7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yagpl8553a611mywlvf7zqdsqdgqh661y51lw0b9alh3m0dix5k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_core"
+  },
+  "external/rust/crates/rand_xorshift": {
+    "dateTime": 1613700377,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2eccecb180ab99571cf2662eb006c47da7a0bafd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pxla85gls4kib4ydlpzzsj3yw2s7ryk1yvljgjx7avkam3ba86m",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rand_xorshift"
+  },
+  "external/rust/crates/rayon": {
+    "dateTime": 1616547936,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "14567b91bc03c22adf6cd69907fbe317051f1b12",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xffdyamd965vw93hl7zw6mgip01mybck8pfljr9msza39wfvp34",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon"
+  },
+  "external/rust/crates/rayon-core": {
+    "dateTime": 1616547937,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "54241b9278355fe81ad5f9704ff3d52cffb547c2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kswciinmwn6f3xfgnxgqpnd6m3v6sm3m7d14vn2xp7938hi7s9w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rayon-core"
+  },
+  "external/rust/crates/regex": {
+    "dateTime": 1617419120,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "101add012c39d75efdbbba5cf5ab732e35b06acd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0liqpk6bqwdypjawgcgwpdiy76a6ab5vvhi249430spb8552rvr2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex"
+  },
+  "external/rust/crates/regex-automata": {
+    "dateTime": 1616547937,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4abcd311dda38f8b87ce939809cac16af45f7ef0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "060cvq9v43k2wca81bcyxyqspgyww0lw08xkiq0bznrql2vp7f04",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-automata"
+  },
+  "external/rust/crates/regex-syntax": {
+    "dateTime": 1618362360,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d55223a96323c0a1f8817ac0b57ad48a9c99a970",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1amzxpm2072myiyzwqvipr1nsxbdikhz49pvm19kbzmasnnx7gin",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/regex-syntax"
+  },
+  "external/rust/crates/remain": {
+    "dateTime": 1613865960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef5e7ac312419c3de3409392216aac11a3cb0f49",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0d53xbgp935395b99anix9l3193ss2imi0dwzxqpr1b3x5imbff6",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/remain"
+  },
+  "external/rust/crates/ring": {
+    "dateTime": 1617843976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b32ed712d107a15263728bfd092c1723c1a822aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1svc2bj08si0x9frpkz90i7zal3lxbfi4kgl20w8r4018hk30c28",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ring"
+  },
+  "external/rust/crates/rusqlite": {
+    "dateTime": 1613865961,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "380bb4be49df6ae0f84050ec50dcd9da7997f510",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vq390rcdxx95pnj75j3dp393irh0rxsc0frz6mwpcfy7qvlkz7k",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rusqlite"
+  },
+  "external/rust/crates/rustc-hash": {
+    "dateTime": 1613865962,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "96c9f36f88db60c2b8e5c65836991d7812ac2366",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v30cz4b7ckpz4i6yzcz4xcnkjvvpfd9ijz2qf0xzfqjaybfhlyb",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustc-hash"
+  },
+  "external/rust/crates/rustversion": {
+    "dateTime": 1614470748,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eb631a126bfbb2cffd93e08d88d70ba5fb0b450b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jjn769sm5h0j1g2ysxip2c3qn5fgiyklnc80kpwpbc8pz359vlm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/rustversion"
+  },
+  "external/rust/crates/ryu": {
+    "dateTime": 1621048008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93df76c273606106940d1ceca0a67981ee217fc7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0x7nx4w6pmy0bwbrlqgkdmjmbp4823gd1mfxxk240g0wy7zbpc8w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/ryu"
+  },
+  "external/rust/crates/same-file": {
+    "dateTime": 1616547941,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb10d93155a1d068657884ce899517e53796164d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hqv1pdqmjpnicwzmk5ysjicp552l61ppqv9liy201iz7bl2yagn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/same-file"
+  },
+  "external/rust/crates/scopeguard": {
+    "dateTime": 1613865963,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81a7bdcdb44f7d995900f7842cab4387345066d4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0yc9w5xz3vyjyyw17la529kz4jy4ayk1s98js871ha4xkbjwh840",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/scopeguard"
+  },
+  "external/rust/crates/serde": {
+    "dateTime": 1621048010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09fbb07280d3a29d3732846166c85808f1dfad8c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z74h4ir11fk52g0fs54mmalc4cd1ixycmngz3dam3li86hami8n",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde"
+  },
+  "external/rust/crates/serde_cbor": {
+    "dateTime": 1616547942,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe9d255547b35324b436d0c0030d59163bc8d633",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hcd2xar0ymvly9qn9sxkwzg9cgx4isnks3v51dfdhz7np2rrj06",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_cbor"
+  },
+  "external/rust/crates/serde_derive": {
+    "dateTime": 1613865965,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5cb25a75d396b6501167431f18541bd6ede6cf21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1api77r6ylamm2zlhl76n3jbfrzqkqbjq42kn9y3bq6akn7ixvw5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_derive"
+  },
+  "external/rust/crates/serde_json": {
+    "dateTime": 1621048011,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "49d35e12abfb979dc577e22ee52111d13f96c95a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qcw6skd8wqgy6mdh14am0wp30dlc7cwp09fg2ml0k3w6d6zrz62",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_json"
+  },
+  "external/rust/crates/serde_test": {
+    "dateTime": 1613531823,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7c02525135474fb18c954782d9008333e394203c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07hdv8n29f5rrngjn7qxmq9dw37j1y5awlbpga204jzj52bg8sax",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/serde_test"
+  },
+  "external/rust/crates/shared_child": {
+    "dateTime": 1621048012,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "80a2d1acd5841571a76b1f4d4780ba307005cb7e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l52r5sxgr164fqmlhfhdk7hr5jwwqfrp558pk41h314y3pr1gg4",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shared_child"
+  },
+  "external/rust/crates/shlex": {
+    "dateTime": 1613865966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "28377deb00588ca5d438aa774839f12368922577",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "135jawxfirwgh6dh0k25bl1k8acmvpwwpah62dcr775x3g885srj",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/shlex"
+  },
+  "external/rust/crates/slab": {
+    "dateTime": 1621048013,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "81badf05d318b4849b8c1615ec3653aeef5490a6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rvrph29d850l06wi8z0j3gzsnfbzlxnpgpqwxqwy3nqvvi90d9s",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/slab"
+  },
+  "external/rust/crates/smallvec": {
+    "dateTime": 1621048014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc1a93d42b61e14334ab499f1820fa3ba7383635",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02mvm1c3d9axdf9qkg2rylvhp7sgxcx9n338xfmaaq1c76wy0l7x",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/smallvec"
+  },
+  "external/rust/crates/spin": {
+    "dateTime": 1621048014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "259993f9034f996f36687c02ac21b5cce2610853",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00kv0aicmq07y6i44hz382h4fzhz4gbl31ckbch0f9c6xyhm0g8a",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/spin"
+  },
+  "external/rust/crates/structopt": {
+    "dateTime": 1621048015,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "545c04fa1e1dad0a1994319fa04f2ff924e5df76",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0n6lk2i8z0brsrg8gilmlx58h58c6j02jhln9rm9x9r13vhy09fq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt"
+  },
+  "external/rust/crates/structopt-derive": {
+    "dateTime": 1613865968,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c14404ca91de2bef127afe88fb723a00cfffbdba",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16yjhl98qilspdi2rk0bhs3ckav3rysdccbq7nm6w6zpvn4jm4zq",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/structopt-derive"
+  },
+  "external/rust/crates/syn": {
+    "dateTime": 1621048016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41d0c2e2e06151870b3844f067faa71248dcd876",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "086z6n4nkw8sdjwjfvnrzrsmiyahq2s6aw4fp776kgwg7lxl7shp",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn"
+  },
+  "external/rust/crates/syn-mid": {
+    "dateTime": 1613865969,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc70d63b57aae1d3a95dbd11091ed926eb28d485",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hhvqxhk4rkwm0qkfh71rc1h3p1naldxw11691igmn6rgr8q94in",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/syn-mid"
+  },
+  "external/rust/crates/termcolor": {
+    "dateTime": 1613865970,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "183f200505293edc806d3bad44c378748584638c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cqjgbwvccydjz2xrsrbsia3lmfzw275g1lmxw4jla1zfja4q9n0",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/termcolor"
+  },
+  "external/rust/crates/textwrap": {
+    "dateTime": 1621048017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f8759e37159a4d0833bbbe3c6d1a8e7545c7137",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hc46d3jlx6v5swfj4d0p9267snl4xx6wpwx26s3bb4s98z4bdfn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/textwrap"
+  },
+  "external/rust/crates/thiserror": {
+    "dateTime": 1621048018,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d9e6e6e02ffe0386dfddce2e1fd5bcfd9a65ffb5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02n6qiz8qpq972a06xdzgxs5bffpgs6mwx63chyxgnqy6726flh3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror"
+  },
+  "external/rust/crates/thiserror-impl": {
+    "dateTime": 1614650776,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dbde016fdbbfd5694581daea6674ac8600507eb7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gg7s24ady7zlh46nffk7yh11rrddg8wvsdcr7c711dsbxxb5584",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thiserror-impl"
+  },
+  "external/rust/crates/thread_local": {
+    "dateTime": 1616547950,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11dfefc5032ace2e49f7f0a786e994cc0837708c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ln79byy89kpxygpqd11bbi5xsjypy1n28wrp91hy6sx786hla85",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/thread_local"
+  },
+  "external/rust/crates/tinytemplate": {
+    "dateTime": 1618023977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "76b2cb767281881a0216e09f9ba6762094812f29",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10wg6wj3bzynr1z9pb50bmr6pc8i7xq56lwjydgwilhwi6p2g96w",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinytemplate"
+  },
+  "external/rust/crates/tinyvec": {
+    "dateTime": 1621048020,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b05c32b096c74bc49f1d2fa2d9cbb2077628d168",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1iarzdmdck0f5fdwidd665m45wxl9aj32s1lm30nd5379cprmrwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec"
+  },
+  "external/rust/crates/tinyvec_macros": {
+    "dateTime": 1621048020,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ed6d2df425dc948b4eaa590c1b535e813c4c62fa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0y1c5xaq9nbiyi52zaapdbbhm7vmq6hizxmg0kd0nlyagd95smsx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tinyvec_macros"
+  },
+  "external/rust/crates/tokio": {
+    "dateTime": 1621048021,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb051f23b42ca82868fbd7b5abd014ab99741764",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zjh0cik5kwp6vfisza3bifjyplp8ymc52navzgqyf2zc5x4lnvx",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio"
+  },
+  "external/rust/crates/tokio-macros": {
+    "dateTime": 1613865974,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efe33c123acac25a75b8c66a4991ebdb8ffa89c2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0py405c2b4bci1gj7gf4swv8s80fzqncm8kppfv04xd78ph9mmwn",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-macros"
+  },
+  "external/rust/crates/tokio-stream": {
+    "dateTime": 1621048022,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5b50d5ce0132dfac5b5185c1dc24c462bf96855",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1369f0daiyy9yvbf9k3caifcnp7b2wjywy29if55kl0rb0pgs764",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-stream"
+  },
+  "external/rust/crates/tokio-test": {
+    "dateTime": 1621048022,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a89e75d72c08f510de66fcd97ebd8f20ff84ef9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r8ddxhlrqdi8qwwj9frqp40l8jzzp3jk2w3bmm31n97sp8ma0xw",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/tokio-test"
+  },
+  "external/rust/crates/unicode-bidi": {
+    "dateTime": 1621048023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9646f821e1e23b37af509603ecea388a3fbe6697",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r6bd31wn5nbs18rrgaf47gyrivlxd2rni86qm78f4r7kabzadhc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-bidi"
+  },
+  "external/rust/crates/unicode-normalization": {
+    "dateTime": 1621048023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "230605d170ce3d0237f42e746339f53c34c4b517",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z5amlnpv23q5n01093rx4j6byjc58yg1r1y0f0lcxxky293r718",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-normalization"
+  },
+  "external/rust/crates/unicode-segmentation": {
+    "dateTime": 1613865976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "05141c2d5a653e8336b27a9a9530a76f9ddb9c5f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07fp8jn2fm4jpy523ifpc7fh9gsb1dqja1x9f508ggigmklgxhic",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-segmentation"
+  },
+  "external/rust/crates/unicode-width": {
+    "dateTime": 1613865977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "359479a94b1a7511317d4de2f0dcd6f00756da84",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xqr3v1kq561xbw126kj4xfvysd47sfj7rz4ld9pr9vm1nxmgr46",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-width"
+  },
+  "external/rust/crates/unicode-xid": {
+    "dateTime": 1613865977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "20686bcfee0d59abba1e144578b78fdef687be66",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11j24rxm4r9zykcidasjhgiy37p1lqrmkpa7dl0rdb7c1hyj7lnc",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/unicode-xid"
+  },
+  "external/rust/crates/untrusted": {
+    "dateTime": 1621048025,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e3d6a5039597d3d95de9aa69b58347ea3a3e68cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "135jcnwi4f8a5lx7lphdc9w9qsdv0xj63lxh7wxgkkz00d12hh93",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/untrusted"
+  },
+  "external/rust/crates/url": {
+    "dateTime": 1621048026,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "09d0886827825b93a9aba17986750cb146d2af8b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wm10msikrg7l999qkrwddiy6q609j07agddz71gk83gar6nfid2",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/url"
+  },
+  "external/rust/crates/uuid": {
+    "dateTime": 1636160765,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9dadc9a8168f0fa4dd9315a5a305c57ae7deb972",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pc8c5dfr58srbz9f9fpdx9gny327kprvxf29bvzhi4cl790a2p3",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/uuid"
+  },
+  "external/rust/crates/vmm_vhost": {
+    "dateTime": 1636160765,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aec81ace25792cfde8355fbaf50ae12512b95e71",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mcpfjh0yvbgbhn1v4n71rbai4spcxb9v2iy1cr859wh679niq77",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vmm_vhost"
+  },
+  "external/rust/crates/vsock": {
+    "dateTime": 1613865979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "48b3e8bd27b761d62219444bed8ca8d54c42104e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13x5kiyz72rcssg5ldfdq77ss5xq2q6ixixijcn4sq5411j75dmd",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/vsock"
+  },
+  "external/rust/crates/walkdir": {
+    "dateTime": 1617419143,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e637704eae622d99d80a9a1c2c6dc8a1f5b2e3fb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "081x2cvl8zh0xh0nb2402kgdv1pak1j5hijlh3iz3msndcsqgrmm",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/walkdir"
+  },
+  "external/rust/crates/weak-table": {
+    "dateTime": 1613865979,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "671a2d894b98fed40b9b048cafa71e75780ede2c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18hkrqykf2rh7hbwzvxmwr58ixybbi7m6sl9mvb3pwk8yf2qzq43",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/weak-table"
+  },
+  "external/rust/crates/which": {
+    "dateTime": 1618362382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "60f29d955f1ad507bfe7fc442a26bcd56ecb3af4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0svgz9mn1d6a14dnhghvw102s82bjyk3s9kh5ja6h08kwch2yzv5",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/which"
+  },
+  "external/rust/crates/zip": {
+    "dateTime": 1621811192,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6ac6f64dc8d73975c3b4d2ef80d89ef51d6cad1c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07da00h2m2kar3r2r891jhc625d5z99jb03vb3c56135kiasnzqi",
+    "url": "https://android.googlesource.com/platform/external/rust/crates/zip"
+  },
+  "external/rust/cxx": {
+    "dateTime": 1618023987,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9ab49b1d48e70017188c0adf5432096b19a0f94",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jlw2bpzhynqzgdaw4f23j41njwxhd47gi3iy64g29z6hqicmdcg",
+    "url": "https://android.googlesource.com/platform/external/rust/cxx"
+  },
+  "external/ruy": {
+    "dateTime": 1616029584,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b7a820d079f92c6e418c6fb328c71c8b83d62166",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sl38mw33dcla901rq0dmw98lvpdsnwyis8fsxr5qkvar7fsfai3",
+    "url": "https://android.googlesource.com/platform/external/ruy"
+  },
+  "external/s2-geometry-library-java": {
+    "dateTime": 1615341966,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "39e6e4f4b95da0f5ac216e01606d90fc4e5c7f92",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x5lyg0jhcnyh647vyyhn28l7x3qgf3x7b5pasd732rqi6kkcibz",
+    "url": "https://android.googlesource.com/platform/external/s2-geometry-library-java"
+  },
+  "external/scapy": {
+    "dateTime": 1614909950,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f3920bc6038e898e0c71c0adf4ea82b50f6b283f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vq0sjbxagkkinxvzx77h6sxcvqlbl9fz9z5845q8kb9wrf2a0b7",
+    "url": "https://android.googlesource.com/platform/external/scapy"
+  },
+  "external/scrypt": {
+    "dateTime": 1612577190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6494bc6849ca71f7d5c986ed69a5bcb60a4bec36",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12y4bhrw9wbp470b6pzpwcnxgy8nvlaskwa13vvpskyydiwxwr4f",
+    "url": "https://android.googlesource.com/platform/external/scrypt"
+  },
+  "external/scudo": {
+    "dateTime": 1637280366,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a5bddf2d9d62a367f55af56a34f757b99fefe422",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05429chi5gla921898w0pfr40sw4am433xhaqbcafchk9yhgnian",
+    "url": "https://android.googlesource.com/platform/external/scudo"
+  },
+  "external/seccomp-tests": {
+    "dateTime": 1612577190,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9fd6f4b29a34fc784b58d3ad2c7b9d8bcee9a621",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "150n3hfdna544dfxw4xcd74idcz1c6rzdfzpxz26pv88ki79nzds",
+    "url": "https://android.googlesource.com/platform/external/seccomp-tests"
+  },
+  "external/selinux": {
+    "dateTime": 1621048033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "946dd56e99ec0b201311a94a8df30f12e41b917c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19lc7df0wygsx22iljwg3528vxsib78ancc1rkq7xjdkhcv8nz7p",
+    "url": "https://android.googlesource.com/platform/external/selinux"
+  },
+  "external/setupcompat": {
+    "dateTime": 1639008446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a8be07f5a381051ca60f850b776cd6546e78dd21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "088kw109h6izpiq7abm3gkl8gz3i6zq2fdbayk6ikg1w1v5dxnhs",
+    "url": "https://android.googlesource.com/platform/external/setupcompat"
+  },
+  "external/setupdesign": {
+    "dateTime": 1639008447,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e21f3b9546333590bd8e50ab00308523e7fb3198",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12blkkjlfdqkxy04idacg00qdnldqygnpp51b76vg41gblqacwj4",
+    "url": "https://android.googlesource.com/platform/external/setupdesign"
+  },
+  "external/sfntly": {
+    "dateTime": 1613952381,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "ba24ddea1088070ba8becc3f72ebc33e6a54b2a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kakd4icw5z61imziwk9xrvrmzr0kz0c3xkx7ajqf313jl9i895w",
+    "url": "https://android.googlesource.com/platform/external/sfntly"
+  },
+  "external/shaderc/spirv-headers": {
+    "dateTime": 1613613977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e7a63d1695e0abef1dab17d617e6e296d674a8df",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1krwchhxqhsgjkj701884g0b40dh0j0ys78psi5g1mzvllbcnpq1",
+    "url": "https://android.googlesource.com/platform/external/shaderc/spirv-headers"
+  },
+  "external/shflags": {
+    "dateTime": 1613865986,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "639c1f0ffb269b9db25eb69a174ce29d4590851a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ffv97gprb7a2j3apfj97ss1ddj4l6zhpjacr63kxkwd4cd1sx5w",
+    "url": "https://android.googlesource.com/platform/external/shflags"
+  },
+  "external/skia": {
+    "dateTime": 1632265566,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "0ecf98e30ae326a71d30bd0a823e887628daf577",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06y1y8148wswb0y49ziax0yiw4d7v5glzp483dsx2pzn52ggkj97",
+    "url": "https://android.googlesource.com/platform/external/skia"
+  },
+  "external/skqp": {
+    "dateTime": 1613865987,
+    "groups": [
+      "cts",
+      "pdk"
+    ],
+    "rev": "998a6f6b9b46c386c8860b67186e56abf654b9e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rbdbripv9gbym5rannpyjycz7jc02rdsnf92l3ji6xz1k962a0c",
+    "url": "https://android.googlesource.com/platform/external/skqp"
+  },
+  "external/sl4a": {
+    "dateTime": 1641607554,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "588f0d78c1824dddab87ffcc6ec2691d6124c459",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ir1bzc0hhj260f5gkz6w5azgqqhdl5l0bg7zms1kqbqd1p582mk",
+    "url": "https://android.googlesource.com/platform/external/sl4a"
+  },
+  "external/slf4j": {
+    "dateTime": 1613531844,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "719e1a3c64ae557723dde823f3800ff43a45f150",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rqxhr85x42h7nl59j3hg9zdn3f8wgv44dk8g2nmvgzfd3l63ymp",
+    "url": "https://android.googlesource.com/platform/external/slf4j"
+  },
+  "external/smali": {
+    "dateTime": 1613865989,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa661bc3a4727c28ca3bb0be91409d31d7760a26",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m2z3hm7q7hyqfabnw21sglarig5g5kjhv4b12387ckx9lzyxz9b",
+    "url": "https://android.googlesource.com/platform/external/smali"
+  },
+  "external/snakeyaml": {
+    "dateTime": 1613613980,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "312da0259042e842b2faf43c508609749cd4f8ae",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11fyx45gqx1rqbk9cghj8lliv7g7qhfrfdbif9r0zjrmq56ap128",
+    "url": "https://android.googlesource.com/platform/external/snakeyaml"
+  },
+  "external/sonic": {
+    "dateTime": 1612577197,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04abe8c467916f87e15b3f5be4bad48d206a733d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17yl2bd3zy8wf0s2snz5734w3appr33c5f3f0jayw9crzdb8kksm",
+    "url": "https://android.googlesource.com/platform/external/sonic"
+  },
+  "external/sonivox": {
+    "dateTime": 1633475174,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "36193f6084a9138cc3104c17042bb58feffa4fbe",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z3w30hz7782xww6qgk3l5h7j899cdbvmnxvrwq28hnpmdhqlmap",
+    "url": "https://android.googlesource.com/platform/external/sonivox"
+  },
+  "external/speex": {
+    "dateTime": 1613865990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1c1872fa3693ff781d8549fffe2062f187560b3e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b4iafcxynjq2y0i6hh3j7wgqzr51bnqm09ngwql72d12g7pvx8v",
+    "url": "https://android.googlesource.com/platform/external/speex"
+  },
+  "external/sqlite": {
+    "dateTime": 1628975180,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1a051fe961fe7050fd9a456921fb2194450411f8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nfx4l4ip228y03p6wpd5rwyq0sl8101xscgr3nb981vn2b8nny8",
+    "url": "https://android.googlesource.com/platform/external/sqlite"
+  },
+  "external/squashfs-tools": {
+    "dateTime": 1613613982,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bc87d35d27eb53537abc165df4f66d70f27b3e4b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18yry9s66q0569l6kgnavxd84lpgqqg2zh7wqad7i7ca8kppagqn",
+    "url": "https://android.googlesource.com/platform/external/squashfs-tools"
+  },
+  "external/starlark-go": {
+    "dateTime": 1618096003,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "149dbbb7f2b78bdf2b40916e0dc68566b27316ae",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kq1npxz7skla11q33az976l0kk4n5wpf3djyrhw0kglcd176vi2",
+    "url": "https://android.googlesource.com/platform/external/starlark-go"
+  },
+  "external/strace": {
+    "dateTime": 1613613983,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0cf80c7f055138d60cd9501d36a8b0dcf860b9f4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rx0660d6z6s9id9mh8kjbmalm7qj38qrc3557k817iy81ac6n3g",
+    "url": "https://android.googlesource.com/platform/external/strace"
+  },
+  "external/stressapptest": {
+    "dateTime": 1612577200,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26b25b035996752bda71f060f916aba71a257976",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q9kbldax37x783ijnbwsr052kmqb87hs0m6z0cpnw29gdkmfai1",
+    "url": "https://android.googlesource.com/platform/external/stressapptest"
+  },
+  "external/subsampling-scale-image-view": {
+    "dateTime": 1616029596,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "447eb97dd836996ff48a4821158e378edb27dba5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0brk3l0gd33d4h8rjb06r7vnlaz821yc3bhpsyskvfv6inkpxh1s",
+    "url": "https://android.googlesource.com/platform/external/subsampling-scale-image-view"
+  },
+  "external/swiftshader": {
+    "dateTime": 1615856774,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "94f4a77038b255a12e27751a4030c043813e2cdd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19drp33i5ha2qlxj3xgv37s8lxx0h0gmzh834fga2ydiazc2lprx",
+    "url": "https://android.googlesource.com/platform/external/swiftshader"
+  },
+  "external/tagsoup": {
+    "dateTime": 1612577206,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "629c9ddaa04e81c8abc54288442c9022dfc3d742",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "092v7vx5md9lkgsnds9iaknsx7n1hm7daazy3icmahiwkq3fs684",
+    "url": "https://android.googlesource.com/platform/external/tagsoup"
+  },
+  "external/tcpdump": {
+    "dateTime": 1613613985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03fc515212f89531df041d90287b385f395e3269",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sy5691a5g4lbdzq449jlywn2pl7g57bfc5a70238ivdi57351bs",
+    "url": "https://android.googlesource.com/platform/external/tcpdump"
+  },
+  "external/tensorflow": {
+    "dateTime": 1616720777,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3175886f1297953f7d6ac7b10d16240f6886ae0b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "163p13dy1ghbpii05y2z2ljcnaf6w40i1cbd1ipv0wbf2pi57d7y",
+    "url": "https://android.googlesource.com/platform/external/tensorflow"
+  },
+  "external/testng": {
+    "dateTime": 1613531848,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d317ede9dd0d0b67c09eae9a07c4f6713822c638",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06hxhlmx7958xbfj925xcmmzm5h3s16jxwqcahh5yp4zzn19af37",
+    "url": "https://android.googlesource.com/platform/external/testng"
+  },
+  "external/tflite-support": {
+    "dateTime": 1616547976,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b2b68fc10f288da4581cf278187443202a09dcf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00mj6sp3h53wpwgyfwmnxfch4j53sfbdijfrwg1n4g0ymafr2adr",
+    "url": "https://android.googlesource.com/platform/external/tflite-support"
+  },
+  "external/timezone-boundary-builder": {
+    "dateTime": 1595932940,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d43285f07881090ac8edfae9e094c0568910f12e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09laamss9pk6q4fbl6gppz8d8ix47qvazqd3r8x4p36qga68n6wc",
+    "url": "https://android.googlesource.com/platform/external/timezone-boundary-builder"
+  },
+  "external/tinyalsa": {
+    "dateTime": 1625188199,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3019c91f9df5d5e770543b9fde6f05b6e1145913",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ka8qwa9j78gsiygs7rlk78lf79yir26202rf0j26xwb5aq2rw7r",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa"
+  },
+  "external/tinyalsa_new": {
+    "dateTime": 1626743249,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "92bf6ae860b800697728600d54ce13165d76835d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jjl611jjrh65kk92zdp5y5jar0qyfrcv2yz86wsf71rld5ljm48",
+    "url": "https://android.googlesource.com/platform/external/tinyalsa_new"
+  },
+  "external/tinycompress": {
+    "dateTime": 1613613988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f6c68bf178e7ada313f59392a1c4581240d953c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "148k9dgzbrrrpx8c1f8plv9zdv66m0kia8ijc0j4mgfz05cnl0wa",
+    "url": "https://android.googlesource.com/platform/external/tinycompress"
+  },
+  "external/tinyxml2": {
+    "dateTime": 1613865998,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "734b490c2587cab0b522896fd62a9fcda36d658b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02cns5hw21sqy0vdd7601aj8v4cdi4rzm08fvpf8xav04xc6n4k7",
+    "url": "https://android.googlesource.com/platform/external/tinyxml2"
+  },
+  "external/toolchain-utils": {
+    "dateTime": 1615428376,
+    "groups": [],
+    "rev": "11c464e8cfb118e9f3ea87b3e5bb514f757358c9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pi0shn1aqwn59yxids5v0jnbbhn3gafplfhp5iy9waazwhl3pfd",
+    "url": "https://android.googlesource.com/platform/external/toolchain-utils"
+  },
+  "external/toybox": {
+    "dateTime": 1621048050,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ef56de5b93e15a1056f0c03d85d1617afdc8960b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19msz3f8ggk2qy0xif0m92aa528phlg74ibssy2b447yj735vkrn",
+    "url": "https://android.googlesource.com/platform/external/toybox"
+  },
+  "external/tpm2-tss": {
+    "dateTime": 1613531852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8bd42b3dbb9207c810f2188016291c040fe93a4a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11niy75h4yrwp73sbrx24v36l20syyl77cvnfy8lnxz51khs73g8",
+    "url": "https://android.googlesource.com/platform/external/tpm2-tss"
+  },
+  "external/tremolo": {
+    "dateTime": 1641946033,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "30c38f3f03e5fcfecd2652fee9187a68b1f5bb63",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lw1sd49xfcamwvwq8nfxyihk1a5mh8sld9ck1xm97ygdk8lia6z",
+    "url": "https://android.googlesource.com/platform/external/tremolo"
+  },
+  "external/turbine": {
+    "dateTime": 1613531852,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9d8d4acc7c943e5df55bc26e1c2c265a48bc5571",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m3n7da7cg181nd9y80fm6zg7dr6i26baxg47yxkgls1agc0garm",
+    "url": "https://android.googlesource.com/platform/external/turbine"
+  },
+  "external/ukey2": {
+    "dateTime": 1613866002,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f3aa2edb1c82ae4ff6b8e5788dc7f2982f658e5a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wprw0h3d5qvzikh24b019506fwmjgzah0j0lmdraiv24vqspldj",
+    "url": "https://android.googlesource.com/platform/external/ukey2"
+  },
+  "external/unicode": {
+    "dateTime": 1632531985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fc38579fcfcac59055ced8f0c714ed0e26b5f6da",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zldjkgxi9kl2sk9ny38nc1693frbyd3z7swnagv987p0av6q8wz",
+    "url": "https://android.googlesource.com/platform/external/unicode"
+  },
+  "external/universal-tween-engine": {
+    "dateTime": 1613613991,
+    "groups": [],
+    "rev": "60a3a707caf2617c2b25ace08de749a9896164ae",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ah027mh8lgrsdcqp8pbv1l6gcxjxaj8ksyji4v244awrqdhmpx0",
+    "url": "https://android.googlesource.com/platform/external/universal-tween-engine"
+  },
+  "external/usrsctp": {
+    "dateTime": 1613952398,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c42ea9bf72dc70d796324ee4d8c073bfcb10bad5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ys21xj86zc4rx0x49d3r62mdi8kwx4035xbyslxqs4qlrai618c",
+    "url": "https://android.googlesource.com/platform/external/usrsctp"
+  },
+  "external/v4l2_codec2": {
+    "dateTime": 1637107566,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c8d3d19669b343dad7c721fb40581688c331e674",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1l1n2jjb7pwb4kfx9dy5k3jr5f3bhcph867xxflc5799f6x7npxg",
+    "url": "https://android.googlesource.com/platform/external/v4l2_codec2"
+  },
+  "external/vboot_reference": {
+    "dateTime": 1613531855,
+    "groups": [
+      "pdk-fs",
+      "vboot"
+    ],
+    "rev": "bb5bc09a9879ef894aa50224fa0fbf6d8371eaa1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0dbrh8hy96vrfdxs7p4vz6y7k256sr6rk9dn1d0nk69pzf58xssa",
+    "url": "https://android.googlesource.com/platform/external/vboot_reference"
+  },
+  "external/virglrenderer": {
+    "dateTime": 1615075616,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0e29f70fd6f6bc8a2c3f69daf6bbfade0a3729e9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m5588rz56xb42hghfkqw5qp5s4mcwcwy97hqnrxcl4sbngmmpx5",
+    "url": "https://android.googlesource.com/platform/external/virglrenderer"
+  },
+  "external/vixl": {
+    "dateTime": 1621048055,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6cf5bff92a5d3e7aee9cbc5e6e52d61a09583ce5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1kgrgqmprmiy2rha9idcqljy7xixgn9cs64vwx3b8swpb08bymar",
+    "url": "https://android.googlesource.com/platform/external/vixl"
+  },
+  "external/vogar": {
+    "dateTime": 1621048056,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6b30ca516a32aa6f05a6920d8e0e6d7a194940cf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pzid6jal940rcrimdf22128c458rkjqalnhz56k8mh0i049pzgg",
+    "url": "https://android.googlesource.com/platform/external/vogar"
+  },
+  "external/volley": {
+    "dateTime": 1613866006,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6fafb76cbbfc1d0241ed12083a0e86fb1eebdf7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1679hx3m8h1k6q8c38pqam01dsbdvrb9y16ylxahi53cc1xqj9c3",
+    "url": "https://android.googlesource.com/platform/external/volley"
+  },
+  "external/vulkan-headers": {
+    "dateTime": 1621048057,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "521513159b582a2c1e4f229c96440dc46135d2cf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04dgizyvxg2p8s46n8ha24yhjmxrzqvaqy8w9v6q5q9v62z2qix0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-headers"
+  },
+  "external/vulkan-validation-layers": {
+    "dateTime": 1613866007,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "85ffc616d37c77497624277226be3de240686ec2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b07rm2880j171mswhqmppf6mn2ijrdl3hz6bicaw41cixz4ckm0",
+    "url": "https://android.googlesource.com/platform/external/vulkan-validation-layers"
+  },
+  "external/walt": {
+    "dateTime": 1613866008,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b621cffac57f2a39dc73e8628ed6dfa76939a63c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04g2zdf06pyk0k6s9ss6yswannhjqhz2m60msq206nvl1qdz81l1",
+    "url": "https://android.googlesource.com/platform/external/walt"
+  },
+  "external/wayland": {
+    "dateTime": 1615075620,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ba2741a81daf8c1d4b4b410f2f662b0cd745d12a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03wp3x0k8lys9jkm4arkcf0zkc9xal2jx9yhi2j9j3qk4h25pi4l",
+    "url": "https://android.googlesource.com/platform/external/wayland"
+  },
+  "external/wayland-protocols": {
+    "dateTime": 1632784001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "03b4eb381936b45de7904da08aea56bec78f0686",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xczs3l8p79dkgi4hyy0czvp6r1cz9jiigf6sss5j7vjkk2mx9y2",
+    "url": "https://android.googlesource.com/platform/external/wayland-protocols"
+  },
+  "external/webp": {
+    "dateTime": 1613866009,
+    "groups": [
+      "pdk",
+      "qcom_msm8x26"
+    ],
+    "rev": "a0a677730c11e985765d61dd69ceb21a327eaf3c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15zv6w3wcw11qwx5f95p5cxb1dbrfkyzlmcl6w5dx9wn0cyxjd55",
+    "url": "https://android.googlesource.com/platform/external/webp"
+  },
+  "external/webrtc": {
+    "dateTime": 1613866010,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "93e187a9e5bb6f6bc6fcf88afb397aa3215ae4ad",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00jjyl1zwgqdzmakvgsw6iyasiz1y9fwh2k3n2yff0050vk6499p",
+    "url": "https://android.googlesource.com/platform/external/webrtc"
+  },
+  "external/wpa_supplicant_8": {
+    "dateTime": 1638922016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a7d670083c0561ea9ee1cd67d8a4b4d409519cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16mnb2lpy31dqyglki0p2j4ppx5z6sw87w1d5zfkbd5j59mdmzfw",
+    "url": "https://android.googlesource.com/platform/external/wpa_supplicant_8"
+  },
+  "external/wycheproof": {
+    "dateTime": 1613095637,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1cd45a15798d09f713ebd9f6fabf116c59154576",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0waib4n8k684l4nl339w9h1f5g52461qh51kk1inknj2bpvy78vn",
+    "url": "https://android.googlesource.com/platform/external/wycheproof"
+  },
+  "external/xmp_toolkit": {
+    "dateTime": 1612577223,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "29f20717f12bc8c62a855cd43a774c5c6b9a1792",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vni2h737zxzcd9lg7fgxh3vv88508kn1kli04nh2cqmld9a9x1v",
+    "url": "https://android.googlesource.com/platform/external/xmp_toolkit"
+  },
+  "external/xz-embedded": {
+    "dateTime": 1613531861,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "061af53e1a70ecb1f5a56fd53fd1f2fb91834084",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "073plk8szhih5chpaf91jfi9w3f8sgx3s38y79zk9g11mms40dpl",
+    "url": "https://android.googlesource.com/platform/external/xz-embedded"
+  },
+  "external/xz-java": {
+    "dateTime": 1613614001,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2d054b0b4ab865739e6c441c3b4acf422f50ff05",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "106wni1mvkx7jjag4401v8dkmqrl7kyd17a8nlik0wqwai9akmbb",
+    "url": "https://android.googlesource.com/platform/external/xz-java"
+  },
+  "external/yapf": {
+    "dateTime": 1588621644,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "ba05b2546ebda8b8ce0a97713cdc391b46c29b3d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04cxpdc46h0z75d2b8a73lx3x25k881qkps309sa7irxvqjlq4av",
+    "url": "https://android.googlesource.com/platform/external/yapf"
+  },
+  "external/zlib": {
+    "dateTime": 1621048064,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "46120f3e321f2092aa0c8f67061e9e197a3475f5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12640wzjmqgjdya2zdb14ir5d3q1fds04hs878wsw8jw84aw3jkp",
+    "url": "https://android.googlesource.com/platform/external/zlib"
+  },
+  "external/zopfli": {
+    "dateTime": 1612577227,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f27ddb8fc1abebef8f543ffdd0d722fdaeaa3a1b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y0lrn1mcw9233dr93361d0mjwpqlsrq4d31l1kgr1lyfdx2lf5l",
+    "url": "https://android.googlesource.com/platform/external/zopfli"
+  },
+  "external/zstd": {
+    "dateTime": 1613866015,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7a5f90e06c6e5f3413efc2001bbb93d5c2db7dc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nc7pf97s580c66hyd11zjcj1ah7dd2ls3nkgdia3qmrfphwl74x",
+    "url": "https://android.googlesource.com/platform/external/zstd"
+  },
+  "external/zxing": {
+    "dateTime": 1613614004,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "43031b79244b072f79c3fc598b08376b73001344",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hn3cmj8msdwggbqzaqvscri38df1j35c921i2k518wikghi7wh0",
+    "url": "https://android.googlesource.com/platform/external/zxing"
+  },
+  "frameworks/av": {
+    "dateTime": 1641607582,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "91843831909164ea7ff478a79b3a1307b833521a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0x3zqnmkqvkc7vcfdl2vmhaz4kfz5q0hmx3p61ib8yiaw7ds95l1",
+    "url": "https://android.googlesource.com/platform/frameworks/av"
+  },
+  "frameworks/base": {
+    "dateTime": 1644453735,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b134ca5e85a6e8c9f694290ffe422069644d34e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "048bgc7vrwgz295s9y6mba26qis4zz7fwhyk6z9mhjaxpfwyavgr",
+    "url": "https://android.googlesource.com/platform/frameworks/base"
+  },
+  "frameworks/compile/libbcc": {
+    "dateTime": 1613866017,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d813d00241e633fe65f12fc4b753d5299211e657",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n03c58wxfp76z0hk2y93r6jfhi7rvrbmv5iwnj6gy9aw6a5a4fg",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/libbcc"
+  },
+  "frameworks/compile/mclinker": {
+    "dateTime": 1621048067,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5647a7c392f4be58d907346e2079b9c4ca0f513d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "162nkr6acndsx278g31ygazpv9raxigb69qnic1sv97n94v7yyvy",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/mclinker"
+  },
+  "frameworks/compile/slang": {
+    "dateTime": 1621048068,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "219296599d6eb665278c32ab4dc64c5a3ea12744",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16jzz2xrgipqlp8ixmssapxpqnhyz0x8rlwkv52v6g90psl25jl8",
+    "url": "https://android.googlesource.com/platform/frameworks/compile/slang"
+  },
+  "frameworks/ex": {
+    "dateTime": 1628975244,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "305c35b6f896c265c2c7518c147cbb17900931fe",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1pr2k2a0hk47khbl1bp9ljxcw95k78b37qbkql9vh51r89hrhyis",
+    "url": "https://android.googlesource.com/platform/frameworks/ex"
+  },
+  "frameworks/hardware/interfaces": {
+    "dateTime": 1634252977,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8a2475f56dd3a5e6add25146202ef3b553ac2bef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1031nf3zchb7jgx4jr3qrmssjr6l5jb54iwdalx616avaj8c9wxs",
+    "url": "https://android.googlesource.com/platform/frameworks/hardware/interfaces"
+  },
+  "frameworks/layoutlib": {
+    "dateTime": 1621048070,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0237ee31b7a30dd94a74fa95079f3b766da8b7a6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cw2y7xcd3w1nzljvzgckli8d328y5xxj5ynmxpnszcrlyiymish",
+    "url": "https://android.googlesource.com/platform/frameworks/layoutlib"
+  },
+  "frameworks/libs/modules-utils": {
+    "dateTime": 1623978477,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "13a3a4c30a4d893103cd078cbac39baa1bab9a4b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0fsixxvkxw1g26jjlwmmrybbzzwgxl1gswbilyk73dmf1cnmx711",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/modules-utils"
+  },
+  "frameworks/libs/native_bridge_support": {
+    "dateTime": 1639188382,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6e7486a73e8e78b850d9805dc9d0a588fd52fd6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "117pjlrcjrxz0269q47zhhcpspcy5zyq7mcpr84f3f7h7dc4kjr9",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/native_bridge_support"
+  },
+  "frameworks/libs/net": {
+    "dateTime": 1629241608,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ca49bfdeb46bfed933e69e27ff9e85560418e12d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0raxv23lflhvcgnz1ci2w6fn6gv5kyb6zx5fmmv8s8bqsq3sbsgm",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/net"
+  },
+  "frameworks/libs/service_entitlement": {
+    "dateTime": 1627521188,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d6013835219a11ca3cbe8b8138cbad6d943270ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z9kin6rn0dh7h1av6larf9swnzcni5ckjc4v8pzyrdvff9qj3l3",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/service_entitlement"
+  },
+  "frameworks/libs/systemui": {
+    "dateTime": 1641513993,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0711ef21880e7664cb29f8225e822254acb54276",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "038h1pmp7sz7p7pwayxxvgwndp55wsyl7pmqq11wy2fd8yzcx3mb",
+    "url": "https://android.googlesource.com/platform/frameworks/libs/systemui"
+  },
+  "frameworks/minikin": {
+    "dateTime": 1623805659,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "37283a4582a97b44ad4579859cd753b5598ddd09",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gja9jpb28rzvjk25ii48vq8mzlnsrhv3ja9k9xmab0jhkpfam99",
+    "url": "https://android.googlesource.com/platform/frameworks/minikin"
+  },
+  "frameworks/multidex": {
+    "dateTime": 1613531872,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "22187a4246f179c376609119113a2144adfa5216",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xwqn0ik1in5rpwnr1xygbggjm8ysiknp2hvf2m24859zg90lng7",
+    "url": "https://android.googlesource.com/platform/frameworks/multidex"
+  },
+  "frameworks/native": {
+    "dateTime": 1642284403,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a9c743db10ce7c303fd7a2e6404cd94fdd0d6878",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0z7ilybkmc2z68ar0jkbl3fmas77w2rwnwfqix2q2nr8gkvanywn",
+    "url": "https://android.googlesource.com/platform/frameworks/native"
+  },
+  "frameworks/opt/bitmap": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "83f22ecffb4c43a9530165787eb14392f539820d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ipvhhkj8d1fpixx5s51133k87riqdczaarw9lnr65anx4s781sb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/bitmap"
+  },
+  "frameworks/opt/calendar": {
+    "dateTime": 1613531873,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "d055faaf7af7bd85cebe11f768b712c89ad826ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jjj2y6qsj5q20fj4rr1kbx7cn233myv6yk5l2j23x41nryandd2",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/calendar"
+  },
+  "frameworks/opt/car/services": {
+    "dateTime": 1636675597,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b031a409be6f25891180f51f9c60f376046fb206",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1iiz2gyvfdsl3m2c05fhyfi4s45n93bwlim1qly6k1pcpb2yi2wb",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/services"
+  },
+  "frameworks/opt/car/setupwizard": {
+    "dateTime": 1638490023,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fa0499c7410ff39a64ad977d17d16843c32fdd6d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10jlx17qgc069rfkisf3303vg33jcqb5b11xcdg7dddyidbjvkpw",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/car/setupwizard"
+  },
+  "frameworks/opt/chips": {
+    "dateTime": 1634951219,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "34a395e93c75f5994c6fec5e19c8f676a513a281",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "074p77mfj9w9b7k17r1dhr4y5p55r8095jhan9xz8v405zxzxl08",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/chips"
+  },
+  "frameworks/opt/colorpicker": {
+    "dateTime": 1621048075,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6c1b15e97466fae0ce76be8465b0fec880feb028",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vvn2sc29sc2yhvk5lz0gcdfb12321w4bcy24xkqvsnfsyddc877",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/colorpicker"
+  },
+  "frameworks/opt/localepicker": {
+    "dateTime": 1621048076,
+    "groups": [],
+    "rev": "6de66ddcd40815f7bd1d187250f8392f2c98389f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r125r6xswixm6b6d68bzc489h6xhb7s0bjgs8fnay4vbsq4419s",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/localepicker"
+  },
+  "frameworks/opt/net/ethernet": {
+    "dateTime": 1624410476,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c45d1d297c9e1aa107c5932f51f077cd8e05bd3f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1w5v0hr8a7qwrnf8f63fb6lnw19hggzjp7a1wrpfg1l539jaxv8k",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ethernet"
+  },
+  "frameworks/opt/net/ims": {
+    "dateTime": 1637885266,
+    "groups": [
+      "frameworks_ims",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a51703188d10f81392887099cfbee3e42521252a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10436q6ls2k9xgwvr6gg52ijia0vqj096zldc81cbqv4ckzcz90v",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/ims"
+  },
+  "frameworks/opt/net/voip": {
+    "dateTime": 1622768867,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e9c6855887880fc8ab837600f121015de9ed6b9c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y3mffpp81hgzkp9qlwl49s82b5zlb2vbznxc3x5hp5kv2p6i7bi",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/voip"
+  },
+  "frameworks/opt/net/wifi": {
+    "dateTime": 1641766101,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dec8468fb2d4775dc49dfc2ac43f5e264ec08905",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07vmqp5yhswl96aa707g3qzba3fvklqz1w8n8jz69063nqcnvx40",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/net/wifi"
+  },
+  "frameworks/opt/photoviewer": {
+    "dateTime": 1629508007,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5aa764438decde1af9b87bc6c18aef5bbad9e7f8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09k0svr6wgxs9dras8ycz4lb1mf94l5q60cark0akggjsm6q0a9x",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/photoviewer"
+  },
+  "frameworks/opt/setupwizard": {
+    "dateTime": 1621048079,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9a19a48d84684d6030f7ca1db684897750e7b0fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sdvs3n3nxd0dflqyjqqhf0g1drznwqrkbd4qv5za5n0g9dqg5x1",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/setupwizard"
+  },
+  "frameworks/opt/telephony": {
+    "dateTime": 1644453737,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d5e7fde1dbf081739ecb84b54500e67c4a93b30f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06phw8jrnawm80iwjw16l03kw20mlk38i7f82vdibp8kfr7m5dfw",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/telephony"
+  },
+  "frameworks/opt/timezonepicker": {
+    "dateTime": 1633208819,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9dea0fd34c00070ac041aeddfb94347ae990edf4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yz5byfqgkra3qim8gnrafna4cdxss3cfl6gflkggw768viabbgz",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/timezonepicker"
+  },
+  "frameworks/opt/tv/tvsystem": {
+    "dateTime": 1621048080,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c8caf6839e03422e7fc8ce7f06da1d444021afca",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1008lz757hs6yjl71xcblv8lny21xlkvsh70sbqnv7akbn4pk3m0",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/tv/tvsystem"
+  },
+  "frameworks/opt/vcard": {
+    "dateTime": 1613531879,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ee2305471aa6652134326473f5c46911136a6373",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ahqdbqw285rpk7cnsjq0fzb60jmpf5a5z32vz52apxlg68k5l1g",
+    "url": "https://android.googlesource.com/platform/frameworks/opt/vcard"
+  },
+  "frameworks/proto_logging": {
+    "dateTime": 1642212415,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "aff1093519aabc5a394d0f11e663b736e44f3e06",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1a7n4dpd4i36ry7v3lrby0dw1s4iczph2q4fqh8a7hvmxl77zd2c",
+    "url": "https://android.googlesource.com/platform/frameworks/proto_logging"
+  },
+  "frameworks/rs": {
+    "dateTime": 1621048081,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "83850b327d4ba12d864d6a72334980e55acabb17",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gybw0hsp2p5mm7g2v737kg0ca5nys2f0333p9ma19sz5dyww3ma",
+    "url": "https://android.googlesource.com/platform/frameworks/rs"
+  },
+  "frameworks/wilhelm": {
+    "dateTime": 1623200882,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a6628564db9f4fa93ccd2288937165581c2375a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nf5sx9zjs2ybcp4fqwzphgan379l83fml58dhs5x4f24rj80bxz",
+    "url": "https://android.googlesource.com/platform/frameworks/wilhelm"
+  },
+  "hardware/broadcom/libbt": {
+    "dateTime": 1615943218,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d2e7e2b748c4b71bf290c38bd6d73582cbdd8ddb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12945i09sz39ygg91szzabmw7kmhasn9b18sb2v8fkxxzqcy7nih",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/libbt"
+  },
+  "hardware/broadcom/wlan": {
+    "dateTime": 1640218032,
+    "groups": [
+      "broadcom_wlan",
+      "pdk"
+    ],
+    "rev": "5605e19267c464cc83b99d6c55810dad8d400526",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hpx8s0lfzmni6ypca0nk5m5qidpn9jw76wnyrggl942x1rwhixm",
+    "url": "https://android.googlesource.com/platform/hardware/broadcom/wlan"
+  },
+  "hardware/google/apf": {
+    "dateTime": 1613866034,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b90443f0c308b5bbeb62c2a5b939e6cd0599f184",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "144hxkgnbh4jvm5a830mjwsj5zcp4z0g61731r9vj9kx8kaxqxrr",
+    "url": "https://android.googlesource.com/platform/hardware/google/apf"
+  },
+  "hardware/google/av": {
+    "dateTime": 1633561918,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0703c0191b2f01ae2bf7c7c4738f0c67252ec2b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d3h8g5fbvqyxj8v7q1b2y049gi17wq8dd32yv2671f5rv5a668j",
+    "url": "https://android.googlesource.com/platform/hardware/google/av"
+  },
+  "hardware/google/camera": {
+    "dateTime": 1638922044,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "07760a9ac07e521f1a76d9fd262d406e8446cc22",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1inbbmghiizfwg627ffdrihhi4i8zsm61lg4v94ql3fqmkcczxsr",
+    "url": "https://android.googlesource.com/platform/hardware/google/camera"
+  },
+  "hardware/google/easel": {
+    "dateTime": 1612577257,
+    "groups": [
+      "easel",
+      "pdk"
+    ],
+    "rev": "f75324343f36b7cfae987ac69e4d73ad30098cd6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0a8hgw2y5z36vqn9ifwsci7bn6qznz1kjzvswhzif2cag7249nvh",
+    "url": "https://android.googlesource.com/platform/hardware/google/easel"
+  },
+  "hardware/google/gchips": {
+    "dateTime": 1635980845,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "79ceb6a2983d88d25117528dabec82dc1deb3343",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15n2xxbpjm7qdca78q769f8jpbwgr3w2116mm2b4w3m6bsddaxgn",
+    "url": "https://android.googlesource.com/platform/hardware/google/gchips"
+  },
+  "hardware/google/graphics/common": {
+    "dateTime": 1640650073,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "ef76f97a68a74cec4e06d5fe72c45aac1e319359",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cjs2y5l2ph113kldgfgiv94w0i06flmlzgf6srq2x3gcy5b082v",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/common"
+  },
+  "hardware/google/graphics/gs101": {
+    "dateTime": 1638583625,
+    "groups": [
+      "pdk-lassen"
+    ],
+    "rev": "6a374b6f4f593a7b0dfbedf94709c4f23bf8521b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ip2lc7qxg6h0ryqnb7n5gv8n2pa88cyrdgxh3mssg6n743ifhii",
+    "url": "https://android.googlesource.com/platform/hardware/google/graphics/gs101"
+  },
+  "hardware/google/interfaces": {
+    "dateTime": 1639008531,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c63f58b37637c7e878c181beaf36f71cfca5569a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ln465hm51ih5zjvlf1aff4xvqna7aass2sph0y0fv7134sqnfgk",
+    "url": "https://android.googlesource.com/platform/hardware/google/interfaces"
+  },
+  "hardware/google/pixel": {
+    "dateTime": 1641607606,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "bda1f3410eabb2a9da0dc7aa24ed5beb4c27b4ee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yqpki4hpa2ziqzl2skj69hxmrwzcpf7rgsyby1vv1yzdgpid6z1",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel"
+  },
+  "hardware/google/pixel-sepolicy": {
+    "dateTime": 1635376050,
+    "groups": [
+      "generic_fs",
+      "pixel"
+    ],
+    "rev": "7678dcfbd2c14de78204cbb63893a16e761249f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1s1m9ba5mgis0rq0rlg87ab37128xymhd0d3byl106vv1n2n6fzc",
+    "url": "https://android.googlesource.com/platform/hardware/google/pixel-sepolicy"
+  },
+  "hardware/interfaces": {
+    "dateTime": 1642284420,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f0d99385c8454bb16681deb93aa41d84cd95d909",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v4khlbbczr3xl8q54f9iv8ixv2zwdqlfkslgp0fjq3qw7vcxfbv",
+    "url": "https://android.googlesource.com/platform/hardware/interfaces"
+  },
+  "hardware/invensense": {
+    "dateTime": 1613866039,
+    "groups": [
+      "invensense",
+      "pdk"
+    ],
+    "rev": "5a14b84a28d358b04b258c53f139e697fec5b618",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12sqj3i0avyqpl6nqi8flaskfqlsfvvxzllskkfa67n9cknnv2p0",
+    "url": "https://android.googlesource.com/platform/hardware/invensense"
+  },
+  "hardware/knowles/athletico/sound_trigger_hal": {
+    "dateTime": 1614910016,
+    "groups": [
+      "coral",
+      "generic_fs"
+    ],
+    "rev": "8d04f5ccd71b874d20c050b2605acb6a717a4187",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zh4cb9rggg5in2ha4sil7qn28m97iwldwn7d07nz6xyqiwxd4i8",
+    "url": "https://android.googlesource.com/platform/hardware/knowles/athletico/sound_trigger_hal"
+  },
+  "hardware/libhardware": {
+    "dateTime": 1639699664,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab9811583c9007863887e5f43a554085c123434c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04a0njwhqyyd35jpkqj2bzwygq0f3jvx00p922336sr9n4bz4rcz",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware"
+  },
+  "hardware/libhardware_legacy": {
+    "dateTime": 1622682513,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "69848d1fd02e11e143fc30f93f31935185232a9f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18wjm9bcka81flw01gkldxslg1vgr0vypsh3ic4b6jxaavxi0b43",
+    "url": "https://android.googlesource.com/platform/hardware/libhardware_legacy"
+  },
+  "hardware/nxp/nfc": {
+    "dateTime": 1642032627,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "039b203a565b01209cae7aded33710a1ab72900d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0p9njiskp259jq9b7j3g227cdc7ybwmjyirr45hz57i650n2gqsc",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/nfc"
+  },
+  "hardware/nxp/secure_element": {
+    "dateTime": 1621991321,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6d5d38354ecc4809b396f59dc0ba746d7aeb3223",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "063k3nh3vp9nffvq2gl3zirn2wx9hna8z67fkcdj30f9bm6vglcq",
+    "url": "https://android.googlesource.com/platform/hardware/nxp/secure_element"
+  },
+  "hardware/qcom/audio": {
+    "dateTime": 1621048092,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_audio"
+    ],
+    "rev": "8039f98adc771d4ce35e80282447617275b3df7a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hikyx0hvmycblqpapviqbjkf890b6cn4yqpiyrs4w4isbf8w37j",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/audio"
+  },
+  "hardware/qcom/bootctrl": {
+    "dateTime": 1613866041,
+    "groups": [
+      "pdk-qcom"
+    ],
+    "rev": "d8661b50b61accc17c4552f1543af66bbbfd6c66",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04dv3a0zj03af7g4c19kiif4v1gff0fby467kh3ji440y4z00r31",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bootctrl"
+  },
+  "hardware/qcom/bt": {
+    "dateTime": 1612577267,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "0bdcb230f7b2003316993e4216b2dd4db0db49aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0a6h3jcprciwxjq86nfiiij8f7475mah4qgxgsfdd2b54cy37jbc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/bt"
+  },
+  "hardware/qcom/camera": {
+    "dateTime": 1613866042,
+    "groups": [
+      "pdk-qcom",
+      "qcom_camera"
+    ],
+    "rev": "aa168282c1918efd678670b5ca701687529d5db9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0p2932v9hsmv6i729zvzq0fypxcdh7xdhfyiz57pspm3xpv7f9yk",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/camera"
+  },
+  "hardware/qcom/data/ipacfg-mgr": {
+    "dateTime": 1613866043,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "ab1fddf2d4bca85eb4d049930ef7aecb5f877141",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11zhb0diqxlz9vsxzbvxn8pv6amxrclvqybnr5acbs8awlc6h6xg",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/data/ipacfg-mgr"
+  },
+  "hardware/qcom/display": {
+    "dateTime": 1613866043,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_display"
+    ],
+    "rev": "1dbb2cf13397d7c1e4a60cf4f6b2bbe0ccb7890a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1w8fr68drhj6wjqvla801wianxb71ybpxwfia4v7mjrf7krs09a2",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/display"
+  },
+  "hardware/qcom/gps": {
+    "dateTime": 1613866044,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_gps"
+    ],
+    "rev": "d64b37aa78a963fa042470c80d2d2c15fb200119",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r99iirahalmj8w9v93cqi9lhandavj88jqwlcgd01czlrynwm9x",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/gps"
+  },
+  "hardware/qcom/keymaster": {
+    "dateTime": 1612656444,
+    "groups": [
+      "pdk-qcom",
+      "qcom",
+      "qcom_keymaster"
+    ],
+    "rev": "a25fbe660d8ec769099291fc72fba6dd872c9bea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09882azkwai7h3xdr0krqv4d5k63qdyvpwzcw6d16wljbfkf525r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/keymaster"
+  },
+  "hardware/qcom/media": {
+    "dateTime": 1613866044,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "c1db01bdd2e55666b1a9a4b64f83817881cc7e82",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1djq7k9gi7d359cdif0rysfprcfs16sjmfjqkj88a6px9sl0mdy8",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/media"
+  },
+  "hardware/qcom/msm8960": {
+    "dateTime": 1592337238,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8960"
+    ],
+    "rev": "a646f7db94dfd0051c9356dfdb0017da548f6549",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13ss8wgnd4306024174vsfv6ka2sf45jzx7d4b8z5ywcpqiyczwm",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8960"
+  },
+  "hardware/qcom/msm8994": {
+    "dateTime": 1592337170,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8994"
+    ],
+    "rev": "a2f070340d3fcdcbc9292992d56494c216abec21",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15zxcb9dx1862fvasyn11iav765a3522my4mxby5iymjax8sir99",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8994"
+  },
+  "hardware/qcom/msm8996": {
+    "dateTime": 1592337277,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8996"
+    ],
+    "rev": "269630ee04fc2b14f5989e3000819758e75843f2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0g381r0mv2rv0yzq0qw2m65z6a6wx2wsc14xln7q9pphn7x7kfyl",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8996"
+  },
+  "hardware/qcom/msm8x09": {
+    "dateTime": 1588715629,
+    "groups": [
+      "qcom_msm8x09"
+    ],
+    "rev": "7d338058a15b75900f68d2b57e0ab792da9114b0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17hq55hsfyzknrjfmw877y5cnm4mgxi7bdj0fpb920gcn6klfdrs",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x09"
+  },
+  "hardware/qcom/msm8x26": {
+    "dateTime": 1592337224,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x26"
+    ],
+    "rev": "d61f16f88158b99f4f547788fbbf56745eeb289a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kxbm2sk5lxzydh2f8jv1z6j3qpjxrb2b2vr3q71mfwms76z7zlc",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x26"
+  },
+  "hardware/qcom/msm8x27": {
+    "dateTime": 1592337231,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x27"
+    ],
+    "rev": "469e33d81529039de304330a75120883d449c3b3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bly3vx1ykfm251fz9c86znqzy9f8rlmgijaczzz1hk78mrk5sy7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x27"
+  },
+  "hardware/qcom/msm8x84": {
+    "dateTime": 1592337218,
+    "groups": [
+      "pdk-qcom",
+      "qcom_msm8x84"
+    ],
+    "rev": "cf2bcdce20697c82215d0af6d169bbfe182ab244",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ds8p9sr9r3m9lncav7kjzma9m1v6abapddjx6xjncn9ghv3ga08",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/msm8x84"
+  },
+  "hardware/qcom/power": {
+    "dateTime": 1613866049,
+    "groups": [
+      "pdk-qcom",
+      "qcom"
+    ],
+    "rev": "f30c1e4cbfd4b6b7c382a25bd5d793190f11198a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hgjhbm8bj66nm29xgmg9xb32y12kz4jn8bm4fpflxn1cz4gb38g",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/power"
+  },
+  "hardware/qcom/sdm845/bt": {
+    "dateTime": 1613866052,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "ccf4840cc9b5351ff6705ddcea25d7b2df628b9d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16wxyxlvywkqpvlxlch8czcdjchnqnza5z8qhb1qgwv0kylrh1pp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/bt"
+  },
+  "hardware/qcom/sdm845/data/ipacfg-mgr": {
+    "dateTime": 1616029670,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845",
+      "vendor"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sdm845/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sdm845/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "3855f90b05667aa0e1ce07b5426baaf0a9254818",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ymwzhq5n5cawc6cwspz5xbdc1vzxnxrp7nslmf9kc7mvln56hr4",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sdm845/display": {
+    "dateTime": 1621905002,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "d5a6ad4dfd37f965f3e300df45b32b447f69c3ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hh37liap88gw5rl1yn15mpx3b96iw8qk7agsvrrxszyxvbksii9",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/display"
+  },
+  "hardware/qcom/sdm845/gps": {
+    "dateTime": 1624497192,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "d5004a281304f62f266565972ef5037a45af21a2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15ibil263invfsc8p2889lb92370zxi27gkgx14b8y0jnpf4jx14",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/gps"
+  },
+  "hardware/qcom/sdm845/media": {
+    "dateTime": 1613866054,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "27f22a59e5a6cd445b57785a2aff35771e16ef44",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10csk645fbbkcszv3lb835h2v1il4x6dihadxg23g7y2cxfi6nvj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/media"
+  },
+  "hardware/qcom/sdm845/thermal": {
+    "dateTime": 1613866054,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "089a686870e93f564bc02438bca35237401f9e7c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08jfmac2ac6zgfxg8hgvxmv70xk5mlz15vqrxy5xcfsg2f4q1c8r",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/thermal"
+  },
+  "hardware/qcom/sdm845/vr": {
+    "dateTime": 1588703755,
+    "groups": [
+      "generic_fs",
+      "qcom_sdm845"
+    ],
+    "rev": "7e39857b8cd9ea71d79231ea1afccce43e1fcf22",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06fbwha2qkigss5r7r5vmgnr3c64cxy3njdp2qlbsxgm0c07xy9q",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sdm845/vr"
+  },
+  "hardware/qcom/sm7150/gps": {
+    "dateTime": 1617152862,
+    "groups": [
+      "qcom_sm7150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "b3327dd32d8d1e96f66d719af041bcf548cb857e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ilgf2rdxniq5b63an8asrbdir2f82yj05qcq8pg51gmkm2550nh",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7150/gps"
+  },
+  "hardware/qcom/sm7250/display": {
+    "dateTime": 1624497194,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "9ce1bcecad7c01149a4c10de0f2d38cbbd21e8a2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vha4cs3p8zy3b8m1di92wgypi8blsgl8a8aw997j9p4rg9pvm29",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/display"
+  },
+  "hardware/qcom/sm7250/gps": {
+    "dateTime": 1631322443,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm7250/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm7250/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "88e0b18638c8e95228713775cfbcea6363144b86",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0a4d7vqlj666q8sw6548fli1hcmviqaqv9xhay4a3l3g4ppgylxp",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/gps"
+  },
+  "hardware/qcom/sm7250/media": {
+    "dateTime": 1624497195,
+    "groups": [
+      "qcom_sm7250"
+    ],
+    "rev": "82c5e0b134e45d6e2a643f745b033624c3c96575",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mxv8v1fnxr4gmjc92l16zmzxbiyppppszmjyjc61rkj3z92vdk7",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm7250/media"
+  },
+  "hardware/qcom/sm8150/data/ipacfg-mgr": {
+    "dateTime": 1624583468,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "a747774ab3ea417933f7ffd4f9c6d73f8f79f85e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nl5wgfh2fnwh6ypyb7c4fga6q434b1nzfl4ha9l0qm24b5zw6vz",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/data/ipacfg-mgr"
+  },
+  "hardware/qcom/sm8150/display": {
+    "dateTime": 1630112862,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "a5391afdabbd58e86c26b07e409f59740ec03877",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03hw9zi4rh43crmxafd1jnjbd9fpzln0mrd6rzc00lyb9hk5if10",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/display"
+  },
+  "hardware/qcom/sm8150/gps": {
+    "dateTime": 1634857692,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "43b7a027fc2d76cb6d7ca28bdb2258e3814cf77e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yhdc4qj2xjm4n6ym6yfldrrpbl263cj81n8fz08l6p4v3qfkc7z",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/gps"
+  },
+  "hardware/qcom/sm8150/media": {
+    "dateTime": 1624640114,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "be57e46e2fadfdb77d92426b75c6996e57334988",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07ghzjg7k8jydqg46w8s5w3ngjx0y533xyx8aigji399f1jdj9fd",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/media"
+  },
+  "hardware/qcom/sm8150/thermal": {
+    "dateTime": 1613866058,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "936fef8ac1acf666a1efb213527a7d39f0a96fbd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "068aa9jpgn5b8gdy62jz74hhik1dh4yjgliaavfhvqmg1mbgn7d5",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/thermal"
+  },
+  "hardware/qcom/sm8150/vr": {
+    "dateTime": 1612577287,
+    "groups": [
+      "qcom_sm8150"
+    ],
+    "rev": "8b71b94e508deb1c06d7ab2dd8fc46d71638ff00",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k4dfzb7l3pk0zdxzad6y20kckyac5dl5i26b6rg03ip940ij7dj",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150/vr"
+  },
+  "hardware/qcom/sm8150p/gps": {
+    "dateTime": 1617152867,
+    "groups": [
+      "qcom_sm8150p"
+    ],
+    "linkfiles": [
+      {
+        "dest": "hardware/qcom/sm8150p/Android.mk",
+        "src": "os_pickup.mk"
+      },
+      {
+        "dest": "hardware/qcom/sm8150p/Android.bp",
+        "src": "os_pickup.bp"
+      }
+    ],
+    "rev": "36a2bb0187e0bc616719993780fc3a4d1bfb21d9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m43j0m0cdjn7xn81n1a9h9v2b3846vixqffamajb8qrfp25yvzr",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/sm8150p/gps"
+  },
+  "hardware/qcom/wlan": {
+    "dateTime": 1637798881,
+    "groups": [
+      "pdk-qcom",
+      "qcom_wlan"
+    ],
+    "rev": "c052cc61bcf5aa94840d0ba1edf48b4507d042db",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00y8hnmjl0a3g311w28iq208hx9spgchl9qz5psj1nl0zaqfrgnl",
+    "url": "https://android.googlesource.com/platform/hardware/qcom/wlan"
+  },
+  "hardware/ril": {
+    "dateTime": 1622768904,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a049d29d35bba0be9b7dd09a906356ae8fc21c3c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13r4911z64whzp7q6sm9153xqj9frzmyq95q6dgfx2z6826gxcxn",
+    "url": "https://android.googlesource.com/platform/hardware/ril"
+  },
+  "hardware/samsung/nfc": {
+    "dateTime": 1621048115,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fb84e111ea777ac55a285425a69f1f5edefa03d0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mcsnjjngc7v1rb0pdf9fkjz5ww7smpdyxvll32yayx27nfmnsdq",
+    "url": "https://android.googlesource.com/platform/hardware/samsung/nfc"
+  },
+  "hardware/st/nfc": {
+    "dateTime": 1633043693,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2ac75660223fd7dc6694160cd507e868865366ab",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18g57s4cfv0wamfn78nwd8hr66vn4b27swnlhllc69psnklql39y",
+    "url": "https://android.googlesource.com/platform/hardware/st/nfc"
+  },
+  "hardware/st/secure_element": {
+    "dateTime": 1621048114,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "128e491115adfaa8078de45876f2068eae30f70b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "043ca4c21n7jrrckdd2b6j9p1prg4y08k8giw7r90q8kk2bf4cwl",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element"
+  },
+  "hardware/st/secure_element2": {
+    "dateTime": 1621048115,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7094bb50b28752fd521736012b216e3c9b97ae9",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "183k0fmav5ndrkxkl7bnkm5mqyq0ddjjw6iilnl5y8122cg8phqn",
+    "url": "https://android.googlesource.com/platform/hardware/st/secure_element2"
+  },
+  "hardware/ti/am57x": {
+    "dateTime": 1613866062,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "666ca606a4f06cb11c485aebbb41218786161215",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gqn5lsyf7s420cdiga57w2c6g03zj048i5qq9r4904abcn9w1bm",
+    "url": "https://android.googlesource.com/platform/hardware/ti/am57x"
+  },
+  "kernel/configs": {
+    "dateTime": 1633208857,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "d9a16ba5d43e53fc183db582cb7985b8d7dae15c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08w0m10d9ni4wazdr78gf1yzzihafqbzg4yxxjzpw1gwrv6qm402",
+    "url": "https://android.googlesource.com/kernel/configs"
+  },
+  "kernel/prebuilts/4.19/arm64": {
+    "dateTime": 1641946103,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ec7a36c1993ef688928806b368584ba04acad898",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "15x4kkyh0744hs3jl0acjmgdn2h2sqgnk5m38w2mz9m3wfkmks89",
+    "url": "https://android.googlesource.com/kernel/prebuilts/4.19/arm64"
+  },
+  "kernel/prebuilts/5.10/arm64": {
+    "dateTime": 1639440459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc5acfeeb2dca7b079147fe4768ba09b78756a16",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16ia73462a37wpd5qar7rlb9kn9ns5a4j5i3xj3vp4dwawp3zpni",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/arm64"
+  },
+  "kernel/prebuilts/5.10/x86_64": {
+    "dateTime": 1639440459,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eda4f2c367763632f8222c30eddb3cd670a5fd8d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "17my5v5r8ix6jgsdkjp2905maqjrm2jflpbi4j3fxl9337jx20ca",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.10/x86-64"
+  },
+  "kernel/prebuilts/5.4/arm64": {
+    "dateTime": 1640131662,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e6ab093f128675b82747ea5be45cd12b9d09085f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hkcaka6rhn8lqwl9pcvglvvj75ais01g0v1d22dx42x99x2cq4m",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/arm64"
+  },
+  "kernel/prebuilts/5.4/x86_64": {
+    "dateTime": 1640131662,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "47cbe16374c5620262058bec4b0ff3b2e174134a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1czk73h8piwgiwrrnhb9qisb76h5s6ff5d42ydsxnqx6sri2xwzh",
+    "url": "https://android.googlesource.com/kernel/prebuilts/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/arm64": {
+    "dateTime": 1612209682,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "707c7364e06a760d93e94f74bfb278e9eb5c44b8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/4.19/x86-64": {
+    "dateTime": 1612209835,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "989b0542ac42cc40fafd106650d400b6bc01a72d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/4.19/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/arm64": {
+    "dateTime": 1639440461,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5764bfa2dc30d8d17635d9e71506cfae4a1954b2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01hwiswcsqyhf64hhvgqv6k3dpq6alyz9bm806iw2znyn1hdqzyc",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.10/x86-64": {
+    "dateTime": 1639440461,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a894cf70513ed8d0b7fb3f5fc9d33852c85ff49b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03b5vsyz9qldfmpmc3j48fsd6zqpxvh889fmjgnhl14jd2b1alag",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.10/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/arm64": {
+    "dateTime": 1640131666,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c5c9eeef9bdab360bbdd59741c23601c8ab00f2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "070812yxvcwspq412zx2bppyasaww00ax3qjpsnvhxxzrb4vvfi8",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/5.4/x86-64": {
+    "dateTime": 1640131666,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7abca6d62508e34b7ba16c2d1c9ca41f85bbe89c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "044f032w1dmzc5xrpf77da0la1qhdsq8mgpqm2b62ww9hx75bkvm",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/5.4/x86-64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/arm64": {
+    "dateTime": 1612210495,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "331cbad677f5c4cc6df4457e151a2e4a51d9126c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/arm64"
+  },
+  "kernel/prebuilts/common-modules/virtual-device/mainline/x86-64": {
+    "dateTime": 1612210658,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b6fcbac11ae722cf9ca07b7d5b7ea6e54731ea1c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/kernel/prebuilts/common-modules/virtual-device/mainline/x86-64"
+  },
+  "kernel/prebuilts/mainline/arm64": {
+    "dateTime": 1623287375,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d0d7e74715eaac5fe3baeb50eb2befa469b8451d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pw66qkkcil7wmfamvikdjsdmsr4vysb4f0aby02ygix2kdwfx6p",
+    "url": "https://android.googlesource.com/kernel/prebuilts/mainline/arm64"
+  },
+  "kernel/tests": {
+    "dateTime": 1624497210,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "2b1eb2c4f59a0eb7659ef1e32a7cefd50ec89e36",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xibcqrq89p12cng3qsg5hcc7lf2mdz90g5cbipz7rxwqpid2qc8",
+    "url": "https://android.googlesource.com/kernel/tests"
+  },
+  "libcore": {
+    "dateTime": 1641607644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1aeb7b394360b255e77d85896ce42d587fc56d40",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zi111nc4412xv5bj0j9hhgpdmdkcq7l5imk0jxsadw92y29z83s",
+    "url": "https://android.googlesource.com/platform/libcore"
+  },
+  "libnativehelper": {
+    "dateTime": 1625706908,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8cbc146ef37dae9f111f3e6742b62acf66b486d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1509vfazmfy60ny84mljzf1iw0m5hswg922z4wm8ac79gw5wsrf2",
+    "url": "https://android.googlesource.com/platform/libnativehelper"
+  },
+  "packages/apps/BasicSmsReceiver": {
+    "dateTime": 1629414742,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "73582e697188ba835c5357f54f33b9df64fe2a1e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13a8aj0lxiz3xw69iq5mf3kyc99v400x64gk9x2pgb6sqwdb8mn9",
+    "url": "https://android.googlesource.com/platform/packages/apps/BasicSmsReceiver"
+  },
+  "packages/apps/Bluetooth": {
+    "dateTime": 1641607645,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4ad5d98724bd31fd5f7aea80f61ee6a33d340bc2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ijdsg8hrv3rll332fc5fs1rldda33pncxgc4834368c6adags34",
+    "url": "https://android.googlesource.com/platform/packages/apps/Bluetooth"
+  },
+  "packages/apps/Browser2": {
+    "dateTime": 1617066458,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e94f4ba268eac7886b607447c85be6d9195c7df1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1h9fvxivq1vg0mcwjvi4bzz37l8qimznybpljqin45smddavryd3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Browser2"
+  },
+  "packages/apps/Calendar": {
+    "dateTime": 1633043706,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b3fa69d71017f15b7f3cbdf353a34545cca1424d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0kfvxpgm706p2yqm52m0c13zzsq7l93b318jinphqkc9pknb44az",
+    "url": "https://android.googlesource.com/platform/packages/apps/Calendar"
+  },
+  "packages/apps/Camera2": {
+    "dateTime": 1636675653,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1c30097f76fdd163e4a19968011ee714854c189b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x01pphlnhqh4m2r6s9244fdsqzf1hymg6ha5f8qs7vwq4x2mz79",
+    "url": "https://android.googlesource.com/platform/packages/apps/Camera2"
+  },
+  "packages/apps/Car/Calendar": {
+    "dateTime": 1637280465,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ee63566495646f9da8c97a25133c0d8dff65f1fc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jyh7kzzybk5d6g2j5ji05x1z773r4dkvvkr8wnlq5y7i3l9g1nj",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Calendar"
+  },
+  "packages/apps/Car/Cluster": {
+    "dateTime": 1636675654,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "88e3fbbf6814b68d6603f854f85361333f5b113a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1l8b4nm4zf1vnrghy1jhb0zyhqvxw3wzp8dpkjj3r3pnhdlfsb2n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Cluster"
+  },
+  "packages/apps/Car/DebuggingRestrictionController": {
+    "dateTime": 1628125955,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7854123a927564fb7e07bbb8c10755dac225f687",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hl1gyk1x3if9vbbd57qi69xrkzlbazfd71cvna9my33aazlz22n",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/DebuggingRestrictionController"
+  },
+  "packages/apps/Car/Dialer": {
+    "dateTime": 1642212466,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "80801b47af3cc374c9ec2619ff144bfcbc44da2c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qs256h0rpk71a3ksid6i0hvazrd36ysiffjb04xmfrq30iv9r5l",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Dialer"
+  },
+  "packages/apps/Car/Hvac": {
+    "dateTime": 1612577306,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2ebf99d8dc0b012b7adc8da0801a8ce30630b901",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1d2hqs0qqjihdjsqcpa1sg1k54rzdnzgj1y045mmxjp3sywd4lny",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Hvac"
+  },
+  "packages/apps/Car/LatinIME": {
+    "dateTime": 1613866076,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "50c917ca9def6367ebc9a516db4972363eec2ed5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0386ikmn57maxfr4brily6klk0996d93yw6fahk0h1vlh1bhqgma",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LatinIME"
+  },
+  "packages/apps/Car/Launcher": {
+    "dateTime": 1640304453,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "51b0af0cc9fbede18c4e830e2e36e4b0acf02b73",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hpmc21rim77gm10dnzddpxssas7kdfb1qawwjh2d1xfkkdvmh0r",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Launcher"
+  },
+  "packages/apps/Car/LinkViewer": {
+    "dateTime": 1621048131,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c107265fb60d2335b5cd09404105d5daa7879bbd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z34jrm6jwb5wpvia998h5izbmx7s80k3vgk43kmizkpfkd99n9p",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LinkViewer"
+  },
+  "packages/apps/Car/LocalMediaPlayer": {
+    "dateTime": 1625015338,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "fd67e5bce2acd77bb43396d10fa54baa1d9342a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1q5kbq8p08vscikaqjhkx2dq4cv7i7q3x4ga9fvjfgjnpvvwcgla",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/LocalMediaPlayer"
+  },
+  "packages/apps/Car/Media": {
+    "dateTime": 1641766157,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b7e006007b772a74727a83c9f2aa05860f3d0160",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "124ygd7qblxq1x8w07cqkmjgn14fpr3l8wpy4fasjmladqsbfy3y",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Media"
+  },
+  "packages/apps/Car/Messenger": {
+    "dateTime": 1637280470,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b30f637272d1884263251dcc352944531cfe5aee",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0pba04pkx6qvcni9hhshqazxwrk1ny43bklb162jah987kiafjkq",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Messenger"
+  },
+  "packages/apps/Car/Notification": {
+    "dateTime": 1639699713,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "aab2c4ab222e8c7fb7c79024209c37ec605d0bc1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ada9nc3rzmqs1mfjj16sqsbsjdwb9w108sqxyfg8n9gfnm5g57f",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Notification"
+  },
+  "packages/apps/Car/Provision": {
+    "dateTime": 1634951280,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "eb818cf5a260be8fd6d1993b1f89907666103b08",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nlc27pgdc5qr5w8fvdvzxm8sn90cairqs9bh8msk48n5igkfd06",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Provision"
+  },
+  "packages/apps/Car/Radio": {
+    "dateTime": 1639260470,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "33f951e907cc6e219187bcc0d7783f8c1ea8c2bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07r9i8cq3sas1qkmzvk2c9z2rk6z5k6x10bl53dyqmskl4c9r3qd",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Radio"
+  },
+  "packages/apps/Car/RotaryController": {
+    "dateTime": 1637798903,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "6f82878a371d6321918fa38727bdd77cab1e561d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zcyfwbwmd37yzvyllmh4hf39f8mz6q1ingz30izd4mw2mn0s9jl",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/RotaryController"
+  },
+  "packages/apps/Car/Settings": {
+    "dateTime": 1642212471,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9f34e911c9addf635dca400b1bd94e75d3e81ad2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hwkn8vpyblq4f54sjjih5k6r5ralkafdsjcr2kn6n3q79ci4081",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/Settings"
+  },
+  "packages/apps/Car/SettingsIntelligence": {
+    "dateTime": 1632957134,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "edefb4fffcc45786aa12afd875ad01014c6924ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f22j3sdh649nv3mywn29hpw9rgbl3p1ad3i22dbfxy1ghyl4ryw",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SettingsIntelligence"
+  },
+  "packages/apps/Car/SystemUI": {
+    "dateTime": 1640304450,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bf541d6f4c2d2f716077512a969c6b913b3f08a8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12pm6fx1snsdnc6lxpilzqljbbs4ns8h5f4di67s5mfd2zsyxf6h",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUI"
+  },
+  "packages/apps/Car/SystemUpdater": {
+    "dateTime": 1625015342,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1c4ff5eb8bd0a3e6b7aef48f666c07fe111fb1b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c5i2y5p3y5gmbdi4fl3k6nrifr9kp1g15115i92fg3vh78f4g0x",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/SystemUpdater"
+  },
+  "packages/apps/Car/libs": {
+    "dateTime": 1642370875,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "0d8f54f8c1507b290726e2175ec08b7ab446d3c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gikia1r6aaabsvigimb91jlxd15s3hil93lrfypfsgnbidwndqb",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/libs"
+  },
+  "packages/apps/Car/tests": {
+    "dateTime": 1634771332,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e87f971283d6a47d4fe97289717b859731024dfc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06zmkfp6jfdqjwi10ph1zv52mjj8af8fcj7839gj3gccn0asdkii",
+    "url": "https://android.googlesource.com/platform/packages/apps/Car/tests"
+  },
+  "packages/apps/CarrierConfig": {
+    "dateTime": 1637021277,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "98888a24136dc93592304c4a6a49d968d6806646",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13q1lpnynivdgigx28cl5rgi4hwyyvbnzgikhk52bcq4f1x1aqx0",
+    "url": "https://android.googlesource.com/platform/packages/apps/CarrierConfig"
+  },
+  "packages/apps/CellBroadcastReceiver": {
+    "dateTime": 1641859666,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b5c047ea4d8d14cf6225070610bb64583524a886",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "098iyr05n1hknvah3yz2rrnmq44r97ar6pfnlb3ija5i2sdhjd8z",
+    "url": "https://android.googlesource.com/platform/packages/apps/CellBroadcastReceiver"
+  },
+  "packages/apps/CertInstaller": {
+    "dateTime": 1640304460,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9f27c5a3b99acea393632ffa6f095ce2e01f7b77",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ijdyzrn2dnzbap9q807p8b7vri65d6d37yvaxss1n9vfv9c7j8q",
+    "url": "https://android.googlesource.com/platform/packages/apps/CertInstaller"
+  },
+  "packages/apps/Contacts": {
+    "dateTime": 1642212475,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "fa6bb63a6009a9dfff9f7714840e15d76137365e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09qgcxnlhhmgr6yqm8yis0ps93hmky569178jg6wrrq7nwrr4vw6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Contacts"
+  },
+  "packages/apps/DeskClock": {
+    "dateTime": 1614996472,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f3a1965ccc51800d88aa8cf0b205a9c0ae870e6c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v7bkqlsi8q3djjbs6h449p3nw9mg0c120y6bj37nkmyci4lw9nm",
+    "url": "https://android.googlesource.com/platform/packages/apps/DeskClock"
+  },
+  "packages/apps/DevCamera": {
+    "dateTime": 1621048139,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d2302e4f0203f85c525109e6c2da40e6ed94dee6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10vv74hndkdq9281dxsv8jk8frfjjqkqw2h48wc63c762mvvfy5f",
+    "url": "https://android.googlesource.com/platform/packages/apps/DevCamera"
+  },
+  "packages/apps/Dialer": {
+    "dateTime": 1642032704,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a41177dc1cbf71acb73994326c4275d3e1d0c231",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1k6225a3dyjxr6rz9rkir2grl621csx7lq74fk7z2ri068fzz6fv",
+    "url": "https://android.googlesource.com/platform/packages/apps/Dialer"
+  },
+  "packages/apps/DocumentsUI": {
+    "dateTime": 1640304462,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4f81e1d5741de7745d3a66dfbcc88241b6cb87c5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gb14ib3lsyjvrw9fn15d27ps4aqpi2hsyyzq944snw65jpa2xvi",
+    "url": "https://android.googlesource.com/platform/packages/apps/DocumentsUI"
+  },
+  "packages/apps/EmergencyInfo": {
+    "dateTime": 1637374095,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2fa54ac859326b5269bd83ce44d71ffb5ea62d0c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v1knymy2blg11ngp5ghs1kinsv6089zzwws831m9vc7f0mdn6bx",
+    "url": "https://android.googlesource.com/platform/packages/apps/EmergencyInfo"
+  },
+  "packages/apps/Gallery": {
+    "dateTime": 1613866087,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "da6de657d71910fc0dbf892163b3da5e46da5ea1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jvm1nsp49a8bdzrykm2ywi5d8kp5s79ynxsaazr56xh88m63swx",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery"
+  },
+  "packages/apps/Gallery2": {
+    "dateTime": 1641514069,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "50858942875fcfffab4fba142e277ccb9422ef75",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0clkzqc5d3ws2znaag6ynwnavz3372limgvzygmphpk5wfcdgm3k",
+    "url": "https://android.googlesource.com/platform/packages/apps/Gallery2"
+  },
+  "packages/apps/HTMLViewer": {
+    "dateTime": 1632957141,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "2665748ca3600a43c48457b17d4de51b6f476fae",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lswma9bl2chznhblrfkg5vrj7h04yyz7vj1rpwvxasaa6agm9hd",
+    "url": "https://android.googlesource.com/platform/packages/apps/HTMLViewer"
+  },
+  "packages/apps/ImsServiceEntitlement": {
+    "dateTime": 1639188458,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ec7f105308ed96d7b1043570ce28cd691bc9f111",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0aifd6g4fisbfjlzd98amlg23swdlrsx3n52nc4hn71195nrby07",
+    "url": "https://android.googlesource.com/platform/packages/apps/ImsServiceEntitlement"
+  },
+  "packages/apps/KeyChain": {
+    "dateTime": 1640304466,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "16423e18916765778093809f2a78dffa5cbea034",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nfxygswbzbfmjj8zqkf8my4md2wmcqb6bhb9hqcigy9ggsw26ar",
+    "url": "https://android.googlesource.com/platform/packages/apps/KeyChain"
+  },
+  "packages/apps/Launcher3": {
+    "dateTime": 1642971428,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "01399534da580196375f44e2a7ec78e4030d6a5d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0l4w46z3rs423yv0s860962kdqyq121jvln1kqynacx87ykkbjrc",
+    "url": "https://android.googlesource.com/platform/packages/apps/Launcher3"
+  },
+  "packages/apps/LegacyCamera": {
+    "dateTime": 1613866089,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "353905a19aafa95cba6d0266a41f70206d2d7918",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xlgpy1lpcixp767g81kahhzid6g81qa4ghzk0q97jpqb9dp7fsy",
+    "url": "https://android.googlesource.com/platform/packages/apps/LegacyCamera"
+  },
+  "packages/apps/ManagedProvisioning": {
+    "dateTime": 1641766171,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "20e95bf46ba0ff7697f89daf3296b73a667f8a3b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07ink9vr79rvwz6v3cv9kv9alvall3mw8p2wchhqrny0ypz5qb0l",
+    "url": "https://android.googlesource.com/platform/packages/apps/ManagedProvisioning"
+  },
+  "packages/apps/Messaging": {
+    "dateTime": 1642032714,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "11f36983aeb3349e5c47499f2c4043b11a5ca247",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x990xlwf9fj3y4zlwplxil2d9bjq2334nl135vn58vkbs0nal0z",
+    "url": "https://android.googlesource.com/platform/packages/apps/Messaging"
+  },
+  "packages/apps/Music": {
+    "dateTime": 1613866090,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8fbbaa3e4d92fb35bf02510cb4de50a482917ef5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0as5xx38vj9lhkqx0vwd76sdn53cd3f3p2igb48lbx31d037q4c3",
+    "url": "https://android.googlesource.com/platform/packages/apps/Music"
+  },
+  "packages/apps/MusicFX": {
+    "dateTime": 1639188461,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3bac83689ae7b8cb17d98cda6b4a660fa3837c82",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rv1vgy29dal28480i15qndz2c2kbbp5fh7qbkxpvzclixbdc3b7",
+    "url": "https://android.googlesource.com/platform/packages/apps/MusicFX"
+  },
+  "packages/apps/Nfc": {
+    "dateTime": 1640398066,
+    "groups": [
+      "apps_nfc",
+      "pdk-fs"
+    ],
+    "rev": "a67a3c3bfb4a82fc894b0dc76f1622894d16e5ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jvknf69yjldvypnrnsnrlib33s7llnsz5h5ml2r8aglf16qy9aw",
+    "url": "https://android.googlesource.com/platform/packages/apps/Nfc"
+  },
+  "packages/apps/OnDeviceAppPrediction": {
+    "dateTime": 1613952494,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1b0b7be544d0e72c7e41fda25ec6cdbd68650524",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fkf6vkd884q62xl21kayi6113ggay9yla8v89nq1dyp2k5w3dna",
+    "url": "https://android.googlesource.com/platform/packages/apps/OnDeviceAppPrediction"
+  },
+  "packages/apps/OneTimeInitializer": {
+    "dateTime": 1612577323,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "76b137e71ce6e1ebf6db6e8e22d3fedf939e0886",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1p5xhhljcd2bcpb57b22h65rgsv6k11l3xdi0bc4jaim9p12sikp",
+    "url": "https://android.googlesource.com/platform/packages/apps/OneTimeInitializer"
+  },
+  "packages/apps/PhoneCommon": {
+    "dateTime": 1640304470,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "61a9598db4a4de9a140b442d9df8fe50c5584876",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nmrb5nw162jbk3sz8v1jip0gxb4fr83bgfq0x0wc793gh9x35nb",
+    "url": "https://android.googlesource.com/platform/packages/apps/PhoneCommon"
+  },
+  "packages/apps/Protips": {
+    "dateTime": 1613952496,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "af8dad5bc9887d266104024e02ae3ee3605d7b45",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0krih7himlvr4i051i1ccrr46pvz34nl7zabxq37i5902fg7ifn6",
+    "url": "https://android.googlesource.com/platform/packages/apps/Protips"
+  },
+  "packages/apps/Provision": {
+    "dateTime": 1613866094,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "074ef3bba737be35309908f6ae51596451aa5122",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1b52p9b9i19cg8pip9ykfj5finlvxxv9ikwjfjpk022pzg0p0zz2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Provision"
+  },
+  "packages/apps/QuickAccessWallet": {
+    "dateTime": 1632532089,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "25d5a10d6ec959107d3124bac192252abdd1be00",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z85rzf28s2f28jxpa89ja51yl8kf12z43a1k72lb7q7cgma6w9a",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickAccessWallet"
+  },
+  "packages/apps/QuickSearchBox": {
+    "dateTime": 1633043730,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "b7bb52abf16b6428ac490bd483febcc65cfb3f1d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "144xmkff19450fqiihysyma0n40jzsqgkrwxdgjq2ja6ipdq4ccl",
+    "url": "https://android.googlesource.com/platform/packages/apps/QuickSearchBox"
+  },
+  "packages/apps/RemoteProvisioner": {
+    "dateTime": 1639008638,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ecdb6e1cb1cd6ee6bfff3b24352cd2bd3d806a89",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1i0sl4y1f55g494p7kh0jn09lpbl24x5895hzgg8x10rzx72mjsp",
+    "url": "https://android.googlesource.com/platform/packages/apps/RemoteProvisioner"
+  },
+  "packages/apps/SafetyRegulatoryInfo": {
+    "dateTime": 1640131697,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "18029d421ab10a3f13499aa461811c29b2e5d256",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "106dkkz5v20cdy9kfxifgwdswmpql1szhrmmfc9f8lhh8sq83r6b",
+    "url": "https://android.googlesource.com/platform/packages/apps/SafetyRegulatoryInfo"
+  },
+  "packages/apps/SampleLocationAttribution": {
+    "dateTime": 1621048150,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7261c821898b8e3cf1f6cf6abd18fe427e3c6efc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rl5fafh4w2ly59yby031ag1h5b1i7fp01i89qlsc85x5c4k3ash",
+    "url": "https://android.googlesource.com/platform/packages/apps/SampleLocationAttribution"
+  },
+  "packages/apps/SecureElement": {
+    "dateTime": 1621048151,
+    "groups": [
+      "apps_se",
+      "pdk-fs"
+    ],
+    "rev": "a43dd4bbc5dcbfa7964602f62d41ae268a2d4cf4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0csvapdfp737y40sywzxbk87bx20dn3j7ppalz6wigc25r2a5wz8",
+    "url": "https://android.googlesource.com/platform/packages/apps/SecureElement"
+  },
+  "packages/apps/Settings": {
+    "dateTime": 1642212490,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "860167796503cf549e5b2351f29ee2064456c2ec",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h5ifzpd2s8377cways45dxdcxqfg4yig0aj1dph31a27635kjc2",
+    "url": "https://android.googlesource.com/platform/packages/apps/Settings"
+  },
+  "packages/apps/SettingsIntelligence": {
+    "dateTime": 1637626079,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "795b2e8ec56c335ca3ef115aa8d213bc1b4dee77",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mzczwh353ligq0fchwgcvvy8sy8riihq0rg3n8x7zcr23py4q9r",
+    "url": "https://android.googlesource.com/platform/packages/apps/SettingsIntelligence"
+  },
+  "packages/apps/SpareParts": {
+    "dateTime": 1612577328,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "00ea839dcd6bcba58f38b8fc4315d99b2a42dd41",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1maawjwjr5mcyh62h02fv6g0jhchfw653y89mmjr1wc9xf13ywvn",
+    "url": "https://android.googlesource.com/platform/packages/apps/SpareParts"
+  },
+  "packages/apps/Stk": {
+    "dateTime": 1631322490,
+    "groups": [
+      "apps_stk",
+      "pdk-fs"
+    ],
+    "rev": "4e3a72a1abd5653905fbe498f49fdbd52e28da53",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05fmh1jk7a0a36sfm0jkv4q1g5h1i02i01fmip2d3czq27xq3l6q",
+    "url": "https://android.googlesource.com/platform/packages/apps/Stk"
+  },
+  "packages/apps/StorageManager": {
+    "dateTime": 1635808092,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "02fad24fb57aa806e68c220209caa6ce5f2c7083",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1496k7wchbxwnngb9sdl78ihgqw00lm2bdjcy8ybdzn3530r7rx7",
+    "url": "https://android.googlesource.com/platform/packages/apps/StorageManager"
+  },
+  "packages/apps/TV": {
+    "dateTime": 1621048156,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "61c86a7b1f067f2dc40370100d777cf72cc6387b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qx3r6m8crigjdxyhxbbfvmrs6r9yjjsjkz5i6aclg2l02hmrqq8",
+    "url": "https://android.googlesource.com/platform/packages/apps/TV"
+  },
+  "packages/apps/Tag": {
+    "dateTime": 1636416540,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e805e59412275eae27e0b00ef55d5bdd26f59237",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0889fsahy8yk9p97kwcpalw1bdnrvkrfsxlavdh4nl8af6phvj40",
+    "url": "https://android.googlesource.com/platform/packages/apps/Tag"
+  },
+  "packages/apps/Test/connectivity": {
+    "dateTime": 1613866100,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5ac4a80167faa247d0886521df4aae73b09638ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10mb5gqc3lyi02r4i68yqhqxiwik1xdi87ik9s6lr9b04clf1fax",
+    "url": "https://android.googlesource.com/platform/packages/apps/Test/connectivity"
+  },
+  "packages/apps/ThemePicker": {
+    "dateTime": 1641766184,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ad3ae978ac8422d0d3b35391dfdb1df5dcf7f2e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fbqp3vkiznls6g99cx96dkp526p91w5f0q42b0h9401k278bygc",
+    "url": "https://android.googlesource.com/platform/packages/apps/ThemePicker"
+  },
+  "packages/apps/TimeZoneData": {
+    "dateTime": 1621048154,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "95758a1e926ad7eefec8d875c0ce10b877d3fa7e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07ap27ilgs63idvgw1lyzy64djz657ad4wz273y0pibgh3nm5fj9",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneData"
+  },
+  "packages/apps/TimeZoneUpdater": {
+    "dateTime": 1622862539,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "73951f1b770265a77f107508b1934c0b1c83c1c0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12ir26ysn4n8q1mvyhxp0lmry7k51zam3n2pcdkg3v3g1s344g80",
+    "url": "https://android.googlesource.com/platform/packages/apps/TimeZoneUpdater"
+  },
+  "packages/apps/Traceur": {
+    "dateTime": 1640218112,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a7e57c03311696da085b747ec30fba383b86253b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f55pivbxv9rjn8bah93bhcnhjvq3afv1f01ssihyqlxfck09xig",
+    "url": "https://android.googlesource.com/platform/packages/apps/Traceur"
+  },
+  "packages/apps/TvSettings": {
+    "dateTime": 1642370897,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "7f2e968a105659a64189c719d6d1c8bed5a32071",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1q4fm8b38i871ypm5l70aabaw622k0d46mn8v7ypc5ms18h2l55h",
+    "url": "https://android.googlesource.com/platform/packages/apps/TvSettings"
+  },
+  "packages/apps/UniversalMediaPlayer": {
+    "dateTime": 1613952505,
+    "groups": [],
+    "rev": "9e62a42f9ca6fd3d2b2baa7be21b3e39d566cfe0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bzyk8zck067snc55bknnd4rsmsqkx3y41yg5w9lm410a7vr7bgz",
+    "url": "https://android.googlesource.com/platform/packages/apps/UniversalMediaPlayer"
+  },
+  "packages/apps/WallpaperPicker": {
+    "dateTime": 1612577334,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f45428e8fbd48acb7389966791f49228102988e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1amwx8m2ckvx5clggdsnwas0ix9qnam2z9sfdwy9wys6rb9mf2qp",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker"
+  },
+  "packages/apps/WallpaperPicker2": {
+    "dateTime": 1641766186,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "078f77d1c9974a9fae60616ff52ebbf7a40ed798",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lsz2p2yil09igrxmhq5g0ck8yxk1qiphn0d4srsx4415pwza3m7",
+    "url": "https://android.googlesource.com/platform/packages/apps/WallpaperPicker2"
+  },
+  "packages/inputmethods/LatinIME": {
+    "dateTime": 1642118948,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "665c11339e44f8e4596dde706bf46de698107080",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1835hvs1f77rz2hvdzdyll16x2wdaw2q5q80dkrimxalkjazak05",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LatinIME"
+  },
+  "packages/inputmethods/LeanbackIME": {
+    "dateTime": 1612577335,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "a5ef8597eee47a0752bb102bf7ff087af4525ab4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19wfvg8izsyvb2fwy1gl21vfk7v9c1icbpw542pqcjdyc6dyb672",
+    "url": "https://android.googlesource.com/platform/packages/inputmethods/LeanbackIME"
+  },
+  "packages/modules/ArtPrebuilt": {
+    "dateTime": 1625533760,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "08cf0ad7ad2b873d7f80dea1929d1c95689c82d3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0i9lnw0byhqxwz242kbr5dhi8dg91grhkycp9jp5icdpza28l66b",
+    "url": "https://android.googlesource.com/platform/packages/modules/ArtPrebuilt"
+  },
+  "packages/modules/BootPrebuilt/5.10/arm64": {
+    "dateTime": 1610155294,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6329430a0ec34dc6ec466483c4695e58c8f44134",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1n7apxd43m3i2sqgjcp80garn9zznfcsq67gnm0nywp0bbi7wd58",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.10/arm64"
+  },
+  "packages/modules/BootPrebuilt/5.4/arm64": {
+    "dateTime": 1613866106,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d2480a5bffeeeec6bb7affea21160d14e0f6c78",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13gs7i4dcwmjwld93q0w47ar1gcah0kaqbkxacwlc404axfzqg72",
+    "url": "https://android.googlesource.com/platform/packages/modules/BootPrebuilt/5.4/arm64"
+  },
+  "packages/modules/CaptivePortalLogin": {
+    "dateTime": 1640304485,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e46a32610782ac4f403c7849a5f357c33c7db412",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "128407hvkascjjx4j707qc3lphi5j2jf762grc02jqhmd2xf3x35",
+    "url": "https://android.googlesource.com/platform/packages/modules/CaptivePortalLogin"
+  },
+  "packages/modules/CellBroadcastService": {
+    "dateTime": 1631322500,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "fe9c3fca48b3f7ec59112f1e9cdd29b90d6fa98c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0slndn640xczh9ry6lplyf9im6b26z9n6v4d367ihbv85kn3yhib",
+    "url": "https://android.googlesource.com/platform/packages/modules/CellBroadcastService"
+  },
+  "packages/modules/Connectivity": {
+    "dateTime": 1644453737,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "0241a9c6750dab1f00a287db393f557af21a0b8b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "031i909n3nxl3q7drkr0j9kn7l4chz6ajign9myharixnvjwjkmx",
+    "url": "https://android.googlesource.com/platform/packages/modules/Connectivity"
+  },
+  "packages/modules/Cronet": {
+    "dateTime": 1625281904,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "263adbab66abd82cb8f1c0ba6e79f4eebb096e12",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Cronet"
+  },
+  "packages/modules/DnsResolver": {
+    "dateTime": 1628305748,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4d7441d19555aa51a2d28ecf8ab91f16565a346a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ckllgahhki8dcx3md37x6jcyjm5maxmh98l43d107h14h1bva10",
+    "url": "https://android.googlesource.com/platform/packages/modules/DnsResolver"
+  },
+  "packages/modules/ExtServices": {
+    "dateTime": 1634016992,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "27281218b81469ec8a799a877102495506e8e15d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "112sxv4lymh9sx4n1ai9hcxd56wpjc9fbll1ih6bvx2421y65ar6",
+    "url": "https://android.googlesource.com/platform/packages/modules/ExtServices"
+  },
+  "packages/modules/GeoTZ": {
+    "dateTime": 1624324321,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "847898e262b2095278794afa500fc40b998f7166",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xw9s4x82r3aa98wcr5cbmclcw2cmmc22palh14ylsypcvpb4zip",
+    "url": "https://android.googlesource.com/platform/packages/modules/GeoTZ"
+  },
+  "packages/modules/Gki": {
+    "dateTime": 1624324322,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b8e30e41665be796e23f3602dfd4d411afef3f6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1snci4l616cvznfbgw3xvmkvsa3i95q1v3fp882327wmv65nrqww",
+    "url": "https://android.googlesource.com/platform/packages/modules/Gki"
+  },
+  "packages/modules/IPsec": {
+    "dateTime": 1628975345,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41709f0396b9e719e57c5af502e72713f1396740",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v2qw6hjafasjn9vby9wac9kp204nfn0y3j0abhz2i591jnbzkdl",
+    "url": "https://android.googlesource.com/platform/packages/modules/IPsec"
+  },
+  "packages/modules/ModuleMetadata": {
+    "dateTime": 1622164166,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cc80967659a696e4fe879fbb5ac50e951b01af30",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wl1mb6fmnym4yyi1w4fc0zni7awb50mh9w91a6plp5j1rmy3x87",
+    "url": "https://android.googlesource.com/platform/packages/modules/ModuleMetadata"
+  },
+  "packages/modules/NetworkPermissionConfig": {
+    "dateTime": 1614132557,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2b965abf7d4a3c8a8b69b32d9e1738942d4e81a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nz2xs3rmpvbfwka7lxr87chqpchq57cc8r25qfgymbhnkkg61pl",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkPermissionConfig"
+  },
+  "packages/modules/NetworkStack": {
+    "dateTime": 1637107684,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "23d55617b5bdf0d25419bf2faaff06c3f0e80904",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zyn71a8b1a95i2d03c7xgk1rklffa96vm7qphafixsp41hg5b5s",
+    "url": "https://android.googlesource.com/platform/packages/modules/NetworkStack"
+  },
+  "packages/modules/NeuralNetworks": {
+    "dateTime": 1642118957,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "886f7bc65ba59c872fca387f353a9f18353dbeb4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1vmbfq7wi4lyam5ha6cs34xk1hy41p4lvbv4ri5hp2gb6bs5zaz8",
+    "url": "https://android.googlesource.com/platform/packages/modules/NeuralNetworks"
+  },
+  "packages/modules/Permission": {
+    "dateTime": 1641946246,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "29bfd2e477e3a476d40203383d084ceec460be6e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ns3gpabxqcykx3wwmmdaxpay7wjh8f9q98n7wh6cfz8dplm11w9",
+    "url": "https://android.googlesource.com/platform/packages/modules/Permission"
+  },
+  "packages/modules/RuntimeI18n": {
+    "dateTime": 1623892165,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1dbde093ef16dd10f985715d8b7ae5fc5446fadd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "016clxna7xjxwy42chxfdcp48ny0j3g4nyxg57zvqglgrlx8cqp2",
+    "url": "https://android.googlesource.com/platform/packages/modules/RuntimeI18n"
+  },
+  "packages/modules/Scheduling": {
+    "dateTime": 1641607692,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b37362855cc040c3e62b6505d3d5a765c994e580",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hcyrwbd156cm8xmcqdlb3rcs5ijbmmrsv4r0vrvgygidwwyr9sw",
+    "url": "https://android.googlesource.com/platform/packages/modules/Scheduling"
+  },
+  "packages/modules/SdkExtensions": {
+    "dateTime": 1628305752,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "10e0ba59b54d1c6b6c95e7292e36ee10c2d3d9a4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m4pl0v7f56g74ym76qrq198g6pnd93w8zh05bynvyvarwbajphd",
+    "url": "https://android.googlesource.com/platform/packages/modules/SdkExtensions"
+  },
+  "packages/modules/StatsD": {
+    "dateTime": 1641607693,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b5b3864ea2e2cafae2357684f9814bdcc6ea3a78",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06fwxkjkk8rq23s9y7r8d5nyjkmyczq87p5jqw4m98wgczyfa6zw",
+    "url": "https://android.googlesource.com/platform/packages/modules/StatsD"
+  },
+  "packages/modules/TestModule": {
+    "dateTime": 1539195664,
+    "groups": [],
+    "rev": "f243a50ca2d988ec33db18663700d556ef3b5e2f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/modules/TestModule"
+  },
+  "packages/modules/Virtualization": {
+    "dateTime": 1625706972,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "11cbaaff36b3938024cce93c5858dc3d877fd152",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1i7h4ppc6clrz7q992fmq7wsw7pznpai9kinwb2w87b0m3yzplk5",
+    "url": "https://android.googlesource.com/platform/packages/modules/Virtualization"
+  },
+  "packages/modules/Wifi": {
+    "dateTime": 1641859712,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "42f6c119938ffc82ca6d101b11d63e97b945807f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11qj79m8lc7avkj32xa5n2csr1lfclcnsi18lf94hnpjrxrh8r2b",
+    "url": "https://android.googlesource.com/platform/packages/modules/Wifi"
+  },
+  "packages/modules/adb": {
+    "dateTime": 1642284497,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "1d49bb2de455a24978634cfb0acca26798354ed0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "046m5xzffvnk088b6w15xjgfa256kmrv90755p3bbv4n5fi61qqg",
+    "url": "https://android.googlesource.com/platform/packages/modules/adb"
+  },
+  "packages/modules/common": {
+    "dateTime": 1632870541,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "fa7d2d6bc1aa45b8464e678450b23c87568d5662",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09fkff1dj3m77sw9z0s4ag6cjhdz9662rddydzq3xsrscdrs3aps",
+    "url": "https://android.googlesource.com/platform/packages/modules/common"
+  },
+  "packages/modules/vndk": {
+    "dateTime": 1631747375,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "246593fc9a09cc4d5b065c1507e8e14b80d4852e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y89gdy14mlhrwhf39f3ibqg28ndf1bfkknhv8zxhm2xv28yz4wv",
+    "url": "https://android.googlesource.com/platform/packages/modules/vndk"
+  },
+  "packages/providers/BlockedNumberProvider": {
+    "dateTime": 1635808111,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "3afebb83d2d114e28edea9db27bb7ff759654288",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0w021wx0aj1r5bldfbb9mf1v98isgjcyp45d3h0aa3k77vbs8dal",
+    "url": "https://android.googlesource.com/platform/packages/providers/BlockedNumberProvider"
+  },
+  "packages/providers/BookmarkProvider": {
+    "dateTime": 1613952519,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "9d98ccb944e64462c38a43ca18c666fb6e4abd05",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06p1pl2iq980hibsdal7jq7qnmvsr3w4zw88jvr53ifgjvaj7jyy",
+    "url": "https://android.googlesource.com/platform/packages/providers/BookmarkProvider"
+  },
+  "packages/providers/CalendarProvider": {
+    "dateTime": 1627348169,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "581ef636e89b2e69ddfdbb741a3118cd4afed0d1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10g01wxvmkylh7r7kjq2analk29zfs2xqaql75h0rw5bnvxkmfdc",
+    "url": "https://android.googlesource.com/platform/packages/providers/CalendarProvider"
+  },
+  "packages/providers/CallLogProvider": {
+    "dateTime": 1621048172,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "f9464eceb2ed521983273c6cdacb940609ddcc2b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qxaag2rzr45ixnnmzl88xhssvvlaz6mijizj75jkrdslj61q2ha",
+    "url": "https://android.googlesource.com/platform/packages/providers/CallLogProvider"
+  },
+  "packages/providers/ContactsProvider": {
+    "dateTime": 1635808113,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "ae32e2727b1a4ad8c4096a7a6bf7ed28f36e5734",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nwxlf6wvv4pp5y4my9iv172gl4kp1ic9l1q24696p4bvga7wybp",
+    "url": "https://android.googlesource.com/platform/packages/providers/ContactsProvider"
+  },
+  "packages/providers/DownloadProvider": {
+    "dateTime": 1641946253,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "04bd60558e202dd5dd62c6f65041cbf33e0ff0c4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y4jl93wphpnlvkg9sxah2byrpcacc2y7si9fnk4g3j1kg61xbsa",
+    "url": "https://android.googlesource.com/platform/packages/providers/DownloadProvider"
+  },
+  "packages/providers/MediaProvider": {
+    "dateTime": 1641341319,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c358b1802f0f5570afe1963f10e4c34b5eb00bbe",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0khckpmh46jkf74agp6s6cq4knl22khkgvmrkrkkfh33rf4bfv3j",
+    "url": "https://android.googlesource.com/platform/packages/providers/MediaProvider"
+  },
+  "packages/providers/PartnerBookmarksProvider": {
+    "dateTime": 1613952521,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "e621c4e124e46a759a04d597f976c243686d0355",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12s14vcmpypbk2h116n3spvqg4akj6xizjrw7vilab7ln8wp89i5",
+    "url": "https://android.googlesource.com/platform/packages/providers/PartnerBookmarksProvider"
+  },
+  "packages/providers/TelephonyProvider": {
+    "dateTime": 1637194356,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "2e11fe45014a31442e30539b784b979268ba6b0e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "00p4mhh3d3jn023dl2pkvw6gz92mr79c6wc1742iimjpzkxzc058",
+    "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider"
+  },
+  "packages/providers/TvProvider": {
+    "dateTime": 1641766205,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ef12ecacc3bbbcb0af105db9433bbb6d5661b0cb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wq8rhwbfxh1aqdgr60r3vvyi1p566cr02nwslqx5fxw5xnbbgp2",
+    "url": "https://android.googlesource.com/platform/packages/providers/TvProvider"
+  },
+  "packages/providers/UserDictionaryProvider": {
+    "dateTime": 1624497274,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "bb2576b612962c0abc5634d65ef8ba4094c51e14",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nkkxj3mm39lp6ga1icachqykkcarfslxi3jngxj8v1rriqa710w",
+    "url": "https://android.googlesource.com/platform/packages/providers/UserDictionaryProvider"
+  },
+  "packages/screensavers/Basic": {
+    "dateTime": 1622596190,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "791cbfe4158a112743c0d0591bf783db02e6b965",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03wkn8gl92cdcqkykb1m5kpmmzmc46hlinz4gyprpacn8wgr6zqx",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/Basic"
+  },
+  "packages/screensavers/PhotoTable": {
+    "dateTime": 1637107695,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1a9f4efe0b08da8117fd0a82c2aa2822577529b7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c5dks82czxys3cnmi86rvrpwgc1xgghgvrg8mx3nzvx6b54yhb2",
+    "url": "https://android.googlesource.com/platform/packages/screensavers/PhotoTable"
+  },
+  "packages/services/AlternativeNetworkAccess": {
+    "dateTime": 1630717700,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "9423e224f949cd6c0e8e2afad45b7b81e3a8ff53",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16b84vhvra87k6ricz42wi0i3byvb3bz9ivn464fc486j5vkgs49",
+    "url": "https://android.googlesource.com/platform/packages/services/AlternativeNetworkAccess"
+  },
+  "packages/services/BuiltInPrintService": {
+    "dateTime": 1638403772,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "29d8bc3803e6fadcc2e4d87a49dd15df7005910e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1jv80fhb3dgmgrjwlq8lpd1mrif5dpx5gd8imn1m6avd6k854vcz",
+    "url": "https://android.googlesource.com/platform/packages/services/BuiltInPrintService"
+  },
+  "packages/services/Car": {
+    "dateTime": 1641946258,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "cca8caf077a09cf154a6d9f7bbc5781c28e2f953",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "19cjhx5dsvqwvww3f7m1jxiw2vlv9r2z2z82a64xvz6jqifg2j42",
+    "url": "https://android.googlesource.com/platform/packages/services/Car"
+  },
+  "packages/services/Iwlan": {
+    "dateTime": 1635462547,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "f8d087f8ec888b505912ef529b74cc81d2bcaf02",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nvqkpryx3dhynckjrcdz9ayslh5ibixjv8caysw9k2mfrrnzljq",
+    "url": "https://android.googlesource.com/platform/packages/services/Iwlan"
+  },
+  "packages/services/Mms": {
+    "dateTime": 1621048178,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "b568cf154fd72a7f8748488d774cde2b06a6a970",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "192dhws43zp66czpx42kciwggd1p21mp34if3hkkcv8gqb5vkxsg",
+    "url": "https://android.googlesource.com/platform/packages/services/Mms"
+  },
+  "packages/services/Mtp": {
+    "dateTime": 1624497278,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "4693ead6c557952a8ad9b82d9d81c9878578bec8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0581pybyfy4npszpycjkkphir38nvj6b16zfl4ciz8fxg6dcwgqz",
+    "url": "https://android.googlesource.com/platform/packages/services/Mtp"
+  },
+  "packages/services/Telecomm": {
+    "dateTime": 1642118972,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "1b7085c15377542800c17e9881450bcb184e5c9b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "059x87p8x7bfk75jzjc9jjsvwb7wpy6cmdqzhv06xicvqxh7q2l0",
+    "url": "https://android.googlesource.com/platform/packages/services/Telecomm"
+  },
+  "packages/services/Telephony": {
+    "dateTime": 1642639636,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e8654e3560d021990f5507f76cafa987b92ea292",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1xh7nkv4wg408i910javcxgccp6l75z87yhrgwiaalp79v730jbx",
+    "url": "https://android.googlesource.com/platform/packages/services/Telephony"
+  },
+  "packages/wallpapers/ImageWallpaper": {
+    "dateTime": 1571790197,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "8f348f8aba5d3ac3436caec6b2dbe2819ae3dc00",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/ImageWallpaper"
+  },
+  "packages/wallpapers/LivePicker": {
+    "dateTime": 1639699769,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "bb4765fa5feaafff1e3ffd523f6bfe86ae371e54",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1iadl9j4xcf5m41w5yjnznp88jx7884riw3qd7pqdbrs7lnh3b1n",
+    "url": "https://android.googlesource.com/platform/packages/wallpapers/LivePicker"
+  },
+  "pdk": {
+    "dateTime": 1621048181,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "04db91bad47bf7e2291f1da91d79a8e7ae358f4b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zxgc4qgxsz4vn8qyzmp8m4zqy98fcsgjsn6abhlagp3ihjh27hv",
+    "url": "https://android.googlesource.com/platform/pdk"
+  },
+  "platform_testing": {
+    "dateTime": 1642032791,
+    "groups": [
+      "cts",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "a657cc370c86f4177906a0c08f526e83df7100ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c56gywz1bz21zlp7k4xsqxsn9yrfviif9i4lzgjn84igpb7bn3s",
+    "url": "https://android.googlesource.com/platform/platform_testing"
+  },
+  "prebuilts/abi-dumps/ndk": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "ab07d1ac0c8055e3c82e318aa0d91baf003eaebf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wv5rriip397yywjswk6d6ayp359kjw27mr5yd25vdv8p793pzja",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/ndk"
+  },
+  "prebuilts/abi-dumps/platform": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "18b350f54b2a6c98d8d5fef8735ff9c2700ae46f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bddynkzc67y3qbfhh9g7cn645027068g8x3503szglwzjdy83wj",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/platform"
+  },
+  "prebuilts/abi-dumps/vndk": {
+    "dateTime": 1637107701,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "386c90f376a517d8140fd2be52f3568c13bad82d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cpdayr5gi05vk1mfsijcc9kvb8ir7xxnrxbl5mnfgr7szdhn65s",
+    "url": "https://android.googlesource.com/platform/prebuilts/abi-dumps/vndk"
+  },
+  "prebuilts/android-emulator": {
+    "dateTime": 1629508120,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "cc76b08dcc4bee744989315a0bdadffd089d05df",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18s3ns14ar9zg89ydis0hyif9djjhngm29i4zxpac79b144iywj3",
+    "url": "https://android.googlesource.com/platform/prebuilts/android-emulator"
+  },
+  "prebuilts/asuite": {
+    "dateTime": 1628126016,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "28112cbe0696b231c6ef54d46801c377fb045743",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "012s3a4fb2gsd7rwn8vzf3b7k38zk1kl6i80r2d4cys5a9vmadxy",
+    "url": "https://android.googlesource.com/platform/prebuilts/asuite"
+  },
+  "prebuilts/bazel/darwin-x86_64": {
+    "dateTime": 1615601352,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "7429e501c14818b940d05e1700bfb322e8b9aa1c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wcwyr0n9m0v9mfyjb8f3ljck0w3payq39iv33f2w7n0kihqalgk",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/darwin-x86_64"
+  },
+  "prebuilts/bazel/linux-x86_64": {
+    "dateTime": 1615601352,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "1a2a239964e108991eb0f86245605f8f6da03641",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mf45cyj47xqfpxp3cvdibwbxjswb2n10gpdydvyb5aynpwg492g",
+    "url": "https://android.googlesource.com/platform/prebuilts/bazel/linux-x86_64"
+  },
+  "prebuilts/build-tools": {
+    "dateTime": 1621386600,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db6c7a2c83febb90a0c9fa38bcb2244d6158d860",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wph12829w8mj7ddrp9ml33igyg8qvw13hvjsv0jcl708pqnbnzf",
+    "url": "https://android.googlesource.com/platform/prebuilts/build-tools"
+  },
+  "prebuilts/bundletool": {
+    "dateTime": 1628809743,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3028d56d9beacf152c38738701c6b09e8c1c591f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zahhs55ba5zx98jf7vbcv8cas4fkqfp4a6inmci86rfj88rwvif",
+    "url": "https://android.googlesource.com/platform/prebuilts/bundletool"
+  },
+  "prebuilts/checkcolor": {
+    "dateTime": 1586493700,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "98206416175b430524ade3bdd4e645cfc85b0dd0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zaw6nl6k2l1d9g7rz45vybgi6yjmbxzfzz7kwrsgaymc27b060r",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkcolor"
+  },
+  "prebuilts/checkstyle": {
+    "dateTime": 1621048187,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2b167c3e6b100841be7d404ee36b3077153e1ec7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j0apf2ddqkxi2v3qqsbjbk9w5b6i7frjfyashymzcwvaz474p50",
+    "url": "https://android.googlesource.com/platform/prebuilts/checkstyle"
+  },
+  "prebuilts/clang-tools": {
+    "dateTime": 1613866135,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f2427ec833ed09f8991eaf5d923c777233c3427d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18l1ppiv14asv6bv2ivshdwmcgx6r100jjyrxjzl5hpi8zwm6wlm",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang-tools"
+  },
+  "prebuilts/clang/host/darwin-x86": {
+    "dateTime": 1624640195,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "e04d6ecddd55f3d2ed6edf027a59cb98f32239ec",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ks4mbdskbwr2r8mxk3ymx68709ccm96j06hgq2wvmc4bb9ajyx0",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86"
+  },
+  "prebuilts/clang/host/linux-x86": {
+    "dateTime": 1632352353,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a7787f61022f2df33cab37a5791b968b45c034ed",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0a8dbqq3qlsvsdrgymjk636rlv8zspfmqzrddx9nsysvkw5wmgsd",
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86"
+  },
+  "prebuilts/cmdline-tools": {
+    "dateTime": 1617930584,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "1d83d165edd4defc212626ef0091652943f84d61",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1h7r0mi51dgsgz61d3gmh0364zw8a3fgrg46fv26vwg2vj4dcp5q",
+    "url": "https://android.googlesource.com/platform/prebuilts/cmdline-tools"
+  },
+  "prebuilts/devtools": {
+    "dateTime": 1561663933,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "45004f99ee55e405ec13d13815194e7190f81bab",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yr6acnwdmwygnvd1kljs27pnhwywgm8gv7qp1m6ir23axwydx0s",
+    "url": "https://android.googlesource.com/platform/prebuilts/devtools"
+  },
+  "prebuilts/fuchsia_sdk": {
+    "dateTime": 1604451501,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "4a2576b2caab9c13296ceb333b3e8da2d9feb17b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0j1rnznlk5z0c985xb1fl8mxk52kwjl0c0vask9hka2bqwxcj7xw",
+    "url": "https://android.googlesource.com/platform/prebuilts/fuchsia_sdk"
+  },
+  "prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493704,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "ebd7c06978878d07c3137493f28101f9084720b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0svy6bm57kq0zkcmc1747x46b77jh4l0rbs8415ka50kvmhwph7s",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586493701,
+    "groups": [
+      "arm",
+      "darwin",
+      "pdk"
+    ],
+    "rev": "79805d3c31014ab3cfed67b70dc829e8a0b62434",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wv4rh1y00w0mjp535arw85psjfbzc3gplczzdhpanr1g4im5vlp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1": {
+    "dateTime": 1578436765,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "d3647885f34c4c236cb0a140072aad39ed4fa147",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gq7nqfj0pfgym7gqnxc12a6nr508zvxlsvgg80qz96cvsrl8gdl",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/host/i686-apple-darwin-4.2.1"
+  },
+  "prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586493704,
+    "groups": [
+      "darwin",
+      "pdk",
+      "x86"
+    ],
+    "rev": "4319afc78a20e2e2c4c2f073bd53675681af1a68",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1526g7ybbd0l31bvqdpbarscjsnp1rajfnb9bwyjy8wq1p4q1pcp",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/darwin-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9": {
+    "dateTime": 1586493705,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "2da2fdbb8d140e36474bcd2e3785d0fd0925520d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0ag3hyvwi9sr0z95v09iwnx6n8wccxsga8z0gwgm286i0q5m4971",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9"
+  },
+  "prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9": {
+    "dateTime": 1586494587,
+    "groups": [
+      "arm",
+      "linux",
+      "pdk"
+    ],
+    "rev": "59ec31110f6fe3432cb0862324e1892b5fefb91c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1am7mjlf4vsybkzgvhhiak6j00awykncg0137wqagshyz5b0sp2h",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8": {
+    "dateTime": 1621048193,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "2778bd126304f38d128404b2d450e6060bc6194e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bccbfl7imas5i47cnj5ms3lvsqkhp4nx37nbips3ia7d6fskjcs",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8"
+  },
+  "prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8": {
+    "dateTime": 1612577410,
+    "groups": [
+      "pdk-fs"
+    ],
+    "rev": "c7c9804a0b59456cd0dd690c42a3ef7db08d061a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1a0ls85jsic0xiyifqaxsp15s046j3a28p8c5mih8ya0hbw80x7l",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8"
+  },
+  "prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9": {
+    "dateTime": 1586494589,
+    "groups": [
+      "linux",
+      "pdk",
+      "x86"
+    ],
+    "rev": "0797b16f514602d2770927bd5abb6b641ef78c4f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0sbw4b8f21cmhxnx6ad5ia5jz1fhv7834m8xskaw4ik5dxrarm11",
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9"
+  },
+  "prebuilts/gdb/darwin-x86": {
+    "dateTime": 1575581434,
+    "groups": [
+      "darwin",
+      "pdk"
+    ],
+    "rev": "80d0ee1ac632419fe6cf1214eba41946eef387ef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0gs89dnw1xkpb94lism8s8arhlkyq52h7w1v530a3zdj656h7xrv",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/darwin-x86"
+  },
+  "prebuilts/gdb/linux-x86": {
+    "dateTime": 1575587382,
+    "groups": [
+      "linux",
+      "pdk"
+    ],
+    "rev": "9fb0c8392e02bd3ef46a15f8b10c53c55b918390",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v8y9rdivi8ydrbcvxrkdlzc8snjpdjwgzra2s7qrjpd2qg4k4k2",
+    "url": "https://android.googlesource.com/platform/prebuilts/gdb/linux-x86"
+  },
+  "prebuilts/go/darwin-x86": {
+    "dateTime": 1614046184,
+    "groups": [
+      "darwin",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "3edd58d6ec74f64a2b071f1ace25d7946a6c1c97",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16hxbnamn9cayw4fv940m22k6k3yz4m9nf3liy89z7bwl008s2yk",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/darwin-x86"
+  },
+  "prebuilts/go/linux-x86": {
+    "dateTime": 1614046184,
+    "groups": [
+      "linux",
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "d076a2028108e7fdd09b0aaf8d73f835f3791341",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07dv2mwbxazin9kf32fv6s30ac28q4khswfavql8d78zcmacgw03",
+    "url": "https://android.googlesource.com/platform/prebuilts/go/linux-x86"
+  },
+  "prebuilts/gradle-plugin": {
+    "dateTime": 1618024161,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6c161412f38a7d028a8f73dab298822f7dbef5a6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sap095xg08fz10f6rxhnnd0c5d2xlld1zphp41hbdga5fhsn8gb",
+    "url": "https://android.googlesource.com/platform/prebuilts/gradle-plugin"
+  },
+  "prebuilts/jdk/jdk11": {
+    "dateTime": 1615428530,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "613fe6f73324f08bb59cef13b44a8321011d8630",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03wsqba6nzghhrqsvsi33rfjh8hdzx98vjkx2as0l601l21cks8n",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk11"
+  },
+  "prebuilts/jdk/jdk8": {
+    "dateTime": 1551002778,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2097447152c4cfcc564579045a9e0d324a50f966",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0mhlk9jrbg0vjmy8fsjgzrn7cpywqixbj72va80mhaavp5425mg1",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk8"
+  },
+  "prebuilts/jdk/jdk9": {
+    "dateTime": 1600160960,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "de5c4706158b20afd075382e1cda2ff2c1538fad",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0f7b8cydz6j6pvgxln6g0dp62qz0g1768zszdiwswk8zcvzk80l0",
+    "url": "https://android.googlesource.com/platform/prebuilts/jdk/jdk9"
+  },
+  "prebuilts/ktlint": {
+    "dateTime": 1586494587,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "756e738785a2082b4a446e15ef3ea5c8af34d109",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11rsh1vvx4k2wyn6cmhq7s5inrg0nrvavvdcx3jpkrvdh3lr1laj",
+    "url": "https://android.googlesource.com/platform/prebuilts/ktlint"
+  },
+  "prebuilts/manifest-merger": {
+    "dateTime": 1613866147,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aa893e6c8708d660b62fb89f0be2404a3b00dc7d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0agc0j0mvr9fbi72x9dbf4dwsf9y8k4sniajzmdnkpyy5jlixd7d",
+    "url": "https://android.googlesource.com/platform/prebuilts/manifest-merger"
+  },
+  "prebuilts/maven_repo/android": {
+    "dateTime": 1572476701,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "26041ce5ea4dfca75a03b7de4f13f75ee79e3c6a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1vlh9fnsdlv60a28rb6sz45laiql495vccq5bzyygy5fsxswdhp7",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/android"
+  },
+  "prebuilts/maven_repo/bumptech": {
+    "dateTime": 1613866148,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "e7995a6ba850658b7be9784d26ccb2873eb4b91a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03wzcxnixq9gfzciy09qjxw97d46zdhzihgx3g5lqv6403il1lf1",
+    "url": "https://android.googlesource.com/platform/prebuilts/maven_repo/bumptech"
+  },
+  "prebuilts/misc": {
+    "dateTime": 1629508136,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "db25a96b3e1f185726662d9ae4c42ee2e34457e0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q26ggqh11aa3878njn3sfbmr7g1wklbk1yrl7pzd12mjvpla3ji",
+    "url": "https://android.googlesource.com/platform/prebuilts/misc"
+  },
+  "prebuilts/module_sdk/Connectivity": {
+    "dateTime": 1643410235,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "dc3cb0a80edf9460a9795a4f8cd421dafc5d0620",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0140l9y2amfc36fz4g7k6cb3zhpqy7m7w0qpz9dh7kv1gvq0gfr7",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Connectivity"
+  },
+  "prebuilts/module_sdk/IPsec": {
+    "dateTime": 1643410236,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "26dd46263f9487a40104da54e716610853691930",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09w9cmnlxxms4d52xbydz4c2gwxhdrv2yg354awg8iz6ri2s97yp",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/IPsec"
+  },
+  "prebuilts/module_sdk/Media": {
+    "dateTime": 1643410237,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6cdacc230cf80864777a41ca52ce44541a6fec65",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0dvbbpihyxrl1pvy61p9b2xqfadsvdcfd4v27nkr1n4pv50y0db6",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Media"
+  },
+  "prebuilts/module_sdk/MediaProvider": {
+    "dateTime": 1643410238,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f8c284b901376f743ef691e3403639d79409875",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1nw30m4in5vy90aqy5dbg98x4lxsgayz8dnnp5fq1yakb5akb2d4",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/MediaProvider"
+  },
+  "prebuilts/module_sdk/Permission": {
+    "dateTime": 1643410238,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f79ad092f6ec162c838a1267397fd70a4d4a9d7f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bnfh8yria5vlphm56pi5r5xsw3rchd2nalsw90fxw0cx4ji06zz",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Permission"
+  },
+  "prebuilts/module_sdk/Scheduling": {
+    "dateTime": 1638583751,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ee020e70044cbbb1b29c6164e7ee86d4e6643612",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1krvsxr582p3bqvgijpxzzx9nkwlbh02ib9yh6drn6srpbjlbr8m",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Scheduling"
+  },
+  "prebuilts/module_sdk/SdkExtensions": {
+    "dateTime": 1638583752,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ac2eaaa40036a954c648b2c2b8e6c3359899ffb8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1r6dvman8wgvgmy6kv2zr2vh1lwl3869b743dqmxsqc16wb2fwbk",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/SdkExtensions"
+  },
+  "prebuilts/module_sdk/StatsD": {
+    "dateTime": 1637885452,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "aaae3802afb56583916f5b8c2eaf6687e5e88a40",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "037ik8d8qkfb9i46m7dkknxb0xr3pmpsfg1x7jfkdxk1rbp5j151",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/StatsD"
+  },
+  "prebuilts/module_sdk/Wifi": {
+    "dateTime": 1643410239,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d1d7f8e21335fb650e71fd83f94afc91c745341b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11w5dxwa2sqf8sg2j78hr4ylp6sh1xip50cwzzf66b1c8lvcnhv6",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/Wifi"
+  },
+  "prebuilts/module_sdk/art": {
+    "dateTime": 1643410240,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c1cd575166b249317958fe1629e37dfb864561ec",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "132hdlcbfh0s5svs87b0hk1wgi3sym5pr1vni8jyspffk6gq09l2",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/art"
+  },
+  "prebuilts/module_sdk/conscrypt": {
+    "dateTime": 1638583750,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5c531bf7f4657c963062c8a837e546e5034c21ea",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zf61rlm3q2by6bi3bvfisw4f7xzb0j0jxjpk3i2v52ka4r0bsd7",
+    "url": "https://android.googlesource.com/platform/prebuilts/module_sdk/conscrypt"
+  },
+  "prebuilts/ndk": {
+    "dateTime": 1617419323,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4ea310e473d15f2375070c84e24961af88dbb3f8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "18g58y7abpi4kgc8zphv08yg89pcs6wazzm54v89lrbry6shhdp5",
+    "url": "https://android.googlesource.com/platform/prebuilts/ndk"
+  },
+  "prebuilts/python/darwin-x86/2.7.5": {
+    "dateTime": 1446753806,
+    "groups": [
+      "darwin",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c5b4d19aecdb433f0094bef55f1077a9de2c73e5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12i9irvl3adz7mbqrmv2w7c9qhr1hb9y6fvinqyrcd1bqgaxpn49",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/darwin-x86/2.7.5"
+  },
+  "prebuilts/python/linux-x86/2.7.5": {
+    "dateTime": 1551111763,
+    "groups": [
+      "linux",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "c1b256d1606776d47b34fa97bafe7c9ba60ec0cd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1fi19mwcmrp3ci4kc5dli1npak5bfy7zrmjwkrw1cdqc80p9hbzb",
+    "url": "https://android.googlesource.com/platform/prebuilts/python/linux-x86/2.7.5"
+  },
+  "prebuilts/qemu-kernel": {
+    "dateTime": 1613866151,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "899ad4bcbec7294310d446a53f5b425987265a7e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "174ffmr45kn5qkzbfc8a9irk8p2ksxzj5rylbbisswhlk7419rpq",
+    "url": "https://android.googlesource.com/platform/prebuilts/qemu-kernel"
+  },
+  "prebuilts/r8": {
+    "dateTime": 1636769352,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "75d1207bf7a640cd0e42848fe9f2c341586fb3b1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zic971y9dyymxlm0p3s3jsv7gddvxacb57177s2v0wmkvg2yxyf",
+    "url": "https://android.googlesource.com/platform/prebuilts/r8"
+  },
+  "prebuilts/remoteexecution-client": {
+    "dateTime": 1635894568,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5700a01138b47ff6fe6174c0a4cfbc01754196f3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0qjzgc0my99hgg1c82xikizs461sv04cxpvvcdrrq9748ac4ix8b",
+    "url": "https://android.googlesource.com/platform/prebuilts/remoteexecution-client"
+  },
+  "prebuilts/runtime": {
+    "dateTime": 1624929289,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e0611815b194838a82a29653c35d05b695e91a3a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0yyl276b039qmbz3b7mqnl4h3mqk5ggv0yq07k2hli9v09w55dha",
+    "url": "https://android.googlesource.com/platform/prebuilts/runtime"
+  },
+  "prebuilts/rust": {
+    "dateTime": 1636160959,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c5b98c74e3185e29dc5a6b7e661b5335bbb0192f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0cbms2bphjrijga9f9arndpxn1bsaps58k5gffxpvjvbcdczsc9c",
+    "url": "https://android.googlesource.com/platform/prebuilts/rust"
+  },
+  "prebuilts/sdk": {
+    "dateTime": 1638835811,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "cb9eb1536b9a74c6f11919bc6043fb9654c211aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "017cn9b1imrpj4h20xxbmi54ficqsnpd5yhr3x4fgmdmz53flarx",
+    "url": "https://android.googlesource.com/platform/prebuilts/sdk"
+  },
+  "prebuilts/tools": {
+    "dateTime": 1639793347,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "6bc4c15e224f8938510996244081ca2fa3cccdc3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h6rmmfspwk64cfw4hk50c54p5y8dm0i479zacxriwf8cipjaxsg",
+    "url": "https://android.googlesource.com/platform/prebuilts/tools"
+  },
+  "prebuilts/vndk/v28": {
+    "dateTime": 1636416602,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a226e6068cb617f34267f38992adaea0a7b8e5a8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1m4zvl6v8lk0ap262bklnwfk8j3bkbwh10j4h0j7dhvmjz7bk58f",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v28"
+  },
+  "prebuilts/vndk/v29": {
+    "dateTime": 1636416602,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c55344197001b78c435c73241d8a140b22e9e1a7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zr93lpdcmjrphyvn9f7i5wwvs92ss0phxh0i429arahhg8qlq1s",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v29"
+  },
+  "prebuilts/vndk/v30": {
+    "dateTime": 1640045347,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "8f38f8a4cbab6138b98d84ac9478b3e575c13981",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sssg906bx2g43bcszi65jvg9kmvdgvwxq9bgz6daadfxxalrf64",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v30"
+  },
+  "prebuilts/vndk/v31": {
+    "dateTime": 1637798988,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "edb6468753c1b54941e88d9ebadbd8714bcb5428",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1i8fw4r9yylq8ycwapj119cf2rk21i72rr7j1sd18h25f19vgg9q",
+    "url": "https://android.googlesource.com/platform/prebuilts/vndk/v31"
+  },
+  "sdk": {
+    "dateTime": 1613441354,
+    "groups": [
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "5ce4ccfce9df9ded9dbdeb2d9e6da1320a24f89c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1x4v7n0i9pcz91q5ii4lpwrmqr9v0hpwjv86mcqjzjw22rzi5rxa",
+    "url": "https://android.googlesource.com/platform/sdk"
+  },
+  "system/apex": {
+    "dateTime": 1635980985,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "efe65b730c47bc0ce0e66bdf6e70a91b2d7ec5bf",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0m9zrsbc2z4fdg2l1drakgc5560m7vgr00zhvk0as2iyq2l4j8xk",
+    "url": "https://android.googlesource.com/platform/system/apex"
+  },
+  "system/bpf": {
+    "dateTime": 1625620193,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3d9991f8a5e269ebd9a9f4de5300a40b6eb2d6e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qp4zl4hzq1xdm7j6qd44bx2fb821j746vyxz9296zi6nwqaj0hf",
+    "url": "https://android.googlesource.com/platform/system/bpf"
+  },
+  "system/bpfprogs": {
+    "dateTime": 1613866159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ddd0777232f93308e2c6c2b116b924283e4478d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "059l6k1y7jpjbkfamq83pjj8nzmghc5pqkz1p53pn556w1hr34jk",
+    "url": "https://android.googlesource.com/platform/system/bpfprogs"
+  },
+  "system/bt": {
+    "dateTime": 1640736556,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "360b71b015966d7bf35a29c0cf552b8430e10724",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "054mkfyz3m5nfwf76x7p6fr5jqjc8jc946fs1sm0llmc85p9rql4",
+    "url": "https://android.googlesource.com/platform/system/bt"
+  },
+  "system/ca-certificates": {
+    "dateTime": 1613866159,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9fac350f7370e598042fc639827f3f8b95aa3e84",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1rz4x4mrsv112csx3bykgi78rrf1sc4g8p5yvma2yyrcn7j0vxq2",
+    "url": "https://android.googlesource.com/platform/system/ca-certificates"
+  },
+  "system/chre": {
+    "dateTime": 1638317414,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "21605b5956939465d245b728e6fcc0874baf7d77",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07nz1sk5wzsds5b0mcic7jj5y1lxvjxf7qhh6xl3b4lzkirrnyfs",
+    "url": "https://android.googlesource.com/platform/system/chre"
+  },
+  "system/connectivity/wificond": {
+    "dateTime": 1628903529,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a931142760194c2f8ca1dc0422c9b7ee3646a4c3",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0lymnj2i95lcb3xmlawm1gpvrbr82y3kgggj1a71vcn4776bs7j3",
+    "url": "https://android.googlesource.com/platform/system/connectivity/wificond"
+  },
+  "system/core": {
+    "dateTime": 1643233201,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9fa1b63671cd708ba0f937246280226b2d64a15d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1lfy6cmsmfpv3m274hnlz42n61hyx81kvmyp69fmw5psfqrbhjsg",
+    "url": "https://android.googlesource.com/platform/system/core"
+  },
+  "system/extras": {
+    "dateTime": 1639526967,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "60af7b595ecfac35c8aad24017837d047c286534",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1sbpflpw3cb71w8v76ps177y7r9hvqc7l9w0l3yv20g6zw4hpnzd",
+    "url": "https://android.googlesource.com/platform/system/extras"
+  },
+  "system/gatekeeper": {
+    "dateTime": 1613532014,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "24dce6b6773874c9d2d57082f8f3f0289d0b9ad8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wxbr2nrgv2w9zwy8vf7pi4vnjcs6jrhg7p0psp36iqqpj46ncpc",
+    "url": "https://android.googlesource.com/platform/system/gatekeeper"
+  },
+  "system/gsid": {
+    "dateTime": 1625707065,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "eef87b2b8ea08129ac7ade673b882c7e53a62c65",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13xicpg8wk1y021a3lxlq49vr51v2nicfwn3zavvz0xgs065ygzs",
+    "url": "https://android.googlesource.com/platform/system/gsid"
+  },
+  "system/hardware/interfaces": {
+    "dateTime": 1630112978,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "657b6c8b049bca49f8baae57ec1fe230feb90f8c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0nq5mdqq63ba26c1iy8hiy9d9mwzy3pjq9m2hh857j8rvhd1w3d8",
+    "url": "https://android.googlesource.com/platform/system/hardware/interfaces"
+  },
+  "system/hwservicemanager": {
+    "dateTime": 1622862604,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "16d6e1bf979ba2bff19351e4b6267f2d072869cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03sg3s64q6iik4i0b8l57dz5m1xxk9dfyqirz72y61ycl4hnagmr",
+    "url": "https://android.googlesource.com/platform/system/hwservicemanager"
+  },
+  "system/incremental_delivery": {
+    "dateTime": 1635980990,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5bf6feac9fb91203a6cc3c8becbba4685910bfef",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01qwp2nl3p7r01ksg6mjzw3ybzh2m246i0xr1fv2q0akm75bwgzr",
+    "url": "https://android.googlesource.com/platform/system/incremental_delivery"
+  },
+  "system/iorap": {
+    "dateTime": 1626225038,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b33ce03bf52b1f7917a88d2103da262d00dc2545",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0q3ip59rm8b3x3ralfn414bc0q51p42hxk2n2mr9pdd7d3vhmbpb",
+    "url": "https://android.googlesource.com/platform/system/iorap"
+  },
+  "system/keymaster": {
+    "dateTime": 1639188542,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1eda6426e7afc50534e8f2c2e1288052f0b188f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "114sjd25k4x60nzx866c46s9d52j0p2wdhi09bcdd9mq9nan586f",
+    "url": "https://android.googlesource.com/platform/system/keymaster"
+  },
+  "system/libartpalette": {
+    "dateTime": 1639440570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4b77057c4c22d463d2800d6985a997dd6f1d9b3c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0r9f816j292rqlz6r80mzyx05z1smrrypa0cz1pamx5s6j78ylpg",
+    "url": "https://android.googlesource.com/platform/system/libartpalette"
+  },
+  "system/libbase": {
+    "dateTime": 1621048222,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "54832bb97ab1a706c9de1f40d7f0b3fbffe717b0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h5aw1r81ikh1y5723m8nzdl3z6f3fq7krrzjfrv80x8zwvgyml2",
+    "url": "https://android.googlesource.com/platform/system/libbase"
+  },
+  "system/libfmq": {
+    "dateTime": 1622077819,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "f59e1c84b03a33535cf159ec6ba0c16c86ee95ac",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gnrsz7k2ish726cdcysa2z0ai6npxnx9kpgpq65crakcnswkdgd",
+    "url": "https://android.googlesource.com/platform/system/libfmq"
+  },
+  "system/libhidl": {
+    "dateTime": 1625188413,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6e5bb45bf36677668fee307e4a6626c00f7a82e8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1y1sw5p7dlal4b74r00jp6p0y5mjpablpli42cdcq5byhayz08r8",
+    "url": "https://android.googlesource.com/platform/system/libhidl"
+  },
+  "system/libhwbinder": {
+    "dateTime": 1622077820,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "a2e76151c79ceac56007061b0faeb1da37ce6c5e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09nwism5hs2514pqccyh5nk558z2qrvrh2fhmqmfv3pm9sdd6bwj",
+    "url": "https://android.googlesource.com/platform/system/libhwbinder"
+  },
+  "system/libprocinfo": {
+    "dateTime": 1625707078,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c4aa20edd23b4290350ccbf7a30b2192aec38c88",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "015y2lxpg1w3ijvlfridfwnbjvqd6gcsgya6fri8xn651m5bhdlz",
+    "url": "https://android.googlesource.com/platform/system/libprocinfo"
+  },
+  "system/libsysprop": {
+    "dateTime": 1621048224,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "99296acd865f2a7d506a466288c0a42a5ba07fa2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0m6nk4r3rp267mlc7pi9cq19a2npb836cf5kv8k1xza1iqiaq0bj",
+    "url": "https://android.googlesource.com/platform/system/libsysprop"
+  },
+  "system/libufdt": {
+    "dateTime": 1621048225,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5f261d82b7ee5751e03f1015b8bd957ea91fd964",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0lx95r91jpfcqhp9d91yvn6z5rdym4s4z2l3v2sa84dqpb72frpp",
+    "url": "https://android.googlesource.com/platform/system/libufdt"
+  },
+  "system/libvintf": {
+    "dateTime": 1621048225,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a18b7f620acef631c0ebff8a693762dc659d08a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11rp914fxzapbdksjn6clmj40n9gmybgdqnngcppyqk4gs97bwz3",
+    "url": "https://android.googlesource.com/platform/system/libvintf"
+  },
+  "system/libziparchive": {
+    "dateTime": 1621048226,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4a88f300073b4b740eb6f2c76fabef6e5828d977",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xhrhxj1f2cbknk5dgld8v9rhrzk22p2q6dzdhnlvyqgqzyf4rg0",
+    "url": "https://android.googlesource.com/platform/system/libziparchive"
+  },
+  "system/linkerconfig": {
+    "dateTime": 1633043813,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5514215cbf57f029b3eec89b34df0f7cc324a9e4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0vai4jakxwblgrh33siaz6zhf77mr2nwk4f880jk64fd5pw1rg13",
+    "url": "https://android.googlesource.com/platform/system/linkerconfig"
+  },
+  "system/logging": {
+    "dateTime": 1628809784,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "83caa4147d84af3b4d2a7470b908ddb171fdd5cc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v7nk3yyllk4ah448kkjil1idv017h1zmi2qslp5zl19c9k1n495",
+    "url": "https://android.googlesource.com/platform/system/logging"
+  },
+  "system/media": {
+    "dateTime": 1639260571,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3796f786be6d1e37787ae8ef6537fcff717ef18e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hrfaj6nydw6cc3wirhs67bs1ypicbx81l0r0h6rdyy0kqg59c3x",
+    "url": "https://android.googlesource.com/platform/system/media"
+  },
+  "system/memory/libdmabufheap": {
+    "dateTime": 1628975410,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d40e3c57e1f6cc996105e5a11083c59003e7b4c8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "03l8sr6dmi8rnf9psclm0sg0pwqfnp7vknc6vydxgbz1gjxgdr34",
+    "url": "https://android.googlesource.com/platform/system/memory/libdmabufheap"
+  },
+  "system/memory/libion": {
+    "dateTime": 1613866169,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5d8d1ddf1055a5ad8f448adf2ec4db21296dd7fd",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0jmb5lh6hgyzpsp711dd5igns56xls0crb2aqnzwqfyvn6dinbz3",
+    "url": "https://android.googlesource.com/platform/system/memory/libion"
+  },
+  "system/memory/libmeminfo": {
+    "dateTime": 1626491419,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "357574340403650904d562381da0b1887eba93eb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hxknnvj22ap00v3nsh6867vi1bcb6dpsm90n223c7z0247kb5az",
+    "url": "https://android.googlesource.com/platform/system/memory/libmeminfo"
+  },
+  "system/memory/libmemtrack": {
+    "dateTime": 1617844202,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "59e6a302f0ca52c4823e2d281da63238fd2f871c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1v1zrkh94ynxgsi30s5i1ivahdabv10clysam1v1c762rczsgr8v",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemtrack"
+  },
+  "system/memory/libmemunreachable": {
+    "dateTime": 1623374605,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "371d18e3f6b51ffecdfb5f7ab302a88d49799df5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1hg82k95l8ph8phl9n982yxy016z68m4hbwjj5sdsnmi217v2cpy",
+    "url": "https://android.googlesource.com/platform/system/memory/libmemunreachable"
+  },
+  "system/memory/lmkd": {
+    "dateTime": 1640304558,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b2bbf56bf7651c97230a2fac0d75affd09697c40",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zs9110x7g59rjxrqjri4xm1s751p3yj0xq9dsbbhyg492l40wd9",
+    "url": "https://android.googlesource.com/platform/system/memory/lmkd"
+  },
+  "system/netd": {
+    "dateTime": 1634346567,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "510c36690440087da9f884f2d593d7522c704296",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "16ra9lzaac6rp1f2a57i6knjnrbhl226wjaf42bkdnw0zcj9gp64",
+    "url": "https://android.googlesource.com/platform/system/netd"
+  },
+  "system/nfc": {
+    "dateTime": 1639440580,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "5fa8b4cf98d74254fa87f21e090401f9b2611b47",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0n6am97qcvl14dxr63pgvkay1iz8xhrjb7q18wch0i4f6srkbbrk",
+    "url": "https://android.googlesource.com/platform/system/nfc"
+  },
+  "system/nvram": {
+    "dateTime": 1612577449,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "d3471a23faf69fb0fd92642ee9c860927d885d25",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "05xspxnd1366hmv4sjq2fmhbgjq4camppfnqpmakkydd4pw4qnn0",
+    "url": "https://android.googlesource.com/platform/system/nvram"
+  },
+  "system/security": {
+    "dateTime": 1641946314,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c197ca067ac7f33f2cea6a695bb7a72101272a88",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0xh4hsgvlxjcb5nb59za7xkzqcp7lwmnli84pwdm6cx073p7868f",
+    "url": "https://android.googlesource.com/platform/system/security"
+  },
+  "system/sepolicy": {
+    "dateTime": 1643410242,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4185cdb29bb0fd7aecc97bf9694757a326ca7a81",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04f3w7irs76zjq087j75i437ppparp2x7q0xkwy6qlzg06pgjbng",
+    "url": "https://android.googlesource.com/platform/system/sepolicy"
+  },
+  "system/server_configurable_flags": {
+    "dateTime": 1613866175,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "3a1b3056232dff61fdc08a224f877170cba33be1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1ih665qh777kw9vyz8sgsbk3nm2bnhklir7v4df25j8wdr8kw4hv",
+    "url": "https://android.googlesource.com/platform/system/server_configurable_flags"
+  },
+  "system/teeui": {
+    "dateTime": 1617066564,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "57cd56ce8e6461d9c261bf9cb4578c47902f7052",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1bicz4kmz79mifxfmzc2rzrgvp95zmcxm7giw8lqsigv32m55avl",
+    "url": "https://android.googlesource.com/platform/system/teeui"
+  },
+  "system/testing/gtest_extras": {
+    "dateTime": 1613866176,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "4144fee88d4ff033642a301deb181528937f7f87",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v5ifyrq7wxsm0mh9843fidj4jmr2x10xqdvdwsshb1p17hxjyyp",
+    "url": "https://android.googlesource.com/platform/system/testing/gtest_extras"
+  },
+  "system/timezone": {
+    "dateTime": 1636769378,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "9866efd8a5f7bc69a0c59947c757a02543c384a5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "08sn293cpbizif7ac3g77dj3dj8wpbcqxasca2xzhj0jxw3khd1c",
+    "url": "https://android.googlesource.com/platform/system/timezone"
+  },
+  "system/tools/aidl": {
+    "dateTime": 1639008755,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "0ed29b40127ceb724c228b9b58b192364d003c98",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0c2mfz16vc7ql3in0mqn11fqb1hdf3jfamh4gkdm1lgclr1f7qzb",
+    "url": "https://android.googlesource.com/platform/system/tools/aidl"
+  },
+  "system/tools/hidl": {
+    "dateTime": 1627701029,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7aae41119b7529a42801757fe51e5e152af31116",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "14klv5dx95fcihfck1r41bz9nxgcblf838sj62mad685pjmah7fb",
+    "url": "https://android.googlesource.com/platform/system/tools/hidl"
+  },
+  "system/tools/mkbootimg": {
+    "dateTime": 1639188557,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b5a7226e7ad3e430436ac90c005d69a60bb0d7a2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1crqv3dz191rwdwym9y5ssvvlb040ycwq2863y272iqywzparn0n",
+    "url": "https://android.googlesource.com/platform/system/tools/mkbootimg"
+  },
+  "system/tools/sysprop": {
+    "dateTime": 1616634570,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6d9e9abf47eaa8ae20ee33345580223244344c63",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hvq6n3kj0lyyx782wwy32q1m24qclkmas5jdb2wy5hxcrsqvwds",
+    "url": "https://android.googlesource.com/platform/system/tools/sysprop"
+  },
+  "system/tools/xsdc": {
+    "dateTime": 1624410644,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6703714e1e67fe90c9823c1e0054b5e7794585ad",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "01kh80wg5r9b1csz23p7x0rqlpb26x5z4r4gi2y4ibisy5bva3w4",
+    "url": "https://android.googlesource.com/platform/system/tools/xsdc"
+  },
+  "system/unwinding": {
+    "dateTime": 1633208987,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "628fea34a133235371cbdff1e5f4ac0981146efc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0iw26p7rx6r9j11r0bvds8idpl7kw6gja4d81wyyfq2j8a2q74ys",
+    "url": "https://android.googlesource.com/platform/system/unwinding"
+  },
+  "system/update_engine": {
+    "dateTime": 1631747446,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "2c9816b0776d5ad5549336dfc5a2ceb29f3045aa",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0rz4d5aqxhvcj0c748sz8dls6dicsvia6skqp4ynm523qhlhjdi6",
+    "url": "https://android.googlesource.com/platform/system/update_engine"
+  },
+  "system/vold": {
+    "dateTime": 1636841376,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "6f2a5f1f66f72d4a1869ca37e53418cf3615bee7",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "14pwnbfznd99y1z95r52gqb9lf3gprjmiyznq79di0mapcp4wzp1",
+    "url": "https://android.googlesource.com/platform/system/vold"
+  },
+  "test/app_compat/csuite": {
+    "dateTime": 1621048240,
+    "groups": [],
+    "rev": "acb782c1cf9c533406e43185d6f8a27b858d8db6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "11h6hldlwrcfk314wn77a218384yh4kz4xz3nzvy3yqm99ywhz8n",
+    "url": "https://android.googlesource.com/platform/test/app_compat/csuite"
+  },
+  "test/catbox": {
+    "dateTime": 1639613597,
+    "groups": [],
+    "rev": "70956aebbd8bf16b99c619d9f0fc0f84e96c86af",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1vvhs8zifbpg425gzykksvqjiv7rhbpk16w5vm78lbmxsl2p847h",
+    "url": "https://android.googlesource.com/platform/test/catbox"
+  },
+  "test/cts-root": {
+    "dateTime": 1624640246,
+    "groups": [],
+    "rev": "c316c07ca2e67d75a9afeb07f24e8d5fa91911a1",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1garbzndz4qsxmv6cys2zf3gwlsay5yw5svfbz770hhim4i037b6",
+    "url": "https://android.googlesource.com/platform/test/cts-root"
+  },
+  "test/framework": {
+    "dateTime": 1613866181,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "b93563be5c97e264624c68ac6c6c7d6e02c783bb",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1p4gak809gfak9r64pzrq708p53i7y7045x10q7ji16jycw123lv",
+    "url": "https://android.googlesource.com/platform/test/framework"
+  },
+  "test/mlts/benchmark": {
+    "dateTime": 1621048239,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bd41f825f3e52080d124d45304c885e3c96b68ed",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0n5yjswf4lnshqg8y0lb2wi65gqqqa0xjfgffkif6m8ma6642mh5",
+    "url": "https://android.googlesource.com/platform/test/mlts/benchmark"
+  },
+  "test/mlts/models": {
+    "dateTime": 1594388199,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "b1f4789125082f6e75fb7dfd329abca7dbece592",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "136fcq4lmc69yp1gzlynvrv7126z91aw2l1y1gns0d69xk9hfbjf",
+    "url": "https://android.googlesource.com/platform/test/mlts/models"
+  },
+  "test/mts": {
+    "dateTime": 1629846580,
+    "groups": [],
+    "rev": "b69887cf2725ae33a44b3b6881c7b5eafa82de1e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06k2xbcdlm0xckbnjgvybgzydk27grx7k5nkx5knxhhal76p5njk",
+    "url": "https://android.googlesource.com/platform/test/mts"
+  },
+  "test/vti/dashboard": {
+    "dateTime": 1551088143,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "fe9202085ceb9b83bf328320ed90d7f07e61f88a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1f92y61l49ljjbfji1y5wqv8hnx08phhyh9xcl8yl5l9valgcx7m",
+    "url": "https://android.googlesource.com/platform/test/vti/dashboard"
+  },
+  "test/vti/fuzz_test_serving": {
+    "dateTime": 1551002920,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "e1c4c32b67b82cea51666c3dcd6cd78526db6b5e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "07ikws6h4m89x1hy6lg7r5n46y78ax305pabmf46d476hpljpq5i",
+    "url": "https://android.googlesource.com/platform/test/vti/fuzz_test_serving"
+  },
+  "test/vti/test_serving": {
+    "dateTime": 1588777700,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "be75865258aa6e2c0bfe47793cc05ebd2dc02727",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12y5bwvhbj1yscbi87irp0xgwmb018fck905zf678aii8qckhp9l",
+    "url": "https://android.googlesource.com/platform/test/vti/test_serving"
+  },
+  "test/vts": {
+    "dateTime": 1641514179,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "a51ec2fc2be2206de6fc44f244e4baadd3dbd21c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1wisf4kabifz94mf826jq7kmz4amy2pc5yvwidfvrkfjlmv8fyh0",
+    "url": "https://android.googlesource.com/platform/test/vts"
+  },
+  "test/vts-testcase/fuzz": {
+    "dateTime": 1613866187,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "6d4b454e1b12465619e84fbed67791092881854b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "106hmz81aaqpy3gq6apgz4a1j6nmvhzp8rbzpldqcl7ymn552h76",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/fuzz"
+  },
+  "test/vts-testcase/hal": {
+    "dateTime": 1640131798,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "1f645c2c6334b723de1e353f16189aff2c02cbfc",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13n1p4d3a832fns95npc1wiqq1jc6h3y432bkm36s7y10qhzd1wp",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal"
+  },
+  "test/vts-testcase/hal-trace": {
+    "dateTime": 1551088166,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "23d331d4cc429fe1b50c71478585faa8b9f58e5c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "12pj9szswrfz5ky87gfmg8s4fccpmfiyxkp96qnwa5kics0qrx0p",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/hal-trace"
+  },
+  "test/vts-testcase/kernel": {
+    "dateTime": 1635894606,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "3fa0d7a2270c4966457b4e340396adadce29a833",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0hlbmm9ifx9a0bmfx1xhw4mx2y9vm5lc1xm43qwzmpdrj1larzk2",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/kernel"
+  },
+  "test/vts-testcase/nbu": {
+    "dateTime": 1613866189,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "ee91f3c4550162629dd119ebff584ab668339638",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1h3vd99wax8n5ygs6cg15f0p8kj07kas75n72j7b20n4qdy2bflz",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/nbu"
+  },
+  "test/vts-testcase/performance": {
+    "dateTime": 1613866189,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "0106a1ac66309a363ff5e52f474a43147eaed2be",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dh5n3pprrdb607f3jriz2madgq3ri8fv4c4mcmqld5fbc56w05b",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/performance"
+  },
+  "test/vts-testcase/security": {
+    "dateTime": 1636067570,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "vts"
+    ],
+    "rev": "d6643e88a44124488fd5211e2a22768b9a48c16c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "10ysras48ih7bka5c413a3mhjqryvsnz96g2rmdfw9xv2v8cb1bj",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/security"
+  },
+  "test/vts-testcase/vndk": {
+    "dateTime": 1629846586,
+    "groups": [
+      "pdk",
+      "vts"
+    ],
+    "rev": "58cebed6fff0068ab4399029c244c67b6280913c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1l8r1qczbzaqvlq8cd4x1wvi2y2lh14m4fqcqypxlmvi3nl62pqx",
+    "url": "https://android.googlesource.com/platform/test/vts-testcase/vndk"
+  },
+  "toolchain/benchmark": {
+    "dateTime": 1613866191,
+    "groups": [],
+    "rev": "9a86ce18c456d2911b1564ecb9f977503cb9ad82",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "04c2hzbgqxcim23z4brvq0px4cifmz52434lxacq741kqy8a3yn8",
+    "url": "https://android.googlesource.com/toolchain/benchmark"
+  },
+  "toolchain/pgo-profiles": {
+    "dateTime": 1626563655,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "e20f2b0b6cfa8207692ba09982fe56a2a4009f4a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "023wq00bzc3lafcy4l4dwyhx0dxlpxikqr7wixj8jvz39n0hlq9g",
+    "url": "https://android.googlesource.com/toolchain/pgo-profiles"
+  },
+  "tools/aadevtools": {
+    "dateTime": 1621048250,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "ab2cf78db487f646d8e579e93bdd3214b5c0238e",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1zb9yfwjj9f0hk75vi7qg9j3fllpk3n5mfhgky8z385bh2jmzk5v",
+    "url": "https://android.googlesource.com/platform/tools/aadevtools"
+  },
+  "tools/acloud": {
+    "dateTime": 1621048250,
+    "groups": [
+      "pdk",
+      "projectarch",
+      "tools",
+      "tradefed",
+      "vts"
+    ],
+    "rev": "e79419f6af70724774b742a77a4eafbeb1bf0e47",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "02svjyi2vj85r6yi6k5i0xffkxkkxh6iyf7bpf99aiwq80aw3hfq",
+    "url": "https://android.googlesource.com/platform/tools/acloud"
+  },
+  "tools/apifinder": {
+    "dateTime": 1623287516,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "957042e455b60eb29ef31439ae628823a3147485",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0bfac5abla83d56kz7hvwdb12h60h90lj9ahy7cgg75qfgjnj9ic",
+    "url": "https://android.googlesource.com/platform/tools/apifinder"
+  },
+  "tools/apksig": {
+    "dateTime": 1622257826,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "9182552ea3f129686422d72d983c33c35393391a",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1dl6k7qnk9kl26sdr3a6hy2mg9939a20bk7qp11jb3c5vnmarcsy",
+    "url": "https://android.googlesource.com/platform/tools/apksig"
+  },
+  "tools/apkzlib": {
+    "dateTime": 1621048253,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "384f25d4c74408bdc6b434b8549cdb6bfe75243b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qbj6g2jivxjlxgm1z27anqgb0hh50fm3mqfpb4bd55mqn73csi8",
+    "url": "https://android.googlesource.com/platform/tools/apkzlib"
+  },
+  "tools/asuite": {
+    "dateTime": 1636161003,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "7f431adbf530d27b175d5079ca6787065eb81e9b",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0lhpqxdbakqawxvkm8ad53m11yvcha5s75jzcqyni806wcspnc2w",
+    "url": "https://android.googlesource.com/platform/tools/asuite"
+  },
+  "tools/carrier_settings": {
+    "dateTime": 1621048255,
+    "groups": [
+      "tools"
+    ],
+    "rev": "8fb84a7289cc835c54ddf6e5e3b9e5685e1e7230",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1gcpddy94nmhqbmpr3y1s6b29w6zx3r5ixn53hd0s4y0rfw9ahj6",
+    "url": "https://android.googlesource.com/platform/tools/carrier_settings"
+  },
+  "tools/currysrc": {
+    "dateTime": 1611605421,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "c6eb1d4612a2665a8f9cb690044592280ff9c181",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0h3smd8j3lrd8lnmzcpirn70k9q8l645sbgzfw6cxdrzbi7p2d1a",
+    "url": "https://android.googlesource.com/platform/tools/currysrc"
+  },
+  "tools/dexter": {
+    "dateTime": 1614996589,
+    "groups": [
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "65e8502754d878c34f1b1b98207815717eeac448",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1mmldb1h69bcxil78y708hfzr1v5s7y547j0v9cb2vgg48m109dg",
+    "url": "https://android.googlesource.com/platform/tools/dexter"
+  },
+  "tools/doc_generation": {
+    "dateTime": 1631747464,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "2a180440e0f1368207dd81e4aa2324231411b5c4",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0wrhriszbxc58k6sqmv1lsipac7bi67q15yjg2clb6k5irp8rzkh",
+    "url": "https://android.googlesource.com/platform/tools/doc_generation"
+  },
+  "tools/external/fat32lib": {
+    "dateTime": 1613441394,
+    "groups": [
+      "tools"
+    ],
+    "rev": "d6efdfa7e493fcc3d73a4cbaf7d7d45263fa4586",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0zx9wqm0l5w1ghcyj49bsfm39y8b97bckfmy9l5r62f6yx4hcgsh",
+    "url": "https://android.googlesource.com/platform/tools/external/fat32lib"
+  },
+  "tools/external_updater": {
+    "dateTime": 1621048257,
+    "groups": [
+      "tools"
+    ],
+    "rev": "69fb0de9c014b588fbb359592ea51b3ce9872b7c",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0aa7dhk94wdc6qa45q2bhc8qc17x7f4n53gn8bqb06pdvwdiilmz",
+    "url": "https://android.googlesource.com/platform/tools/external_updater"
+  },
+  "tools/metalava": {
+    "dateTime": 1638583810,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "02f33687b8ae811e86a9e7c48e89cc8b4a9fef6f",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "06n81pbkibhn0bk0ap1g67nlzj4sq6iblqp2mqpcxr448xn44392",
+    "url": "https://android.googlesource.com/platform/tools/metalava"
+  },
+  "tools/ndkports": {
+    "dateTime": 1599773449,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "41943316f00d584c2b46c30ecad9b914a29941f6",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "13f0scvw1gkwjx24l6hqgk9v7q919zilas7v0b6h8pg2akiyd45h",
+    "url": "https://android.googlesource.com/platform/tools/ndkports"
+  },
+  "tools/platform-compat": {
+    "dateTime": 1633389022,
+    "groups": [
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs"
+    ],
+    "rev": "6b139b946ced8e3edcb37f0ea4183240876a5150",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "193lr1nxwghrz0ch9a2r744w108npnvr7rpzziy1h3wxgg8474qk",
+    "url": "https://android.googlesource.com/tools/platform-compat"
+  },
+  "tools/repohooks": {
+    "dateTime": 1634685007,
+    "groups": [
+      "adt-infra",
+      "cts",
+      "developers",
+      "motodev",
+      "pdk",
+      "tools",
+      "tradefed"
+    ],
+    "rev": "d80c7cc19c0f5bbfb2e5c439501e4642dd3bb610",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1yx3bwnpw5crc22v4sssy6vr55z2j1m9x4wa1gphix0lqy6n163j",
+    "url": "https://android.googlesource.com/platform/tools/repohooks"
+  },
+  "tools/security": {
+    "dateTime": 1634253180,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "44b59f77dd87fc3e1e08bbe3ebff887ab3a948d0",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "09sk0fv0xghznv3hy3smxwgkgpg0a4ha516frfxjgxhc7rs0da17",
+    "url": "https://android.googlesource.com/platform/tools/security"
+  },
+  "tools/test/connectivity": {
+    "dateTime": 1641946376,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "bbb0ffed7b27f74bacf44b3f9b8637d247e0e775",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cp37j0j49ky6hfsjvkn3s69d300nrmkgffgba3lkpgxfpz84fdy",
+    "url": "https://android.googlesource.com/platform/tools/test/connectivity"
+  },
+  "tools/test/graphicsbenchmark": {
+    "dateTime": 1621048264,
+    "groups": [
+      "pdk"
+    ],
+    "rev": "da29ce47c1a8b93893c00f1d6f7e5e668ce9af43",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "0v5b8p7lwcwrmd1sxc6axf7qkdqyq9p5dqcyazngr0amhdf2xg0j",
+    "url": "https://android.googlesource.com/platform/tools/test/graphicsbenchmark"
+  },
+  "tools/test/openhst": {
+    "dateTime": 1613866206,
+    "groups": [
+      "tools"
+    ],
+    "rev": "9712b8400ebdcf0493cbf7d3a00e88ca5baff7d5",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1qlnvcpsy11nd9cjjh6yy1bhcsikx3xg5rzkqbfhli0q0a5jwrpp",
+    "url": "https://android.googlesource.com/platform/tools/test/openhst"
+  },
+  "tools/tradefederation/prebuilts": {
+    "dateTime": 1642212609,
+    "groups": [
+      "pdk",
+      "tradefed"
+    ],
+    "rev": "41badad2c39a077c3cd2c239531e5edda98d323d",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1z18jfsha5vb81kcv1rlsrn720g9a01vbgmvlz87r183lclgwh7a",
+    "url": "https://android.googlesource.com/platform/tools/tradefederation/prebuilts"
+  },
+  "tools/treble": {
+    "dateTime": 1621048267,
+    "groups": [
+      "pdk",
+      "tools"
+    ],
+    "rev": "57e7fd15887e051dc5016895ed6481afc5456df2",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1cm4prh06srq421ibkac8s9kdjxvq6s0gy336sa92wc886hg8k2d",
+    "url": "https://android.googlesource.com/platform/tools/treble"
+  },
+  "tools/trebuchet": {
+    "dateTime": 1621048267,
+    "groups": [
+      "cts",
+      "pdk",
+      "pdk-cw-fs",
+      "pdk-fs",
+      "tools"
+    ],
+    "rev": "a968b489c7e06b39c02ffb5cd4f233b787584dd8",
+    "revisionExpr": "refs/tags/android-12.1.0_r2",
+    "sha256": "1i3iz9fyd0jbvmjawxy3w0qvf6ycnv6jvmxk6c7xm272ad43gxag",
+    "url": "https://android.googlesource.com/platform/tools/trebuchet"
+  }
+}

--- a/modules/12/build_make/0003-Add-option-to-include-prebuilt-images-when-signing-t.patch
+++ b/modules/12/build_make/0003-Add-option-to-include-prebuilt-images-when-signing-t.patch
@@ -1,6 +1,6 @@
-From 105e08518e96424d9a8deaead77290baea906f42 Mon Sep 17 00:00:00 2001
+From 203d99fcfe8ec55a04c12fdb070c893cfa604022 Mon Sep 17 00:00:00 2001
 From: Zhaofeng Li <hello@zhaofeng.li>
-Date: Sat, 6 Nov 2021 12:48:25 -0700
+Date: Wed, 23 Mar 2022 19:16:53 -0700
 Subject: [PATCH] Add option to include prebuilt images when signing target
  files.
 
@@ -34,13 +34,13 @@ Change-Id: Id906b2e32797f95b0ee47859036ba31ea7975b64
  1 file changed, 30 insertions(+)
 
 diff --git a/tools/releasetools/sign_target_files_apks.py b/tools/releasetools/sign_target_files_apks.py
-index 0842af9018..b160a21c67 100755
+index 936ef888dc..a78b178cb7 100755
 --- a/tools/releasetools/sign_target_files_apks.py
 +++ b/tools/releasetools/sign_target_files_apks.py
-@@ -136,6 +136,11 @@ Usage:  sign_target_files_apks [flags] input_target_files output_target_files
- 
-   --android_jar_path <path>
-       Path to the android.jar to repack the apex file.
+@@ -141,6 +141,11 @@ Usage:  sign_target_files_apks [flags] input_target_files output_target_files
+       Allow the existence of the file 'userdebug_plat_sepolicy.cil' under
+       (/system/system_ext|/system_ext)/etc/selinux.
+       If not set, error out when the file exists.
 +
 +  --prebuilt_image <path to prebuilt image>
 +      Specify a path to a prebuilt image file, to be added to the
@@ -49,7 +49,7 @@ index 0842af9018..b160a21c67 100755
  """
  
  from __future__ import print_function
-@@ -173,6 +178,7 @@ OPTIONS = common.OPTIONS
+@@ -178,6 +183,7 @@ OPTIONS = common.OPTIONS
  
  OPTIONS.extra_apks = {}
  OPTIONS.extra_apex_payload_keys = {}
@@ -57,7 +57,7 @@ index 0842af9018..b160a21c67 100755
  OPTIONS.skip_apks_with_path_prefix = set()
  OPTIONS.key_map = {}
  OPTIONS.rebuild_recovery = False
-@@ -1190,6 +1196,8 @@ def main(argv):
+@@ -1206,6 +1212,8 @@ def main(argv):
        names = names.split(",")
        for n in names:
          OPTIONS.extra_apks[n] = key
@@ -66,15 +66,15 @@ index 0842af9018..b160a21c67 100755
      elif o == "--extra_apex_payload_key":
        apex_name, key = a.split("=")
        OPTIONS.extra_apex_payload_keys[apex_name] = key
-@@ -1339,6 +1347,7 @@ def main(argv):
-           "gki_signing_key=",
+@@ -1358,6 +1366,7 @@ def main(argv):
            "gki_signing_algorithm=",
            "gki_signing_extra_args=",
+           "allow_gsi_debug_sepolicy",
 +          "prebuilt_image=",
        ],
        extra_option_handler=option_handler)
  
-@@ -1381,6 +1390,23 @@ def main(argv):
+@@ -1400,6 +1409,23 @@ def main(argv):
                       platform_api_level, codename_to_api_level_map,
                       compressed_extension)
  
@@ -98,7 +98,7 @@ index 0842af9018..b160a21c67 100755
    common.ZipClose(input_zip)
    common.ZipClose(output_zip)
  
-@@ -1390,6 +1416,10 @@ def main(argv):
+@@ -1409,6 +1435,10 @@ def main(argv):
    # recovery patch is guaranteed to be regenerated there.
    if OPTIONS.rebuild_recovery:
      new_args.append("--rebuild_recovery")
@@ -110,5 +110,5 @@ index 0842af9018..b160a21c67 100755
    add_img_to_target_files.main(new_args)
  
 -- 
-2.33.0
+2.35.1
 

--- a/modules/apv/latest-telephony-provider.json
+++ b/modules/apv/latest-telephony-provider.json
@@ -1,9 +1,9 @@
 {
   "url": "https://android.googlesource.com/platform/packages/providers/TelephonyProvider",
-  "rev": "573d2001243853ff55c6052adc61c97c3ef0b61e",
-  "date": "2022-01-31T17:23:18+00:00",
-  "path": "/nix/store/a6a309zan3q40rlmps3wm41brvxnf3yq-TelephonyProvider",
-  "sha256": "1b6nwcmjcdjmf9ax74s3m0z9rvpd1m9z50ml7kyr1cf2zjv41zx1",
+  "rev": "c4d25e98907344b9f5835662bf92031ede7c9296",
+  "date": "2022-03-21T17:05:19+00:00",
+  "path": "/nix/store/24l40zp96anfnwf8nwvf5grbm7i86881-TelephonyProvider",
+  "sha256": "1bs215z3xifdcgg1rrf5w4pjqmik7w4qwm3ibprfs2hmp71b7izm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -231,7 +231,7 @@ in
       "9" = 28;
       "10" = 29;
       "11" = 30;
-      "12" = 31;
+      "12" = 32; # Assuming 12.1
     }.${builtins.toString config.androidVersion} or 30;
 
     buildNumber = mkOptionDefault (formatSecondsSinceEpoch config.buildDateTime);

--- a/modules/pixel/pixel-beta-imgs.json
+++ b/modules/pixel/pixel-beta-imgs.json
@@ -1,1 +1,34 @@
-[]
+[
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/flame-s3b1.220218.004-factory-b2cbf580.zip",
+    "sha256": "b2cbf580ea7dbaac5087e19df585976106bbf0cd7304aa448516f9030727ba11"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/coral-s3b1.220218.004-factory-c9109025.zip",
+    "sha256": "c91090258c86a6a4db02b1d2b715b5b0df44191e6685a89b1e5c6284b1f5a459"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/sunfish-s3b1.220218.004-factory-6105065f.zip",
+    "sha256": "6105065fa4146b6b3250fd0e7ccdc6e43ebb673476a568426f03fbd7d47a2b87"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/bramble-s3b1.220218.004-factory-a2a7cafb.zip",
+    "sha256": "a2a7cafb8b9fc478bc106607dba7fa67bd486743ae9cf1331443cd1ec2f5c77a"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/redfin-s3b1.220218.004-factory-6ce928b1.zip",
+    "sha256": "6ce928b121693027d36adb978a835612a32823b89eed8ffa7efafbecacafac04"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/barbet-s3b1.220218.004-factory-b1e0c1d9.zip",
+    "sha256": "b1e0c1d95a3ea9a976f76ee462e2db0b6848bc9f745bbdd193eb5596b2182f5c"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/oriole-s3b1.220218.004-factory-e2876727.zip",
+    "sha256": "e28767272a058f018fea085badac61f29776f4e126bbe17a216025f573b7e806"
+  },
+  {
+    "url": "https://dl.google.com/developers/android/sc/images/factory/raven-s3b1.220218.004-factory-11526368.zip",
+    "sha256": "11526368ed1940494c63ab7e80a62a68269103a8b30addfe502378917bab5fa7"
+  }
+]

--- a/modules/pixel/pixel-drivers.json
+++ b/modules/pixel/pixel-drivers.json
@@ -60,6 +60,10 @@
     "sha256": "9c2a6e6fee566286c8775588236ce0f2661bfd8fd6b8881ed8a3da74f2f1d85e"
   },
   {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-oriole-sp2a.220305.013.a3-04c512f4.tgz",
+    "sha256": "e6fda241eb2096f992fd57ebc86b339651bc06245b74188915992b4c674207c4"
+  },
+  {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sd1a.210817.015.a4-31a5656a.tgz",
     "sha256": "4267914736943b542103ee037b872084fce71b06f90c3f638cd7aca7d009abb4"
   },
@@ -118,6 +122,10 @@
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sq1d.220205.004-feab753d.tgz",
     "sha256": "87444a10f959c7fe86c3dac36f5c220eb4a0d91a042a6a654f314fc06088b544"
+  },
+  {
+    "url": "https://dl.google.com/dl/android/aosp/google_devices-raven-sp2a.220305.013.a3-00b68352.tgz",
+    "sha256": "0e1aa36686e44ae441ad25ffcbc0bf77a42aa241fd42ad3ec5691876a635a533"
   },
   {
     "url": "https://dl.google.com/dl/android/aosp/google_devices-barbet-rd2a.210605.006-22c86344.tgz",

--- a/modules/pixel/pixel-imgs.json
+++ b/modules/pixel/pixel-imgs.json
@@ -66,6 +66,12 @@
     "sha256": "eb39151c89c1a0d8b5226b2b83a1ab3fe0d638e05bd3f14b87f424b8bc6531a9"
   },
   {
+    "device": "oriole",
+    "version": "12.1.0 (SP2A.220305.013.A3, Mar 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-sp2a.220305.013.a3-factory-8bea92d1.zip",
+    "sha256": "8bea92d1215036b9d6d3f8e04c9cd07857ff46d810207cfcbdfcf65670b1c5f6"
+  },
+  {
     "device": "raven",
     "version": "12.0.0 (SD1A.210817.015.A4, Oct 2021)",
     "url": "https://dl.google.com/dl/android/aosp/raven-sd1a.210817.015.a4-factory-bd6cb030.zip",
@@ -130,6 +136,12 @@
     "version": "12.0.0 (SQ1D.220205.004, Feb 2022)",
     "url": "https://dl.google.com/dl/android/aosp/raven-sq1d.220205.004-factory-206b1b3c.zip",
     "sha256": "206b1b3c3ee21193335530e13d83a203e713f66fcf21c695cd0027007bf9f7fd"
+  },
+  {
+    "device": "raven",
+    "version": "12.1.0 (SP2A.220305.013.A3, Mar 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-sp2a.220305.013.a3-factory-87b3bf0a.zip",
+    "sha256": "87b3bf0aab411afd17220eeb06c83492613b011cb02dcbabdf4fb18df7e2d630"
   },
   {
     "device": "barbet",

--- a/modules/pixel/pixel-otas.json
+++ b/modules/pixel/pixel-otas.json
@@ -66,6 +66,12 @@
     "sha256": "36ba07e7ae6fac9c18bf1e545e1ef113feba8c1acef2010afa818f62c6f7b0be"
   },
   {
+    "device": "oriole",
+    "version": "12.1.0 (SP2A.220305.013.A3, Mar 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/oriole-ota-sp2a.220305.013.a3-d7b50e71.zip",
+    "sha256": "d7b50e710759d7cfcac7ca4057970ff4a4395ee61c750ce51af4159bf3fba873"
+  },
+  {
     "device": "raven",
     "version": "12.0.0 (SD1A.210817.015.A4, Oct 2021)",
     "url": "https://dl.google.com/dl/android/aosp/raven-ota-sd1a.210817.015.a4-83028e9c.zip",
@@ -130,6 +136,12 @@
     "version": "12.0.0 (SQ1D.220205.004, Feb 2022)",
     "url": "https://dl.google.com/dl/android/aosp/raven-ota-sq1d.220205.004-408ce2fc.zip",
     "sha256": "408ce2fcf9585a78aff53ac894184514e91fcda4ca9ab10487a20d9eee7cfb92"
+  },
+  {
+    "device": "raven",
+    "version": "12.1.0 (SP2A.220305.013.A3, Mar 2022)",
+    "url": "https://dl.google.com/dl/android/aosp/raven-ota-sp2a.220305.013.a3-14589c37.zip",
+    "sha256": "14589c377bfe5ee6ead1b6199e9d72cdde6b507ce6d151642d0d92058504b1c6"
   },
   {
     "device": "barbet",

--- a/pkgs/android-prepare-vendor/default.nix
+++ b/pkgs/android-prepare-vendor/default.nix
@@ -15,7 +15,7 @@ let
   version = {
     "29" = "2020-08-26";
     "30" = "2021-09-07";
-    "31" = "2021-10-21";
+    "32" = "2021-10-21";
   }.${builtins.toString api};
 
   src = {
@@ -33,7 +33,7 @@ let
       rev = "227f5ce7cd89a3f57291fe2b84869c7a5d1e17fa";
       sha256 = "07g5dcl2x44ai5q2yfq9ybx7j7kn41s82hgpv7jff5v1vr38cia9";
     });
-    "31" = (fetchFromGitHub {
+    "32" = (fetchFromGitHub {
       owner = "grapheneos";
       repo = "android-prepare-vendor";
       rev = "7c09cb887d3b9a2643cfc6ecf3966db1e378be32";
@@ -63,7 +63,7 @@ in
       ./11/0003-Allow-for-externally-set-config-file.patch
       ./11/0004-Add-option-to-use-externally-provided-carrier_list.p.patch
     ];
-    "31" = [
+    "32" = [
       ./12/0001-Just-write-proprietary-blobs.txt-to-current-dir.patch
       ./12/0002-Allow-for-externally-set-config-file.patch
       ./12/0003-Add-option-to-use-externally-provided-carrier_list.p.patch


### PR DESCRIPTION
Currently doesn't work with APV due to some new module definition conflicts. We may want to adopt [adevtool](https://github.com/kdrag0n/adevtool) which is what ProtonAOSP and GrapheneOS have switched to.

Tested with oriole with `pixel.useUpstreamDriverBinaries`.