### PR TITLE
Add Dependabot for nix flake updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
See https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/