### PR TITLE
signing: error early if user has avb key size mismatch

### DIFF
--- a/modules/signing.nix
+++ b/modules/signing.nix
@@ -529,6 +529,17 @@ in
             echo "Missing Device AVB key"
             RETVAL=1
           fi
+
+          # ensure the avb key we are using is the same as we expect in signing.avb.size
+          # there isn't a great way of getting the number of bits of an encrypted key without decyrpting it
+          # what we can do is check the size of the key file, and associate it with the bit size
+          # 4096 bit key == 3434 bytes on disk
+          # 2048 bit key == 1874 bytes on disk
+          avbkeyfilesize=$(wc -c < "${config.device}/avb.pem")
+          if [[ ${builtins.toString (config.signing.avb.size)} == "4096" ]] && [[ $avbkeyfilesize == "1874" ]]; then
+            echo "We expect a 4096 bit key, but were provided a 2048 bit key. Please set signing.avb.size=2048 in your config."
+            exit 1
+          fi
         ''}
 
         if [[ "$RETVAL" -ne 0 ]]; then


### PR DESCRIPTION
in a2c4835 the default avb key size was changed from 2048 to 4096

this can create problems if someone uses a 2048 avb key, as `signing.avb.size` is passed to the signing tooling

so their key would be 2048 but the signing tools thing its a 4096 bit key, which results in an error late in the release signing process

the user can solve this trivially by explicitly setting `signing.avb.size` but most will likely have no way of knowing they need to

so lets add a check to the verify keys script to error out early, with a meaningful error message.