### PR TITLE
fix: should always generate "url" for ota metadata

### DIFF
--- a/modules/release.nix
+++ b/modules/release.nix
@@ -224,7 +224,7 @@ in
                 "id" = config.buildNumber;
                 "romtype" = config.envVars.RELEASE_TYPE;
                 "size" = "ROM_SIZE";
-                # "url" = "${config.apps.updater.url}${ota.name}"; # FIXME is this supposed to always be passed? Makes otaDir fail to eval
+                "url" = "${config.apps.updater.url}${ota.name}";
                 "version" = config.flavorVersion;
               }
             ];


### PR DESCRIPTION
The LineageOS Updater expects the `url` field to exist. Otherwise it ignores the update.

https://github.com/LineageOS/android_packages_apps_Updater/blob/b1101b4970edbb7b263bd2bfc3d181e6b6bbf7cb/app/src/main/java/org/lineageos/updater/misc/Utils.java#L82

https://github.com/LineageOS/android_packages_apps_Updater/blob/b1101b4970edbb7b263bd2bfc3d181e6b6bbf7cb/app/src/main/java/org/lineageos/updater/misc/Utils.java#L157

So if the `url` is omitted, the generated `otaDir` becomes invalid.