### PR TITLE
signing: default to 4096 bit rsa keys for avb

### DIFF
--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -146,7 +146,7 @@ in
 
         size = mkOption {
           type = types.number;
-          default = 2048;
+          default = 4096;
           description = "Size of the SHA256 RSA keys";
         };
       };


### PR DESCRIPTION
grapheneos defaults to suggesting 4096 bit keys instead of 2048, we should as well
https://grapheneos.org/build#generating-release-signing-keys