### PR TITLE
hash mismatch in fixed-output derivation - include-saved-battery-history-chunks-into-batteryusagestats-parcel

### DIFF
--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -106,7 +106,7 @@ in
       (pkgs.fetchurl {
         name = "include-saved-battery-history-chunks-into-batteryusagestats-parcel.patch";
         url = "https://github.com/aosp-mirror/platform_frameworks_base/commit/c4b9de7d95fd2d6bd8072f16f0ac71d2b1773a1b.patch";
-        sha256 = "sha256-ZIi96yF2qTgQ4iGTY86ppBmg4TeIRJ1qu7CSA5IPSnE=";
+        sha256 = "sha256-T9EBOMJJtZ2tPOYx3epXV9ZBg3gSuz3zwM7+9QIOgs8=";
       })
     ];
 

--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -103,7 +103,7 @@ in
         url = "https://github.com/aosp-mirror/platform_frameworks_base/commit/0856f76846e61ad058e1e9ec0759739812a00600.patch";
         sha256 = "sha256-of8dyOCicSVh64kLicuIk9av2K29YXLzUxeb6CI0NZo=";
       })
-      (pkgs.fetchurl {
+      (pkgs.fetchpatch {
         name = "include-saved-battery-history-chunks-into-batteryusagestats-parcel.patch";
         url = "https://github.com/aosp-mirror/platform_frameworks_base/commit/c4b9de7d95fd2d6bd8072f16f0ac71d2b1773a1b.patch";
         sha256 = "sha256-T9EBOMJJtZ2tPOYx3epXV9ZBg3gSuz3zwM7+9QIOgs8=";

--- a/flavors/vanilla/12/default.nix
+++ b/flavors/vanilla/12/default.nix
@@ -106,7 +106,7 @@ in
       (pkgs.fetchpatch {
         name = "include-saved-battery-history-chunks-into-batteryusagestats-parcel.patch";
         url = "https://github.com/aosp-mirror/platform_frameworks_base/commit/c4b9de7d95fd2d6bd8072f16f0ac71d2b1773a1b.patch";
-        sha256 = "sha256-T9EBOMJJtZ2tPOYx3epXV9ZBg3gSuz3zwM7+9QIOgs8=";
+        sha256 = "sha256-SalnJQSrc7X24XW1vg0N04PYIQ11vm++xy/CPbPogy4=";
       })
     ];
 


### PR DESCRIPTION
When I try to build the current master branch with a minimal config like

```
{
  inputs.robotnix.url = "github:danielfullmer/robotnix";

  outputs = { self, robotnix }: {
    robotnixConfigurations."dailydriver" = robotnix.lib.robotnixSystem ({ config, pkgs, ... }: {
      device = "oriole";
      flavor = "vanilla"; # "grapheneos" is another option
      apps.chromium.enable = false;
    });

    defaultPackage.x86_64-linux = self.robotnixConfigurations."dailydriver".img;
  };
}
```

 I get a hash mismatch on a fixed output derivation

```
error: hash mismatch in fixed-output derivation '/nix/store/vp7qgg4s87xvwhxc11kq05y84m37dmi5-include-saved-battery-history-chunks-into-batteryusagestats-parcel.patch.drv':
         specified: sha256-ZIi96yF2qTgQ4iGTY86ppBmg4TeIRJ1qu7CSA5IPSnE=
            got:    sha256-T9EBOMJJtZ2tPOYx3epXV9ZBg3gSuz3zwM7+9QIOgs8=
error: 1 dependencies of derivation '/nix/store/lr8m91pb72n7zxa3c03yxrygrk73wjdn-frameworks=base-patched.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ixyaz8ra5md4d410lvpz4k3x412hg764-unpack.sh.drv' failed to build
error: 1 dependencies of derivation '/nix/store/3mhssqkpc0d57m9qvh0bgqcbyyy8aywp-robotnix-aosp_oriole-2022022022.drv' failed to build
error: 1 dependencies of derivation '/nix/store/a2ya92wjdvxgwfb49wiqchzh2w9hlq72-oriole-img-2022022022.zip.drv' failed to build
```

I don't know how the patch in question could go bad like that.

Do other people also observe this?
Should it be fixed merging this PR, switching to the new hash that I'm observing?