### PR TITLE
release: include avb_pkmd in factory release image for grapheneos builds

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -45,6 +45,7 @@ upstream documentation](https://source.android.com/setup/build/running).
     performs a factory reset, and will remove all user data from the device.
 
  4. Flash your custom AVB signing key using
+    NOTE: on GrapheneOS builds you can skip this step, `flash-all.sh` does it for you
     ```console
     $ fastboot erase avb_custom_key
     $ fastboot flash avb_custom_key ./avb_pkmd.bin

--- a/modules/release.nix
+++ b/modules/release.nix
@@ -121,6 +121,10 @@ let
       export BOOTLOADER=$(get_radio_image bootloader)
       export RADIO=$(get_radio_image baseband)
 
+      ${lib.optionalString (
+        config.signing.enable && config.flavor == "grapheneos"
+      ) ''export AVB_PKMD="$KEYSDIR/${config.device}/avb_pkmd.bin"''}
+
       export PATH=${lib.getBin pkgs.zip}/bin:${lib.getBin pkgs.unzip}/bin:$PATH
       ${pkgs.runtimeShell} ${config.source.dirs."device/common".src}/generate-factory-images-common.sh
       mv $PRODUCT-factory-$VERSION.zip ${out}


### PR DESCRIPTION
lets the user skip manually installing their avb_pkmd