### PR TITLE
Add security.pki.certificateFiles option

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,7 @@ let
       ./modules/etc.nix
       ./modules/framework.nix
       ./modules/hosts.nix
+      ./modules/security-pki.nix
       ./modules/kernel.nix
       ./modules/microg.nix
       ./modules/pixel

--- a/modules/security-pki.nix
+++ b/modules/security-pki.nix
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2022 Daniel Fullmer and robotnix contributors
+# SPDX-License-Identifier: MIT
+
+{ config, pkgs, lib, ... }:
+
+let
+  inherit (lib) mkIf mkOption types;
+in
+{
+  options = {
+    security.pki.certificateFiles = mkOption {
+      default = [];
+      type = types.listOf types.path;
+      description = "A list of files containing trusted root certificates in PEM format.  These are added as system-level trust anchors.";
+    };
+  };
+
+  config = mkIf (config.security.pki.certificateFiles != []) {
+    source.dirs."system/ca-certificates".postPatch = lib.concatMapStringsSep "\n" (certFile: ''
+      cp -v ${lib.escapeShellArg "${certFile}"} $out/files/$(${pkgs.openssl}/bin/openssl x509 -inform PEM -subject_hash_old -in ${lib.escapeShellArg "${certFile}"} -noout).0
+    '') config.security.pki.certificateFiles;
+  };
+}


### PR DESCRIPTION
I use a custom CA for my internal systems, including the machine that serves my robotnix updates.  Although Android allows users to add CA certs, these don't appear to affect system services such as the updater.  This patch adds an option, "security.pki.certificateFiles" (named after the one in NixOS) which allows the user to add a list of CA certs at the system level.  I have tested that this works with the built-in updater app on GrapheneOS.